### PR TITLE
feat: Implement CI/CD pipeline for APK builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Build and Release APK
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission to gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew assembleRelease
+
+      - name: Sign APK
+        if: secrets.RELEASE_KEYSTORE != ''
+        id: sign_apk
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: app/build/outputs/apk/release
+          signingKeyBase64: ${{ secrets.RELEASE_KEYSTORE }}
+          alias: ${{ secrets.RELEASE_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          keyPassword: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: "34.0.0"
+
+      - name: Create Release
+        if: secrets.RELEASE_KEYSTORE != ''
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v1.0.${{ github.run_number }}
+          files: ${{steps.sign_apk.outputs.signedReleaseFile}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Unsigned APK as Artifact
+        if: secrets.RELEASE_KEYSTORE == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-apk
+          path: app/build/outputs/apk/release/app-release-unsigned.apk


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the build and release process of the Android application.

The workflow is triggered on every push to the `master` branch and performs the following actions:
- Sets up a Java 17 environment on an Ubuntu runner.
- Builds the release APK using Gradle.
- If `RELEASE_KEYSTORE` and other signing secrets are available, it signs the APK and creates a new release on GitHub, attaching the signed APK as an asset.
- If the secrets are not available, it uploads the unsigned APK as a build artifact named `unsigned-apk`.

This new pipeline streamlines the release process and ensures that a build artifact is always available for testing or deployment.