### PR TITLE
fix-recycle-icon

### DIFF
--- a/cluster-widgets/air-control/src/components/status.js
+++ b/cluster-widgets/air-control/src/components/status.js
@@ -10,7 +10,7 @@ var recycleOut = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8BAMAAADI
 
 export function createStatusElement() {
     const isAutoOn = stateManager.get('auto') === 1;
-    const isRecycleIn = stateManager.get('recycle') === 0;
+    const isRecycleIn = stateManager.get('recycle') === 1;
 
     var autoModeIconElement = img({
         src: autoModeIcon(isAutoOn ? '#2563eb' : '#9ca3af'),


### PR DESCRIPTION
Corrige a inicialização do ícone de recirculação do ar-condicionado

A lógica de inicialização estava verificando o estado `recycle === 0` para a recirculação interna, enquanto a lógica de atualização e o comportamento real do veículo indicam que o estado correto é `1`.

Isso causava a exibição do ícone invertido no carregamento do widget. A correção alinha a verificação inicial com a de atualização.