### PR TITLE
Add new shortcuts to manage AVM camera from wheel buttons

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -176,6 +176,7 @@ public class ServiceManager {
     private IIntelligentVehicleControlService controlService;
     private IVehicle vehicle;
     private IDvr dvr;
+    private boolean delayNextAVM = false;
     private IVehicleModel vehicleModel;
     private IClusterService clusterService;
     private ServiceConnection clusterServiceConnection;
@@ -679,6 +680,27 @@ public class ServiceManager {
                     }
                 }
                 break;
+            case TOGGLE_CAMERA_AVM:
+                boolean cameraAVM = sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_AVM_CAR_STOPPED.getKey(), false);
+                cameraAVM = !cameraAVM;
+                sharedPreferences.edit().putBoolean(SharedPreferencesKeys.DISABLE_AVM_CAR_STOPPED.getKey(), cameraAVM).apply();
+                Log.w(TAG, "Camera AVM state changed to: " + cameraAVM);
+                break;
+            case OPEN_AVM_ONCE:
+                try {
+                    if (getData(CarConstants.SYS_AVM_PREVIEW_STATUS.getValue()).equals("0")) {
+                        delayNextAVM = true;
+                        dvr.setAVM(1);
+                        Log.w(TAG, "Camera AVM temporarily triggered");
+                    } else {
+                        delayNextAVM = false;
+                        dvr.setAVM(0);
+                        Log.w(TAG, "Camera AVM closed");
+                    }
+                } catch (RemoteException e) {
+                    Log.w(TAG, "Error to launch AVM camera");
+                }
+                break;
         }
     }
 
@@ -847,7 +869,7 @@ public class ServiceManager {
         }
     }
 
-    private void dispatchServiceManagerEvent(ServiceManagerEventType event, Object... args) {
+    public void dispatchServiceManagerEvent(ServiceManagerEventType event, Object... args) {
         Log.w(TAG, "Dispatching service manager event: " + event);
         for (IServiceManagerEvent listener : new ArrayList<>(serviceManagerEventListeners)) {
             try {
@@ -984,10 +1006,14 @@ public class ServiceManager {
                     closeSunroofDueToeSpeed = false;
                 }
                 if (currentSpeed <= 0 & sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_AVM_CAR_STOPPED.getKey(), false) && !getData(CarConstants.CAR_BASIC_GEAR_STATUS.getValue()).equals("4")) {
-                    dvr.setAVM(0);
+                    if (value.equals("1") && !delayNextAVM) dvr.setAVM(0);
                 }
-            } else if (key.equals(CarConstants.SYS_AVM_PREVIEW_STATUS.getValue()) && sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_AVM_CAR_STOPPED.getKey(), false) && value.equals("1") && Float.parseFloat(getData(CarConstants.CAR_BASIC_VEHICLE_SPEED.getValue())) <= 0f && !getData(CarConstants.CAR_BASIC_GEAR_STATUS.getValue()).equals("4")) {
-                dvr.setAVM(0);
+            } else if (key.equals(CarConstants.SYS_AVM_PREVIEW_STATUS.getValue()) && sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_AVM_CAR_STOPPED.getKey(), false) && Float.parseFloat(getData(CarConstants.CAR_BASIC_VEHICLE_SPEED.getValue())) <= 0f && !getData(CarConstants.CAR_BASIC_GEAR_STATUS.getValue()).equals("4")) {
+                if (value.equals("1")) {
+                    if (!delayNextAVM) dvr.setAVM(0);
+                } else {
+                    delayNextAVM = false;
+                }
             } else if (key.equals(CarConstants.CAR_BASIC_DRIVING_READY_STATE.getValue())) {
                 if ((value.equals("-1") || value.equals("0"))) {
                     boolean disableBluetoothOnPowerOff = sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF.getKey(), false);

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SteeringWheelCustomActionType.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SteeringWheelCustomActionType.kt
@@ -7,7 +7,9 @@ enum class SteeringWheelCustomActionType(val key: String, val description: Strin
     TOGGLE_ANION("toggle_anion", "Alternar ionizador do ar-condicionado."),
     //TOGGLE_ESP("toggle_esp", "Alternar controle de estabilidade (ESP)."),
     TOGGLE_ONE_PEDAL_DRIVING("toggle_one_pedal_driving", "Alternar condução com um pedal."),
-    OPEN_APP("open_app", "Abrir aplicativo de sua escolha.")
+    OPEN_APP("open_app", "Abrir aplicativo de sua escolha."),
+    TOGGLE_CAMERA_AVM("toggle_avm", "Alternar o modo de desabilitar a camera com o carro parado."),
+    OPEN_AVM_ONCE("open_avm_once", "Abrir a camera sem interrupções.")
     ;
 
     companion object {


### PR DESCRIPTION
This is a small change that allows 2 new wheel button shortcut options
1. Enable/Disable the AVM camera when stopped
2. Trigger to launch (or close) the AVM camera by ignoring the AVM setting from the app (it launches the camera without closing it if car is stopped)

There are some possible enhancements that can come in later stage
1. When button is pressed for option 1 above, its not refreshing the app checkbox
2. Check if possible to map the AVM camera button from central console (this would allow forcing it to also ignore the ACM camera option and open display even if car is stopped


<img width="380" height="238" alt="image" src="https://github.com/user-attachments/assets/40041f0e-e5b5-4376-98ee-89723a7c2e80" />


Note: we can review the description of each option (maybe its not optimal)