### PR TITLE
feat: Tamanho do Layout configurável (Pequeno/Médio/Grande/Outro)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,4 +80,6 @@ dependencies {
     compileOnly(libs.annotation)
     debugImplementation(libs.ui.tooling)
     debugImplementation(libs.ui.test.manifest)
+
+    testImplementation("junit:junit:4.13.2")
 }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/MainActivity.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/MainActivity.kt
@@ -2,6 +2,7 @@
 
 package br.com.redesurftank.havalshisuku
 
+import android.app.Activity
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.content.ComponentName
@@ -78,8 +79,11 @@ class MainActivity : ComponentActivity() {
         override fun onCreate(savedInstanceState: Bundle?) {
                 super.onCreate(savedInstanceState)
                 enableEdgeToEdge()
+                val prefs = App.getDeviceProtectedContext()
+                        .getSharedPreferences("haval_prefs", Context.MODE_PRIVATE)
+                val layoutScale = resolveLayoutScale(prefs)
                 setContent {
-                        HavalShisukuTheme {
+                        HavalShisukuTheme(layoutScale = layoutScale) {
                                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                                         MainScreen(modifier = Modifier.padding(innerPadding))
                                 }
@@ -515,7 +519,154 @@ fun BasicSettingsTab() {
                 )
         }
 
+        // Layout Size (Tamanho do Layout) state
+        var layoutSizeMode by remember {
+                mutableStateOf(
+                        LayoutSizeMode.fromValue(
+                                prefs.getString(
+                                        SharedPreferencesKeys.LAYOUT_SIZE_MODE.key,
+                                        LayoutSizeMode.SMALL.value
+                                )
+                        )
+                )
+        }
+        var layoutSizeCustomScale by remember {
+                mutableFloatStateOf(
+                        prefs.getFloat(
+                                SharedPreferencesKeys.LAYOUT_SIZE_CUSTOM_SCALE.key,
+                                LayoutSizeMode.DEFAULT_CUSTOM_SCALE
+                        )
+                )
+        }
+        var layoutSizeExpanded by remember { mutableStateOf(false) }
+
         val settingsList = mutableListOf<SettingItem>()
+
+        settingsList.add(
+                SettingItem(
+                        title = "Tamanho do Layout",
+                        description = "Escala o layout e as fontes do app (não afeta o cluster)",
+                        checked = true,
+                        onCheckedChange = {},
+                        hideSwitch = true,
+                        customContent = {
+                                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                                        ExposedDropdownMenuBox(
+                                                expanded = layoutSizeExpanded,
+                                                onExpandedChange = {
+                                                        layoutSizeExpanded = !layoutSizeExpanded
+                                                }
+                                        ) {
+                                                TextField(
+                                                        value = layoutSizeMode.label,
+                                                        onValueChange = {},
+                                                        readOnly = true,
+                                                        label = { Text("Tamanho") },
+                                                        trailingIcon = {
+                                                                ExposedDropdownMenuDefaults
+                                                                        .TrailingIcon(
+                                                                                expanded =
+                                                                                        layoutSizeExpanded
+                                                                        )
+                                                        },
+                                                        colors =
+                                                                ExposedDropdownMenuDefaults
+                                                                        .textFieldColors(),
+                                                        modifier =
+                                                                Modifier.menuAnchor(
+                                                                        MenuAnchorType
+                                                                                .PrimaryNotEditable
+                                                                )
+                                                                        .fillMaxWidth()
+                                                )
+                                                ExposedDropdownMenu(
+                                                        expanded = layoutSizeExpanded,
+                                                        onDismissRequest = {
+                                                                layoutSizeExpanded = false
+                                                        }
+                                                ) {
+                                                        LayoutSizeMode.values().forEach { mode ->
+                                                                DropdownMenuItem(
+                                                                        text = { Text(mode.label) },
+                                                                        onClick = {
+                                                                                layoutSizeMode =
+                                                                                        mode
+                                                                                prefs.edit {
+                                                                                        putString(
+                                                                                                SharedPreferencesKeys
+                                                                                                        .LAYOUT_SIZE_MODE
+                                                                                                        .key,
+                                                                                                mode.value
+                                                                                        )
+                                                                                }
+                                                                                layoutSizeExpanded =
+                                                                                        false
+                                                                                if (mode !=
+                                                                                                LayoutSizeMode
+                                                                                                        .CUSTOM
+                                                                                ) {
+                                                                                        (context
+                                                                                                        as?
+                                                                                                        Activity)
+                                                                                                ?.recreate()
+                                                                                }
+                                                                        }
+                                                                )
+                                                        }
+                                                }
+                                        }
+
+                                        if (layoutSizeMode == LayoutSizeMode.CUSTOM) {
+                                                val pct =
+                                                        (layoutSizeCustomScale * 100).toInt()
+                                                Text(
+                                                        text = "Escala: $pct%",
+                                                        color = AppColors.TextPrimary,
+                                                        fontSize = 14.sp
+                                                )
+                                                Slider(
+                                                        value = layoutSizeCustomScale,
+                                                        onValueChange = { newVal ->
+                                                                layoutSizeCustomScale =
+                                                                        (Math.round(newVal * 20f) /
+                                                                                        20f)
+                                                                                .coerceIn(
+                                                                                        LayoutSizeMode
+                                                                                                .MIN_SCALE,
+                                                                                        LayoutSizeMode
+                                                                                                .MAX_SCALE
+                                                                                )
+                                                        },
+                                                        onValueChangeFinished = {
+                                                                prefs.edit {
+                                                                        putFloat(
+                                                                                SharedPreferencesKeys
+                                                                                        .LAYOUT_SIZE_CUSTOM_SCALE
+                                                                                        .key,
+                                                                                layoutSizeCustomScale
+                                                                        )
+                                                                }
+                                                                (context as? Activity)?.recreate()
+                                                        },
+                                                        valueRange =
+                                                                LayoutSizeMode.MIN_SCALE..LayoutSizeMode
+                                                                                .MAX_SCALE,
+                                                        steps = 19,
+                                                        colors =
+                                                                SliderDefaults.colors(
+                                                                        thumbColor =
+                                                                                AppColors.Primary,
+                                                                        activeTrackColor =
+                                                                                AppColors.Primary,
+                                                                        inactiveTrackColor =
+                                                                                Color(0xFF2C3139)
+                                                                )
+                                                )
+                                        }
+                                }
+                        }
+                )
+        )
 
         if (isAdvancedUse && !selfInstallationCheck) {
                 settingsList.add(

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/SplashActivity.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/SplashActivity.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import br.com.redesurftank.App
+import br.com.redesurftank.havalshisuku.models.resolveLayoutScale
 import br.com.redesurftank.havalshisuku.ui.theme.HavalShisukuTheme
 import kotlinx.coroutines.delay
 
@@ -39,8 +41,11 @@ class SplashActivity : ComponentActivity() {
         // Force landscape orientation
         requestedOrientation = android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
         
+        val prefs = App.getDeviceProtectedContext()
+            .getSharedPreferences("haval_prefs", android.content.Context.MODE_PRIVATE)
+        val layoutScale = resolveLayoutScale(prefs)
         setContent {
-            HavalShisukuTheme {
+            HavalShisukuTheme(layoutScale = layoutScale) {
                 SplashScreen {
                     // Navigate to MainActivity
                     startActivity(Intent(this@SplashActivity, MainActivity::class.java))

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/LayoutSize.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/LayoutSize.kt
@@ -1,0 +1,41 @@
+package br.com.redesurftank.havalshisuku.models
+
+import android.content.SharedPreferences
+
+enum class LayoutSizeMode(val value: String, val label: String, val presetScale: Float?) {
+    SMALL("small", "Pequeno", 1.0f),
+    MEDIUM("medium", "Médio", 1.15f),
+    LARGE("large", "Grande", 1.30f),
+    CUSTOM("custom", "Outro", null);
+
+    companion object {
+        const val MIN_SCALE = 1.0f
+        const val MAX_SCALE = 2.0f
+        const val DEFAULT_CUSTOM_SCALE = 1.0f
+
+        fun fromValue(v: String?): LayoutSizeMode = values().firstOrNull { it.value == v } ?: SMALL
+    }
+}
+
+/**
+ * Pure logic, testable without Android. Given the stored mode value and the stored custom scale,
+ * returns the effective layout scale clamped to [MIN_SCALE, MAX_SCALE].
+ */
+fun resolveLayoutScale(modeValue: String?, customScale: Float): Float {
+    val mode = LayoutSizeMode.fromValue(modeValue)
+    return mode.presetScale ?: customScale.coerceIn(
+        LayoutSizeMode.MIN_SCALE,
+        LayoutSizeMode.MAX_SCALE
+    )
+}
+
+fun resolveLayoutScale(prefs: SharedPreferences): Float = resolveLayoutScale(
+    modeValue = prefs.getString(
+        SharedPreferencesKeys.LAYOUT_SIZE_MODE.key,
+        LayoutSizeMode.SMALL.value
+    ),
+    customScale = prefs.getFloat(
+        SharedPreferencesKeys.LAYOUT_SIZE_CUSTOM_SCALE.key,
+        LayoutSizeMode.DEFAULT_CUSTOM_SCALE
+    )
+)

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -83,5 +83,7 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
     BOTTOM_BAR_OVERRIDES("bottomBarOverrides", "Overrides de aplicativos salvos (JSON)"),
     ENABLE_SPEED_ADJUSTMENT("enableSpeedAdjustment", "Habilitar ajuste de velocidade no painel"),
     SPEED_ADJUSTMENT_OFFSET("speedAdjustmentOffset", "Fator de ajuste de velocidade (%)"),
-    ALWAYS_USE_THEME_DIMENSIONS("alwaysUseThemeDimensions", "Sempre usar dimensões do tema para apps")
+    ALWAYS_USE_THEME_DIMENSIONS("alwaysUseThemeDimensions", "Sempre usar dimensões do tema para apps"),
+    LAYOUT_SIZE_MODE("layoutSizeMode", "Modo de Tamanho do Layout (small/medium/large/custom)"),
+    LAYOUT_SIZE_CUSTOM_SCALE("layoutSizeCustomScale", "Escala custom do layout (1.0 a 2.0)")
 }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/theme/Theme.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package br.com.redesurftank.havalshisuku.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -9,7 +8,10 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
@@ -38,6 +40,7 @@ fun HavalShisukuTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
+    layoutScale: Float = 1f,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {
@@ -50,9 +53,17 @@ fun HavalShisukuTheme(
         else -> LightColorScheme
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        content = content
+    val baseDensity = LocalDensity.current
+    val scaledDensity = Density(
+        density = baseDensity.density * layoutScale,
+        fontScale = baseDensity.fontScale * layoutScale
     )
+
+    CompositionLocalProvider(LocalDensity provides scaledDensity) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = Typography,
+            content = content
+        )
+    }
 }

--- a/app/src/test/java/br/com/redesurftank/havalshisuku/models/LayoutSizeTest.kt
+++ b/app/src/test/java/br/com/redesurftank/havalshisuku/models/LayoutSizeTest.kt
@@ -1,0 +1,71 @@
+package br.com.redesurftank.havalshisuku.models
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LayoutSizeTest {
+
+    @Test
+    fun fromValue_mapsKnownValues() {
+        assertEquals(LayoutSizeMode.SMALL, LayoutSizeMode.fromValue("small"))
+        assertEquals(LayoutSizeMode.MEDIUM, LayoutSizeMode.fromValue("medium"))
+        assertEquals(LayoutSizeMode.LARGE, LayoutSizeMode.fromValue("large"))
+        assertEquals(LayoutSizeMode.CUSTOM, LayoutSizeMode.fromValue("custom"))
+    }
+
+    @Test
+    fun fromValue_fallsBackToSmall_forUnknownOrNull() {
+        assertEquals(LayoutSizeMode.SMALL, LayoutSizeMode.fromValue(null))
+        assertEquals(LayoutSizeMode.SMALL, LayoutSizeMode.fromValue(""))
+        assertEquals(LayoutSizeMode.SMALL, LayoutSizeMode.fromValue("garbage"))
+    }
+
+    @Test
+    fun presetScales_haveExpectedValues() {
+        assertEquals(1.0f, LayoutSizeMode.SMALL.presetScale!!, 0.0001f)
+        assertEquals(1.15f, LayoutSizeMode.MEDIUM.presetScale!!, 0.0001f)
+        assertEquals(1.30f, LayoutSizeMode.LARGE.presetScale!!, 0.0001f)
+        assertNull(LayoutSizeMode.CUSTOM.presetScale)
+    }
+
+    @Test
+    fun scaleBounds_matchContract() {
+        // Contract: slider goes from 1.0x to 2.0x.
+        assertEquals(1.0f, LayoutSizeMode.MIN_SCALE, 0.0001f)
+        assertEquals(2.0f, LayoutSizeMode.MAX_SCALE, 0.0001f)
+        assertEquals(1.0f, LayoutSizeMode.DEFAULT_CUSTOM_SCALE, 0.0001f)
+    }
+
+    @Test
+    fun resolveLayoutScale_presetModes_ignoreCustomValue() {
+        // Preset modes must use their fixed scale regardless of custom value.
+        assertEquals(1.0f, resolveLayoutScale("small", customScale = 1.8f), 0.0001f)
+        assertEquals(1.15f, resolveLayoutScale("medium", customScale = 1.8f), 0.0001f)
+        assertEquals(1.30f, resolveLayoutScale("large", customScale = 1.8f), 0.0001f)
+    }
+
+    @Test
+    fun resolveLayoutScale_customMode_returnsCustomValue() {
+        assertEquals(1.5f, resolveLayoutScale("custom", customScale = 1.5f), 0.0001f)
+        assertEquals(1.0f, resolveLayoutScale("custom", customScale = 1.0f), 0.0001f)
+        assertEquals(2.0f, resolveLayoutScale("custom", customScale = 2.0f), 0.0001f)
+    }
+
+    @Test
+    fun resolveLayoutScale_customMode_clampsOutOfRange() {
+        // Below minimum.
+        assertEquals(1.0f, resolveLayoutScale("custom", customScale = 0.5f), 0.0001f)
+        assertEquals(1.0f, resolveLayoutScale("custom", customScale = -3f), 0.0001f)
+        // Above maximum.
+        assertEquals(2.0f, resolveLayoutScale("custom", customScale = 2.5f), 0.0001f)
+        assertEquals(2.0f, resolveLayoutScale("custom", customScale = 100f), 0.0001f)
+    }
+
+    @Test
+    fun resolveLayoutScale_unknownMode_fallsBackToSmall() {
+        // Unknown/null mode should behave like SMALL, ignoring custom scale.
+        assertEquals(1.0f, resolveLayoutScale(null, customScale = 1.7f), 0.0001f)
+        assertEquals(1.0f, resolveLayoutScale("bogus", customScale = 1.7f), 0.0001f)
+    }
+}


### PR DESCRIPTION
## Summary

Adiciona uma nova configuração **Básico → Tamanho do Layout** que escala o app inteiro (layout + fontes), já que o padrão pode ficar pequeno na tela do carro. Quatro opções:

- **Pequeno** — 1.0x (atual / padrão)
- **Médio** — 1.15x
- **Grande** — 1.30x
- **Outro** — slider livre de 100% a 200%

A seleção é persistida em `SharedPreferences` e sobrevive a reinício do processo e do device.

## Como funciona

- Novo enum `LayoutSizeMode` + helper puro `resolveLayoutScale(modeValue, customScale)` em `models/LayoutSize.kt`.
- Duas novas chaves em `SharedPreferencesKeys`: `LAYOUT_SIZE_MODE` e `LAYOUT_SIZE_CUSTOM_SCALE`.
- `HavalShisukuTheme` passa a aceitar `layoutScale: Float` e envolve o conteúdo com `CompositionLocalProvider(LocalDensity provides Density(density * scale, fontScale * scale))`. Isso faz tudo em `dp` e `sp` crescer uniformemente — sem precisar tocar em `Typography`/`Modifier`.
- `MainActivity` e `SplashActivity` leem a pref e repassam para o tema; o item de configuração em `BasicSettingsTab` tem dropdown + slider condicional (1.0–2.0, passo 0.05) e chama `recreate()` após salvar.
- **Cluster não é afetado** — `InstrumentProjector*` usa `RelativeLayout`/`TextView` (não Compose), então fica isolado por construção.

## Testes

Testes unitários JUnit 4 em `LayoutSizeTest.kt` cobrem a lógica pura:
- presets retornam 1.0 / 1.15 / 1.30,
- `CUSTOM` usa o valor salvo,
- clamping em 1.0 e 2.0,
- fallback para `SMALL` quando o modo é desconhecido.

## Test plan

- [ ] `./gradlew :app:testDebugUnitTest` passa
- [ ] Instalar, abrir **Configurações → Básico → Tamanho do Layout** → selecionar **Médio** → UI cresce ~15% após recreate
- [ ] Selecionar **Grande** → cresce ~30%
- [ ] Selecionar **Outro** → slider aparece, mover para 200% → UI dobra
- [ ] Abrir cluster no painel do motorista → permanece idêntico
- [ ] Matar o app e reabrir → a escala escolhida persiste

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #67