### PR TITLE
FIX: Restore Shizuku timeout restart in ForegroundService

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
@@ -49,7 +49,8 @@ public class ForegroundService extends Service implements Shizuku.OnBinderDeadLi
 
     private final Runnable timeoutRunnable = () -> {
         if (!isShizukuInitialized) {
-            Log.e(TAG, "Shizuku initialization timed out. Retrying...");
+            Log.w(TAG, "Shizuku initialization timed out. Restarting service...");
+            restart();
         }
     };
 


### PR DESCRIPTION
This might fix the issue where Impulse app is not auto-starting on MMI on power on