### PR TITLE
feat: adicionar opção para silenciar avisos de voz do veículo

### DIFF
--- a/DOCS/configuracoes.md
+++ b/DOCS/configuracoes.md
@@ -59,6 +59,7 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
 | `INSTRUMENT_REVISION_KM` | `instrumentRevisionKm` | Int | Km da próxima revisão |
 | `INSTRUMENT_REVISION_NEXT_DATE` | `instrumentRevisionNextDate` | Long | Data da próxima revisão (millis) |
 | `DISABLE_AVAS` | `disableAvas` | Boolean | Desativar AVAS |
+| `DISABLE_VEHICLE_WARNING_TTS` | `disableVehicleWarningTts` | Boolean | Suprimir avisos de voz do veículo (ACC, atenção ao conduzir, etc.) |
 | `DISABLE_AVM_CAR_STOPPED` | `disableAvmCarStopped` | Boolean | Desativar câmera quando parado |
 | `CAR_MONITOR_PROPERTIES` | `carMonitorProperties` | StringSet | Propriedades extras monitoradas |
 | `BYPASS_SELF_INSTALLATION_INTEGRITY_CHECK` | `bypassSelfInstallationIntegrityCheck` | Boolean | Bypass da verificação de UID |

--- a/DOCS/features.md
+++ b/DOCS/features.md
@@ -27,6 +27,7 @@
 |---------|------|-----------|
 | Manter desativado monitoramento de distrações | Toggle | Força desativação do DMS (Driver Monitoring System). Re-desativa automaticamente se o sistema tentar reativar |
 | Desativar AVAS | Toggle | Força desativação do AVAS (Acoustic Vehicle Alerting System - som do carro elétrico). Re-desativa se o sistema tentar reativar |
+| Desativar avisos de voz do veículo | Toggle | Suprime as falas TTS de avisos do veículo (ACC ativado, "atenção ao conduzir" ao ultrapassar caminhão, alertas de pista, etc.). Avisos visuais no painel e bipes sonoros permanecem ativos. Re-desativa automaticamente se o sistema tentar reativar |
 | Desativar câmera AVM quando parado | Toggle | Desliga automaticamente a câmera de visão 360° quando o veículo está parado (velocidade ≤ 0 e marcha ≠ Ré) |
 
 ### Cluster (Painel de Instrumentos)

--- a/DOCS/servicos-e-propriedades.md
+++ b/DOCS/servicos-e-propriedades.md
@@ -27,7 +27,7 @@ Sequência de inicialização:
 11. Conecta ao ConnectivityManager (via ShizukuBinderWrapper)
 12. Registra receivers de Bluetooth e Wi-Fi
 13. Dispara dispatchAllData() - busca valores atuais de todas as keys
-14. Aplica configurações iniciais (volume, monitoramento, AVAS, brilho, Frida, etc.)
+14. Aplica configurações iniciais (volume, monitoramento, AVAS, avisos TTS do veículo, brilho, Frida, etc.)
 15. Inicializa MainUiManager
 16. Inicializa ProjectorManager
 ```

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/MainActivity.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/MainActivity.kt
@@ -307,6 +307,7 @@ fun BasicSettingsTab() {
     var bypassSelfInstallationCheck by remember { mutableStateOf(prefs.getBoolean(SharedPreferencesKeys.BYPASS_SELF_INSTALLATION_INTEGRITY_CHECK.key, false)) }
     var disableMonitoring by remember { mutableStateOf(prefs.getBoolean(SharedPreferencesKeys.DISABLE_MONITORING.key, false)) }
     var disableAvas by remember { mutableStateOf(prefs.getBoolean(SharedPreferencesKeys.DISABLE_AVAS.key, false)) }
+    var disableVehicleWarningTts by remember { mutableStateOf(prefs.getBoolean(SharedPreferencesKeys.DISABLE_VEHICLE_WARNING_TTS.key, false)) }
     var disableAvmCarStopped by remember { mutableStateOf(prefs.getBoolean(SharedPreferencesKeys.DISABLE_AVM_CAR_STOPPED.key, false)) }
     var closeWindowOnPowerOff by remember { mutableStateOf(prefs.getBoolean(SharedPreferencesKeys.CLOSE_WINDOW_ON_POWER_OFF.key, false)) }
     var closeWindowOnFoldMirror by remember { mutableStateOf(prefs.getBoolean(SharedPreferencesKeys.CLOSE_WINDOW_ON_FOLD_MIRROR.key, false)) }
@@ -535,6 +536,16 @@ fun BasicSettingsTab() {
                     disableAvas = it
                     prefs.edit { putBoolean(SharedPreferencesKeys.DISABLE_AVAS.key, it) }
                     ServiceManager.getInstance().setAvasEnabled(!it)
+                }
+            ),
+            SettingItem(
+                title = "Desativar avisos de voz do veículo",
+                description = "Suprime as falas TTS (ACC ativado, atenção ao conduzir, alertas de pista, etc.). Avisos visuais e bipes continuam ativos",
+                checked = disableVehicleWarningTts,
+                onCheckedChange = {
+                    disableVehicleWarningTts = it
+                    prefs.edit { putBoolean(SharedPreferencesKeys.DISABLE_VEHICLE_WARNING_TTS.key, it) }
+                    ServiceManager.getInstance().setVehicleWarningTtsEnabled(!it)
                 }
             ),
             SettingItem(

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -501,6 +501,11 @@ public class ServiceManager {
                 setAvasEnabled(false);
                 Log.w(TAG, "AVAS disabled by user preference");
             }
+            boolean isForceDisableVehicleWarningTts = sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_VEHICLE_WARNING_TTS.getKey(), false);
+            if (isForceDisableVehicleWarningTts) {
+                setVehicleWarningTtsEnabled(false);
+                Log.w(TAG, "Vehicle warning TTS disabled by user preference");
+            }
             if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_AUTO_BRIGHTNESS.getKey(), false)) {
                 AutoBrightnessManager.Companion.getInstance().setEnabled(true);
             }
@@ -909,6 +914,12 @@ public class ServiceManager {
                     setAvasEnabled(false);
                     Log.w(TAG, "AVAS disabled by user preference");
                 }
+            } else if (key.equals(CarConstants.SYS_SETTINGS_AUDIO_VEHICLE_WARNING_TTS_ENABLE.getValue()) && value.equals("1")) {
+                boolean isForceDisableVehicleWarningTts = sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_VEHICLE_WARNING_TTS.getKey(), false);
+                if (isForceDisableVehicleWarningTts) {
+                    setVehicleWarningTtsEnabled(false);
+                    Log.w(TAG, "Vehicle warning TTS disabled by user preference");
+                }
             } else if ((key.equals(CarConstants.CAR_DMS_WORK_STATE.getValue()) && value.equals("0"))) {
                 boolean closeWindowOnPowerOff = sharedPreferences.getBoolean(SharedPreferencesKeys.CLOSE_WINDOW_ON_POWER_OFF.getKey(), false);
                 if (closeWindowOnPowerOff) {
@@ -1069,6 +1080,19 @@ public class ServiceManager {
             Log.w(TAG, "AVAS enabled: " + b);
         } catch (RemoteException e) {
             Log.e(TAG, "Error setting AVAS", e);
+        }
+    }
+
+    public void setVehicleWarningTtsEnabled(boolean b) {
+        if (controlService == null) {
+            Log.e(TAG, "ControlService not initialized");
+            return;
+        }
+        try {
+            controlService.request("cmd.common.request.set", CarConstants.SYS_SETTINGS_AUDIO_VEHICLE_WARNING_TTS_ENABLE.getValue(), b ? "1" : "0");
+            Log.w(TAG, "Vehicle warning TTS enabled: " + b);
+        } catch (RemoteException e) {
+            Log.e(TAG, "Error setting vehicle warning TTS", e);
         }
     }
 

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -30,6 +30,7 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
     INSTRUMENT_REVISION_KM("instrumentRevisionKm", "Quilometragem para aviso de revisão no painel de instrumentos"),
     INSTRUMENT_REVISION_NEXT_DATE("instrumentRevisionNextDate", "Data da próxima revisão no painel de instrumentos"),
     DISABLE_AVAS("disableAvas", "Desativar AVAS (sistema de alerta de veículo silencioso)"),
+    DISABLE_VEHICLE_WARNING_TTS("disableVehicleWarningTts", "Desativar avisos de voz do veículo (ACC ativado, atenção ao conduzir, etc.)"),
     DISABLE_AVM_CAR_STOPPED("disableAvmCarStopped", "Desativar camera AVM quando o carro está parado"),
     CAR_MONITOR_PROPERTIES("carMonitorProperties", "Propriedades do monitoramento do carro"),
     BYPASS_SELF_INSTALLATION_INTEGRITY_CHECK("bypassSelfInstallationIntegrityCheck", "Ignorar verificação de integridade da instalação"),


### PR DESCRIPTION
## Resumo

Adiciona um toggle em **Configurações > Monitoramento** que silencia os avisos de voz (TTS) do veículo, mantendo todos os indicadores visuais e bipes ativos.

Após algumas atualizações de firmware, o sistema passou a anunciar verbalmente eventos do ACC, do cruzeiro inteligente e de outros assistentes de condução. Para quem prefere só os indicadores visuais e os bipes, a feature dá um controle simples para desligar a voz.

## Como funciona

Escreve `0` (silenciado) ou `1` (padrão) na propriedade `sys.settings.audio.vehicle_warning_tts_enable` via o mesmo canal `IIntelligentVehicleControlService.request("cmd.common.request.set", ...)` já usado pelo projeto.

Segue o mesmo padrão do toggle **Desativar AVAS**:

- Aplica no boot se a preferência estiver ligada
- Re-aplica automaticamente se o sistema tentar reativar (via `OnDataChanged`)
- Toggle no Compose, logo após o de AVAS

A constante `SYS_SETTINGS_AUDIO_VEHICLE_WARNING_TTS_ENABLE` já existia no `CarConstants`, então a mudança é puramente aditiva.

## Arquivos alterados

- `SharedPreferencesKeys.kt`: nova chave `DISABLE_VEHICLE_WARNING_TTS`
- `ServiceManager.java`: novo setter `setVehicleWarningTtsEnabled`, aplicação no boot e listener
- `MainActivity.kt`: novo `SettingItem` em `BasicSettingsTab`
- `DOCS/features.md`, `DOCS/configuracoes.md`, `DOCS/servicos-e-propriedades.md`: atualização da documentação

## Plano de teste

Testado em um Haval H6 (`qti/gwm:9`, projeto `gbc147 / BUX1.1_B01`):

- [x] Leitura inicial da propriedade retorna `'1'`
- [x] Ligar o toggle: leitura passa a `'0'` imediatamente
- [x] Ativar/desativar o ACC pelo volante: sem voz
- [x] Indicadores visuais no cluster continuam aparecendo normalmente
- [x] Bipes (cinto, ré, etc.) continuam funcionando
- [x] Desligar o toggle: leitura volta a `'1'` e a voz retorna