### PR TITLE
feat: HotRouter — roteia o hotspot pela WLAN externa (Starlink) com fallback automático pro 4G

### DIFF
--- a/app/src/main/assets/hotrouter.sh
+++ b/app/src/main/assets/hotrouter.sh
@@ -1,0 +1,263 @@
+#!/system/bin/sh
+
+# hotrouter.sh
+#
+# Automatic router daemon for the multimedia hotspot.
+#
+# Goal:
+# - Prefer external WLAN (wlan0), e.g. Starlink, for hotspot clients.
+# - Fall back to OEM 4G route (vlan13) when WLAN is unavailable.
+#
+# Usage:
+#   sh hotrouter.sh start   # run the routing loop (default)
+#   sh hotrouter.sh stop    # kill the daemon and tear down all rules
+
+BASE="/data/local/tmp"
+NAME="hotrouter"
+LOG="$BASE/$NAME.log"
+PIDFILE="$BASE/$NAME.pid"
+STATEFILE="$BASE/$NAME.state"
+HOTSPOT_IF="wlan2"
+WLAN_IF="wlan0"
+WLAN_TABLE="wlan0"
+RULE_PRIO="17999"
+CHECK_HOSTS="8.8.8.8 1.1.1.1"
+INTERVAL_SEC=5
+MAX_LOG_LINES=400
+HEARTBEAT_EVERY=24
+
+log() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') [$1] $2" >> "$LOG"
+}
+
+write_state() {
+  echo "$1|$(date +%s)" > "$STATEFILE"
+}
+
+trim_log() {
+  [ -f "$LOG" ] || return
+  lines="$(wc -l < "$LOG" 2>/dev/null)"
+  [ "$lines" -gt "$MAX_LOG_LINES" ] || return
+  tail -n "$MAX_LOG_LINES" "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"
+}
+
+kill_old_hotrouters() {
+  self="$$"
+  # Kill the recorded daemon pid first. Toybox `ps` does not print script args, so a
+  # `ps | grep hotrouter.sh` sweep never matches the setsid'd daemon — the pidfile and a
+  # /proc/<pid>/cmdline scan are the only reliable ways to find it.
+  if [ -f "$PIDFILE" ]; then
+    oldpid="$(cat "$PIDFILE" 2>/dev/null)"
+    if [ -n "$oldpid" ] && [ "$oldpid" != "$self" ]; then
+      kill -9 "$oldpid" 2>/dev/null
+    fi
+  fi
+  for p in /proc/[0-9]*; do
+    pid="${p#/proc/}"
+    [ "$pid" = "$self" ] && continue
+    # Read via cat so a process exiting mid-scan (cmdline gone) is swallowed by 2>/dev/null
+    # instead of leaking a shell "can't open" error to stderr.
+    cmd="$(cat "$p/cmdline" 2>/dev/null | tr '\0' ' ')"
+    case "$cmd" in
+      *hotrouter.sh*start*) kill -9 "$pid" 2>/dev/null ;;
+    esac
+  done
+  rm -f "$PIDFILE"
+}
+
+cleanup_duplicate_rules() {
+  while ip rule | grep -q "iif $HOTSPOT_IF lookup $WLAN_TABLE"; do
+    ip rule del from all iif "$HOTSPOT_IF" lookup "$WLAN_TABLE" priority "$RULE_PRIO" 2>/dev/null || break
+  done
+}
+
+ensure_rule_once() {
+  cleanup_duplicate_rules
+  ip rule add from all iif "$HOTSPOT_IF" lookup "$WLAN_TABLE" priority "$RULE_PRIO" 2>/dev/null
+}
+
+chain_exists() {
+  iptables -nL "$1" >/dev/null 2>&1
+}
+
+nat_chain_exists() {
+  iptables -t nat -nL "$1" >/dev/null 2>&1
+}
+
+ensure_iptables() {
+  nat_chain_exists tetherctrl_nat_POSTROUTING || {
+    log ERROR "Missing NAT chain tetherctrl_nat_POSTROUTING"
+    return 1
+  }
+
+  chain_exists tetherctrl_FORWARD || {
+    log ERROR "Missing chain tetherctrl_FORWARD"
+    return 1
+  }
+
+  chain_exists tetherctrl_counters || {
+    log ERROR "Missing chain tetherctrl_counters"
+    return 1
+  }
+
+  iptables -t nat -C tetherctrl_nat_POSTROUTING -o "$WLAN_IF" -j MASQUERADE 2>/dev/null || \
+  iptables -t nat -I tetherctrl_nat_POSTROUTING 1 -o "$WLAN_IF" -j MASQUERADE
+
+  iptables -C tetherctrl_FORWARD -i "$WLAN_IF" -o "$HOTSPOT_IF" -m state --state RELATED,ESTABLISHED -g tetherctrl_counters 2>/dev/null || \
+  iptables -I tetherctrl_FORWARD 1 -i "$WLAN_IF" -o "$HOTSPOT_IF" -m state --state RELATED,ESTABLISHED -g tetherctrl_counters
+
+  iptables -C tetherctrl_FORWARD -i "$HOTSPOT_IF" -o "$WLAN_IF" -m state --state INVALID -j DROP 2>/dev/null || \
+  iptables -I tetherctrl_FORWARD 2 -i "$HOTSPOT_IF" -o "$WLAN_IF" -m state --state INVALID -j DROP
+
+  iptables -C tetherctrl_FORWARD -i "$HOTSPOT_IF" -o "$WLAN_IF" -g tetherctrl_counters 2>/dev/null || \
+  iptables -I tetherctrl_FORWARD 3 -i "$HOTSPOT_IF" -o "$WLAN_IF" -g tetherctrl_counters
+
+  iptables -C tetherctrl_counters -i "$HOTSPOT_IF" -o "$WLAN_IF" -j RETURN 2>/dev/null || \
+  iptables -I tetherctrl_counters 1 -i "$HOTSPOT_IF" -o "$WLAN_IF" -j RETURN
+
+  iptables -C tetherctrl_counters -i "$WLAN_IF" -o "$HOTSPOT_IF" -j RETURN 2>/dev/null || \
+  iptables -I tetherctrl_counters 2 -i "$WLAN_IF" -o "$HOTSPOT_IF" -j RETURN
+
+  return 0
+}
+
+teardown_iptables() {
+  while iptables -t nat -C tetherctrl_nat_POSTROUTING -o "$WLAN_IF" -j MASQUERADE 2>/dev/null; do
+    iptables -t nat -D tetherctrl_nat_POSTROUTING -o "$WLAN_IF" -j MASQUERADE 2>/dev/null || break
+  done
+
+  while iptables -C tetherctrl_FORWARD -i "$WLAN_IF" -o "$HOTSPOT_IF" -m state --state RELATED,ESTABLISHED -g tetherctrl_counters 2>/dev/null; do
+    iptables -D tetherctrl_FORWARD -i "$WLAN_IF" -o "$HOTSPOT_IF" -m state --state RELATED,ESTABLISHED -g tetherctrl_counters 2>/dev/null || break
+  done
+
+  while iptables -C tetherctrl_FORWARD -i "$HOTSPOT_IF" -o "$WLAN_IF" -m state --state INVALID -j DROP 2>/dev/null; do
+    iptables -D tetherctrl_FORWARD -i "$HOTSPOT_IF" -o "$WLAN_IF" -m state --state INVALID -j DROP 2>/dev/null || break
+  done
+
+  while iptables -C tetherctrl_FORWARD -i "$HOTSPOT_IF" -o "$WLAN_IF" -g tetherctrl_counters 2>/dev/null; do
+    iptables -D tetherctrl_FORWARD -i "$HOTSPOT_IF" -o "$WLAN_IF" -g tetherctrl_counters 2>/dev/null || break
+  done
+
+  while iptables -C tetherctrl_counters -i "$HOTSPOT_IF" -o "$WLAN_IF" -j RETURN 2>/dev/null; do
+    iptables -D tetherctrl_counters -i "$HOTSPOT_IF" -o "$WLAN_IF" -j RETURN 2>/dev/null || break
+  done
+
+  while iptables -C tetherctrl_counters -i "$WLAN_IF" -o "$HOTSPOT_IF" -j RETURN 2>/dev/null; do
+    iptables -D tetherctrl_counters -i "$WLAN_IF" -o "$HOTSPOT_IF" -j RETURN 2>/dev/null || break
+  done
+}
+
+starlink_has_ping() {
+  ip link show "$HOTSPOT_IF" >/dev/null 2>&1 || return 1
+  ip link show "$WLAN_IF" >/dev/null 2>&1 || return 1
+  ip route show table "$WLAN_TABLE" | grep -q "^default" || return 1
+
+  for host in $CHECK_HOSTS; do
+    ping -I "$WLAN_IF" -c 1 -W 2 "$host" >/dev/null 2>&1 && return 0
+  done
+
+  return 1
+}
+
+route_to_starlink() {
+  echo 1 > /proc/sys/net/ipv4/ip_forward
+  ensure_rule_once
+  ensure_iptables || return 1
+  ip route flush cache
+  return 0
+}
+
+route_to_4g() {
+  cleanup_duplicate_rules
+  ip route flush cache
+}
+
+do_stop() {
+  # kill_old_hotrouters kills the daemon via pidfile + /proc cmdline scan (toybox ps
+  # does not show script args, so a ps-based sweep can't find the setsid'd daemon).
+  kill_old_hotrouters
+  cleanup_duplicate_rules
+  teardown_iptables
+  ip route flush cache
+  write_state "OFF"
+  log INFO "Service stopped + teardown done"
+}
+
+CMD="${1:-start}"
+
+case "$CMD" in
+  stop)
+    do_stop
+    exit 0
+    ;;
+  start)
+    ;;
+  *)
+    echo "usage: $0 {start|stop}"
+    exit 1
+    ;;
+esac
+
+kill_old_hotrouters
+
+echo $$ > "$PIDFILE"
+
+trap 'rm -f "$PIDFILE"; write_state "OFF"; log INFO "Service stopped"; exit 0' INT TERM EXIT
+
+echo 1 > /proc/sys/net/ipv4/ip_forward
+
+last_mode="initial"
+tick=0
+
+log INFO "Service force-started"
+log INFO "Old hotrouter processes killed"
+log INFO "Hotspot=$HOTSPOT_IF | Starlink=$WLAN_IF | Table=$WLAN_TABLE | Ping=$CHECK_HOSTS"
+
+while true; do
+  trim_log
+
+  if starlink_has_ping; then
+    if route_to_starlink; then
+      mode="starlink"
+    else
+      # Could not apply the WLAN route (e.g. tetherctrl chains missing). Clean up
+      # any half-applied diversion rule so the hotspot genuinely falls back to 4G,
+      # keeping the reported "4G" state honest instead of leaving traffic broken.
+      route_to_4g
+      mode="broken"
+      log ERROR "Starlink has ping, but route_to_starlink failed; fell back to 4G"
+    fi
+  else
+    route_to_4g
+    mode="4g"
+  fi
+
+  case "$mode" in
+    starlink) write_state "WLAN" ;;
+    *)        write_state "4G" ;;
+  esac
+
+  if [ "$mode" != "$last_mode" ]; then
+    case "$mode" in
+      starlink)
+        log INFO "Route transition: $last_mode -> STARLINK. Hotspot forced through $WLAN_IF."
+        ;;
+      4g)
+        log WARN "Route transition: $last_mode -> 4G. Starlink ping unavailable."
+        ;;
+      broken)
+        log ERROR "Route transition: $last_mode -> BROKEN. Starlink ping OK but firewall/routing failed."
+        ;;
+    esac
+    last_mode="$mode"
+  fi
+
+  tick=$((tick + 1))
+
+  if [ "$tick" -ge "$HEARTBEAT_EVERY" ]; then
+    log INFO "Heartbeat: current_mode=$mode"
+    tick=0
+  fi
+
+  sleep "$INTERVAL_SEC"
+done

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/HotRouterManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/HotRouterManager.java
@@ -1,0 +1,236 @@
+package br.com.redesurftank.havalshisuku.managers;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.SystemClock;
+import android.util.Base64;
+import android.util.Log;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+import br.com.redesurftank.App;
+import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys;
+import br.com.redesurftank.havalshisuku.utils.ShizukuUtils;
+
+public class HotRouterManager {
+
+    private static final String TAG = "HotRouterManager";
+
+    private static final String BASE = "/data/local/tmp";
+    private static final String SCRIPT = BASE + "/hotrouter.sh";
+    private static final String PIDFILE = BASE + "/hotrouter.pid";
+    private static final String STATEFILE = BASE + "/hotrouter.state";
+    private static final String ASSET_NAME = "hotrouter.sh";
+
+    private static final String PID_ALIVE_CMD =
+            "kill -0 $(cat " + PIDFILE + " 2>/dev/null) 2>/dev/null && echo ALIVE || echo DEAD";
+
+    private static final long WATCHDOG_INTERVAL_MS = 60000L;
+    private static final long START_GRACE_MS = 20000L;
+
+    // UI-facing status modes
+    public static final String MODE_OFF = "OFF";
+    public static final String MODE_STARTING = "STARTING";
+    public static final String MODE_WLAN = "WLAN";
+    public static final String MODE_4G = "4G";
+    public static final String MODE_ERROR = "ERROR";
+
+    public static class Status {
+        public final String mode;
+        public final long epochSeconds;
+
+        public Status(String mode, long epochSeconds) {
+            this.mode = mode;
+            this.epochSeconds = epochSeconds;
+        }
+    }
+
+    private static volatile HotRouterManager INSTANCE;
+
+    public static HotRouterManager getInstance() {
+        if (INSTANCE == null) {
+            synchronized (HotRouterManager.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = new HotRouterManager();
+                }
+            }
+        }
+        return INSTANCE;
+    }
+
+    private final SharedPreferences prefs;
+    private final Handler bgHandler;
+    private volatile boolean watchdogRunning = false;
+    private volatile long enableTimeMs = 0L;
+
+    private HotRouterManager() {
+        prefs = App.getDeviceProtectedContext().getSharedPreferences("haval_prefs", Context.MODE_PRIVATE);
+        HandlerThread thread = new HandlerThread("HotRouterThread");
+        thread.start();
+        bgHandler = new Handler(thread.getLooper());
+    }
+
+    private boolean isEnabled() {
+        return prefs.getBoolean(SharedPreferencesKeys.ENABLE_HOT_ROUTER.getKey(), false);
+    }
+
+    /** Called from the settings toggle. Persistence is done by the UI before this call. */
+    public void setEnabled(boolean enabled) {
+        if (enabled) {
+            enableTimeMs = SystemClock.elapsedRealtime();
+            bgHandler.post(() -> {
+                pushScript();
+                startDaemon();
+            });
+            startWatchdog();
+        } else {
+            bgHandler.post(this::stopDaemon);
+        }
+    }
+
+    /** Called by ForegroundService once Shizuku is ready (covers boot autostart). */
+    public void onServicesReady() {
+        if (isEnabled()) {
+            enableTimeMs = SystemClock.elapsedRealtime();
+            bgHandler.post(() -> {
+                pushScript();
+                String alive = ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c", PID_ALIVE_CMD});
+                if (!alive.contains("ALIVE")) {
+                    startDaemon();
+                }
+            });
+            startWatchdog();
+        }
+    }
+
+    private void pushScript() {
+        try {
+            String b64 = readAssetBase64();
+            if (b64.isEmpty()) {
+                Log.e(TAG, "Empty hotrouter.sh asset, aborting push");
+                return;
+            }
+            String cmd = "echo " + b64 + " | base64 -d > " + SCRIPT + " && chmod 755 " + SCRIPT;
+            ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c", cmd});
+            Log.w(TAG, "hotrouter.sh pushed to " + SCRIPT);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to push hotrouter.sh: " + e.getMessage(), e);
+        }
+    }
+
+    private String readAssetBase64() {
+        try (InputStream is = App.getContext().getAssets().open(ASSET_NAME)) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buf = new byte[4096];
+            int n;
+            while ((n = is.read(buf)) != -1) {
+                baos.write(buf, 0, n);
+            }
+            return Base64.encodeToString(baos.toByteArray(), Base64.NO_WRAP);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to read asset " + ASSET_NAME + ": " + e.getMessage(), e);
+            return "";
+        }
+    }
+
+    private void startDaemon() {
+        try {
+            // Detach with the project's proven idiom (see FridaUtils): setsid + redirect
+            // + `< /dev/null` so the daemon fully reparents and the Shizuku controlling
+            // process returns immediately (otherwise runCommandAndGetOutput's waitFor()
+            // could wedge the single HotRouterThread looper on the infinite-loop daemon).
+            String cmd = "setsid sh " + SCRIPT + " start >" + BASE + "/hotrouter.out 2>&1 < /dev/null &";
+            ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c", cmd});
+            Log.w(TAG, "hotrouter daemon start requested");
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to start hotrouter daemon: " + e.getMessage(), e);
+        }
+    }
+
+    private void stopDaemon() {
+        try {
+            ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c", "sh " + SCRIPT + " stop"});
+            Log.w(TAG, "hotrouter daemon stop requested");
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to stop hotrouter daemon: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Arms the watchdog. Posted to bgHandler so the watchdogRunning check-then-set runs
+     * on the single looper thread (no race between setEnabled and onServicesReady). The
+     * loop self-terminates the next time it finds the feature disabled.
+     */
+    private void startWatchdog() {
+        bgHandler.post(() -> {
+            if (watchdogRunning) {
+                return;
+            }
+            watchdogRunning = true;
+            bgHandler.postDelayed(watchdogRunnable, WATCHDOG_INTERVAL_MS);
+        });
+    }
+
+    private final Runnable watchdogRunnable = new Runnable() {
+        @Override
+        public void run() {
+            if (!isEnabled()) {
+                watchdogRunning = false;
+                return;
+            }
+            try {
+                String alive = ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c", PID_ALIVE_CMD});
+                if (!alive.contains("ALIVE")) {
+                    Log.w(TAG, "Watchdog: daemon dead while enabled, relaunching");
+                    enableTimeMs = SystemClock.elapsedRealtime();
+                    pushScript();
+                    startDaemon();
+                }
+            } catch (Exception e) {
+                Log.e(TAG, "Watchdog error: " + e.getMessage(), e);
+            }
+            bgHandler.postDelayed(this, WATCHDOG_INTERVAL_MS);
+        }
+    };
+
+    /**
+     * Blocking status read (runs shell via Shizuku). Call off the main thread.
+     */
+    public Status readStatusBlocking() {
+        if (!isEnabled()) {
+            return new Status(MODE_OFF, 0L);
+        }
+        String alive = ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c", PID_ALIVE_CMD});
+        if (alive.contains("ALIVE")) {
+            String raw = ShizukuUtils.runCommandAndGetOutput(
+                    new String[]{"sh", "-c", "cat " + STATEFILE + " 2>/dev/null"}).trim();
+            if (raw.isEmpty()) {
+                return new Status(MODE_STARTING, 0L);
+            }
+            String[] parts = raw.split("\\|");
+            String mode = parts[0].trim();
+            long epoch = 0L;
+            if (parts.length > 1) {
+                try {
+                    epoch = Long.parseLong(parts[1].trim());
+                } catch (NumberFormatException ignored) {
+                }
+            }
+            if (MODE_OFF.equals(mode)) {
+                return new Status(MODE_STARTING, epoch);
+            }
+            if (MODE_WLAN.equals(mode) || MODE_4G.equals(mode)) {
+                return new Status(mode, epoch);
+            }
+            return new Status(MODE_STARTING, epoch);
+        }
+        long since = SystemClock.elapsedRealtime() - enableTimeMs;
+        if (since < START_GRACE_MS) {
+            return new Status(MODE_STARTING, 0L);
+        }
+        return new Status(MODE_ERROR, 0L);
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -214,5 +214,6 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
     TRIP_CONSISTENCY_CLUSTER_ACTIVE("tripConsistencyClusterActive", "Indicador discreto de análise de viagem ativa no cluster"),
     TRIP_CONSISTENCY_CLUSTER_SCORE("tripConsistencyClusterScore", "Score de consistência em tempo real no cluster"),
     AA_PATCH_AUTO_MOUNT("aaPatchAutoMount", "Habilitar montagem automática dos patches do Android Auto ao iniciar"),
-    CARPLAY_PATCH_AUTO_MOUNT("carPlayPatchAutoMount", "Habilitar montagem automática dos patches do CarPlay ao iniciar")
+    CARPLAY_PATCH_AUTO_MOUNT("carPlayPatchAutoMount", "Habilitar montagem automática dos patches do CarPlay ao iniciar"),
+    ENABLE_HOT_ROUTER("enableHotRouter", "Roteia o hotspot pelo 4G ou WLAN (Starlink) quando disponível")
 }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
@@ -37,6 +37,7 @@ import br.com.redesurftank.havalshisuku.managers.AndroidAutoPatchManager;
 import br.com.redesurftank.havalshisuku.managers.CarPlayPatchManager;
 import br.com.redesurftank.havalshisuku.managers.DisplayAppLauncher;
 import br.com.redesurftank.havalshisuku.managers.ServiceManager;
+import br.com.redesurftank.havalshisuku.managers.HotRouterManager;
 import br.com.redesurftank.havalshisuku.models.CommandListener;
 import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys;
 import br.com.redesurftank.havalshisuku.utils.IPTablesUtils;
@@ -616,6 +617,12 @@ public class ForegroundService extends Service implements Shizuku.OnBinderDeadLi
                 Log.e(TAG, "Projection patch auto-mount check failed: " + e.getMessage(), e);
             }
         });
+
+        try {
+            HotRouterManager.getInstance().onServicesReady();
+        } catch (Exception e) {
+            Log.e(TAG, "Error starting HotRouter: " + e.getMessage(), e);
+        }
 
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction("com.beantechs.intelligentvehiclecontrol.INIT_COMPLETED");

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.edit
 import br.com.redesurftank.App
 import br.com.redesurftank.havalshisuku.managers.AutoBrightnessManager
+import br.com.redesurftank.havalshisuku.managers.HotRouterManager
 import br.com.redesurftank.havalshisuku.managers.ServiceManager
 import br.com.redesurftank.havalshisuku.models.BottomBarState
 import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys
@@ -29,6 +30,12 @@ import br.com.redesurftank.havalshisuku.models.SteeringWheelCustomActionType
 import br.com.redesurftank.havalshisuku.ui.components.AppColors
 import br.com.redesurftank.havalshisuku.ui.components.SettingItem
 import br.com.redesurftank.havalshisuku.ui.components.TwoColumnSettingsLayout
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -181,6 +188,11 @@ fun BasicSettingsTab() {
                                 SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF.key,
                                 false
                         )
+                )
+        }
+        var enableHotRouter by remember {
+                mutableStateOf(
+                        prefs.getBoolean(SharedPreferencesKeys.ENABLE_HOT_ROUTER.key, false)
                 )
         }
         var nightBrightnessLevel by remember {
@@ -1316,6 +1328,92 @@ fun BasicSettingsTab() {
                                 }
                         ),
                         SettingItem(
+                                title = "HotRouter",
+                                description = SharedPreferencesKeys.ENABLE_HOT_ROUTER.description,
+                                checked = enableHotRouter,
+                                onCheckedChange = {
+                                        enableHotRouter = it
+                                        prefs.edit {
+                                                putBoolean(
+                                                        SharedPreferencesKeys.ENABLE_HOT_ROUTER.key,
+                                                        it
+                                                )
+                                        }
+                                        HotRouterManager.getInstance().setEnabled(it)
+                                },
+                                customContent =
+                                        if (enableHotRouter) {
+                                                {
+                                                        var statusMode by remember {
+                                                                mutableStateOf(
+                                                                        HotRouterManager.MODE_STARTING
+                                                                )
+                                                        }
+                                                        var statusEpoch by remember {
+                                                                mutableStateOf(0L)
+                                                        }
+
+                                                        LaunchedEffect(Unit) {
+                                                                while (true) {
+                                                                        val s =
+                                                                                withContext(
+                                                                                        Dispatchers.IO
+                                                                                ) {
+                                                                                        HotRouterManager
+                                                                                                .getInstance()
+                                                                                                .readStatusBlocking()
+                                                                                }
+                                                                        statusMode = s.mode
+                                                                        statusEpoch = s.epochSeconds
+                                                                        delay(3000)
+                                                                }
+                                                        }
+
+                                                        val label =
+                                                                when (statusMode) {
+                                                                        HotRouterManager.MODE_OFF ->
+                                                                                "Desligado"
+                                                                        HotRouterManager
+                                                                                .MODE_STARTING ->
+                                                                                "Iniciando…"
+                                                                        HotRouterManager.MODE_WLAN ->
+                                                                                "Ativo (WLAN)"
+                                                                        HotRouterManager.MODE_4G ->
+                                                                                "Ativo (4G)"
+                                                                        HotRouterManager.MODE_ERROR ->
+                                                                                "Erro"
+                                                                        else -> "—"
+                                                                }
+
+                                                        Column(
+                                                                verticalArrangement =
+                                                                        Arrangement.spacedBy(8.dp)
+                                                        ) {
+                                                                HorizontalDivider(
+                                                                        color = Color(0xFF3A3F47),
+                                                                        thickness = 1.dp
+                                                                )
+                                                                Text(
+                                                                        text = "Status: $label",
+                                                                        color = Color.White,
+                                                                        fontSize = 16.sp
+                                                                )
+                                                                if (statusEpoch > 0L) {
+                                                                        Text(
+                                                                                text =
+                                                                                        "atualizado ${formatHms(statusEpoch)}",
+                                                                                color =
+                                                                                        Color(
+                                                                                                0xFFB0B8C4
+                                                                                        ),
+                                                                                fontSize = 12.sp
+                                                                        )
+                                                                }
+                                                        }
+                                                }
+                                        } else null
+                        ),
+                        SettingItem(
                                 title = "Habilitar botões personalizados no volante",
                                 description =
                                         SharedPreferencesKeys.ENABLE_STEERING_WHEEL_CUSTOM_BUTTONS
@@ -2101,4 +2199,8 @@ fun BasicSettingsTab() {
                         dialog.show()
                 }
         }
+}
+
+private fun formatHms(epochSeconds: Long): String {
+        return SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(Date(epochSeconds * 1000L))
 }


### PR DESCRIPTION
## O que é

Adiciona o **HotRouter**: uma opção nas Configurações que mantém o hotspot da multimídia (`wlan2`) roteado por uma WLAN externa (`wlan0` — por exemplo uma Starlink/roteador ligado à central) sempre que essa rede tiver internet, e cai automaticamente de volta para o 4G da OEM (`vlan13`) quando a WLAN não está disponível.

Ref: #89.

## Como funciona

- **Daemon de sistema** (`hotrouter.sh`, empacotado como asset do APK): é o dono do loop de roteamento (checa a cada 5s). Roda *detached* via Shizuku (`setsid … < /dev/null &`), então **sobrevive ao app ser fechado** — o app é só o controle liga/desliga + leitor de status.
- **A cada ciclo**: se a `wlan0` tem rota default e responde ping (8.8.8.8 / 1.1.1.1), aplica uma `ip rule` (prioridade 17999, acima da 18000 da OEM) + as regras `tetherctrl` de MASQUERADE/FORWARD no iptables, forçando o tráfego do hotspot pela WLAN. Se a WLAN cai, remove a regra e o tráfego volta naturalmente pro 4G.
- **Contrato "ligado = ligado de verdade"**: ao ligar, o app empurra o script, sobe o daemon e confirma o estado lendo o pidfile + state file. Ao desligar, **mata o daemon e faz o teardown completo** de todas as regras `ip rule`/`iptables` — volta exatamente ao padrão da OEM, sem regra fantasma.
- **Autostart no boot**: o `ForegroundService` sobe o daemon assim que o Shizuku fica pronto (se a opção estiver ligada), e um **watchdog** de 60s reergue o daemon caso ele morra enquanto a opção está ativa.

## Como fica na UI

Toggle **"HotRouter"** nas configurações básicas. Descrição: *"Roteia o hotspot pelo 4G ou WLAN (Starlink) quando disponível"*.

Com a opção ligada, mostra o status ao vivo (atualiza a cada 3s):

- `Desligado`
- `Iniciando…`
- `Ativo (WLAN)`
- `Ativo (4G)`
- `Erro`

…com a hora da última atualização (`atualizado HH:MM:SS`).

## Testado de verdade

Validei **end-to-end no meu próprio Haval** (root + Shizuku, APK compilado por mim):

- Ligar → `Iniciando…` → `Ativo (WLAN)`, com o tráfego do hotspot saindo pela Starlink (regras `ip rule` 17999 + MASQUERADE `wlan0` aplicadas, pacotes fluindo).
- Derrubar a WLAN → `Ativo (4G)` + fallback; reconectar → volta pra `Ativo (WLAN)`.
- Desligar → daemon morto + regras limpas (sobra só a `18000 vlan13` da OEM).

**Estou rodando essa versão no meu carro neste exato momento.**

## Arquivos (1 commit, 5 arquivos)

- `app/src/main/assets/hotrouter.sh` (novo) — o daemon
- `app/src/main/java/.../managers/HotRouterManager.java` (novo) — push/start/stop/watchdog/leitura de status
- `app/src/main/java/.../ui/screens/BasicSettingsScreen.kt` — toggle + status ao vivo
- `app/src/main/java/.../models/SharedPreferencesKeys.kt` — pref `enableHotRouter`
- `app/src/main/java/.../services/ForegroundService.java` — autostart quando os serviços sobem

🤖 Generated with [Claude Code](https://claude.com/claude-code)