### PR TITLE
feat: ventilação automática do banco do passageiro com A/C (+ fix typo 'motorista')

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -1460,10 +1460,14 @@ public class ServiceManager {
                         autoOpenSunroofCurtain();
                     }
                 }
-            } else if (key.equals(CarConstants.CAR_HVAC_POWER_MODE.getValue()) && value.equals("1") && sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_SEAT_VENTILATION_ON_AC_ON.getKey(), false)) {
-                updateData(CarConstants.CAR_COMFORT_SETTING_DRIVER_SEAT_VENTILATION_LEVEL.getValue(), "3");
-            } else if (key.equals(CarConstants.CAR_HVAC_POWER_MODE.getValue()) && value.equals("0") && sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_SEAT_VENTILATION_ON_AC_ON.getKey(), false)) {
-                updateData(CarConstants.CAR_COMFORT_SETTING_DRIVER_SEAT_VENTILATION_LEVEL.getValue(), "0");
+            } else if (key.equals(CarConstants.CAR_HVAC_POWER_MODE.getValue()) && (value.equals("1") || value.equals("0"))) {
+                String seatVentLevel = value.equals("1") ? "3" : "0";
+                if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_SEAT_VENTILATION_ON_AC_ON.getKey(), false)) {
+                    updateData(CarConstants.CAR_COMFORT_SETTING_DRIVER_SEAT_VENTILATION_LEVEL.getValue(), seatVentLevel);
+                }
+                if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_PASSENGER_SEAT_VENTILATION_ON_AC_ON.getKey(), false)) {
+                    updateData(CarConstants.CAR_COMFORT_SETTING_PASSENGER_SEAT_VENTILATION_LEVEL.getValue(), seatVentLevel);
+                }
             } else if (key.equals(CarConstants.CAR_BASIC_INSIDE_TEMP.getValue()) && sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_MAX_AC_ON_UNLOCK.getKey(), false)) {
                 if (isMaxAcActive) updateMaxAcSmoothing();
             }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -106,6 +106,10 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
             "enableSeatVentilationOnAcOn",
             "Habilitar ventilação do banco do motorista ao ligar o ar-condicionado"
     ),
+    ENABLE_PASSENGER_SEAT_VENTILATION_ON_AC_ON(
+            "enablePassengerSeatVentilationOnAcOn",
+            "Habilitar ventilação do banco do passageiro ao ligar o ar-condicionado"
+    ),
     ENABLE_STEERING_WHEEL_CUSTOM_BUTTONS(
             "enableSteeringWheelCustomButtons",
             "Habilitar botões personalizados no volante"

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -201,6 +201,14 @@ fun BasicSettingsTab() {
                         )
                 )
         }
+        var enablePassengerSeatVentilationOnAcOn by remember {
+                mutableStateOf(
+                        prefs.getBoolean(
+                                SharedPreferencesKeys.ENABLE_PASSENGER_SEAT_VENTILATION_ON_AC_ON.key,
+                                false
+                        )
+                )
+        }
         var enableCustomSteeringWheelButtons by remember {
                 mutableStateOf(
                         prefs.getBoolean(
@@ -1262,7 +1270,7 @@ fun BasicSettingsTab() {
                                 }
                         ),
                         SettingItem(
-                                title = "Ligar ventilação do banco do motorisca com A/C ligado",
+                                title = "Ligar ventilação do banco do motorista com A/C ligado",
                                 description =
                                         SharedPreferencesKeys.ENABLE_SEAT_VENTILATION_ON_AC_ON
                                                 .description,
@@ -1273,6 +1281,24 @@ fun BasicSettingsTab() {
                                                 putBoolean(
                                                         SharedPreferencesKeys
                                                                 .ENABLE_SEAT_VENTILATION_ON_AC_ON
+                                                                .key,
+                                                        it
+                                                )
+                                        }
+                                }
+                        ),
+                        SettingItem(
+                                title = "Ligar ventilação do banco do passageiro com A/C ligado",
+                                description =
+                                        SharedPreferencesKeys.ENABLE_PASSENGER_SEAT_VENTILATION_ON_AC_ON
+                                                .description,
+                                checked = enablePassengerSeatVentilationOnAcOn,
+                                onCheckedChange = {
+                                        enablePassengerSeatVentilationOnAcOn = it
+                                        prefs.edit {
+                                                putBoolean(
+                                                        SharedPreferencesKeys
+                                                                .ENABLE_PASSENGER_SEAT_VENTILATION_ON_AC_ON
                                                                 .key,
                                                         it
                                                 )


### PR DESCRIPTION
## O que faz

Adiciona a opção de ligar automaticamente a ventilação do banco do **passageiro** quando o ar-condicionado é ligado — espelhando a função que já existe para o banco do motorista.

Também corrige um typo no texto da opção do motorista: "motorisca" → "motorista".

## Detalhes

- Nova pref `ENABLE_PASSENGER_SEAT_VENTILATION_ON_AC_ON`.
- O handler de `CAR_HVAC_POWER_MODE` foi refatorado para tratar motorista e passageiro de forma independente (cada um conforme sua própria pref), usando `CAR_COMFORT_SETTING_PASSENGER_SEAT_VENTILATION_LEVEL`.
- Novo toggle em Config → Básico, logo abaixo do toggle do motorista.

## Arquivos

- `ServiceManager.java` — handler HVAC combinado (motorista + passageiro)
- `SharedPreferencesKeys.kt` — nova pref
- `BasicSettingsScreen.kt` — novo toggle + correção do typo

Testado em um Haval H6 (display físico).
