### PR TITLE
feat: desligar Bluetooth/WiFi apenas ao recolher o retrovisor + restaurar estado ao ligar

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -646,7 +646,7 @@ public class ServiceManager {
                         int state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR);
                         if (state == BluetoothAdapter.STATE_ON) {
                             String drivingReady = getUpdatedData(CarConstants.CAR_BASIC_DRIVING_READY_STATE.getValue());
-                            if ((drivingReady.equals("-1") || drivingReady.equals("0")) && sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF.getKey(), false)) {
+                            if ((drivingReady.equals("-1") || drivingReady.equals("0")) && sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF.getKey(), false) && !sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR.getKey(), false)) {
                                 disableBluetooth();
                             }
                         }
@@ -659,11 +659,15 @@ public class ServiceManager {
                 @Override
                 public void onReceive(Context context, Intent intent) {
                     if ("android.net.wifi.WIFI_AP_STATE_CHANGED".equals(intent.getAction())) {
-                        if (intent.getIntExtra("wifi_state", 0) == 13) {
+                        int wifiApState = intent.getIntExtra("wifi_state", 0);
+                        if (wifiApState == 13) {
+                            wifiTetherEnabled = true;
                             String drivingReady = getUpdatedData(CarConstants.CAR_BASIC_DRIVING_READY_STATE.getValue());
-                            if ((drivingReady.equals("-1") || drivingReady.equals("0")) && sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF.getKey(), false)) {
+                            if ((drivingReady.equals("-1") || drivingReady.equals("0")) && sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF.getKey(), false) && !sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR.getKey(), false)) {
                                 disableWifiTether();
                             }
+                        } else if (wifiApState == 11) {
+                            wifiTetherEnabled = false;
                         }
                     }
                 }
@@ -1399,6 +1403,14 @@ public class ServiceManager {
                 if (closeSunRoofOnFoldMirror) {
                     closeSunRoof(true);
                 }
+                if (sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF.getKey(), false)
+                        && sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR.getKey(), false)) {
+                    shutdownBluetoothIfEnabled();
+                }
+                if (sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF.getKey(), false)
+                        && sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR.getKey(), false)) {
+                    shutdownWifiTetherIfEnabled();
+                }
             } else if (key.equals(CarConstants.CAR_BASIC_VEHICLE_SPEED.getValue())) {
                 float currentSpeed = Float.parseFloat(value);
                 boolean closeWindowOnSpeed = sharedPreferences.getBoolean(SharedPreferencesKeys.CLOSE_WINDOWS_ON_SPEED.getKey(), false);
@@ -1435,24 +1447,21 @@ public class ServiceManager {
             } else if (key.equals(CarConstants.CAR_BASIC_DRIVING_READY_STATE.getValue())) {
                 if ((value.equals("-1") || value.equals("0"))) {
                     boolean disableBluetoothOnPowerOff = sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF.getKey(), false);
-                    boolean currentBluetoothState = currentBluetoothState();
-                    if (currentBluetoothState && disableBluetoothOnPowerOff) {
-                        sharedPreferences.edit().putBoolean(SharedPreferencesKeys.BLUETOOTH_STATE_ON_POWER_OFF.getKey(), true).apply();
-                        disableBluetooth();
+                    boolean bluetoothOnlyOnFold = sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR.getKey(), false);
+                    if (disableBluetoothOnPowerOff && !bluetoothOnlyOnFold) {
+                        shutdownBluetoothIfEnabled();
                     }
                     boolean disableHotspotOnPowerOff = sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF.getKey(), false);
-                    if (disableHotspotOnPowerOff) {
-                        disableWifiTether();
+                    boolean hotspotOnlyOnFold = sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR.getKey(), false);
+                    if (disableHotspotOnPowerOff && !hotspotOnlyOnFold) {
+                        shutdownWifiTetherIfEnabled();
                     }
                     if (isMaxAcActive) {
                         cancelMaxAcMode();
                     }
                 } else {
-                    boolean disableBluetoothOnPowerOff = sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF.getKey(), false);
-                    boolean bluetoothStateOnPowerOff = sharedPreferences.getBoolean(SharedPreferencesKeys.BLUETOOTH_STATE_ON_POWER_OFF.getKey(), false);
-                    if (disableBluetoothOnPowerOff && bluetoothStateOnPowerOff && !currentBluetoothState()) {
-                        enableBluetooth();
-                    }
+                    restoreBluetoothIfWasEnabled();
+                    restoreWifiTetherIfWasEnabled();
                     if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_MAX_AC_ON_UNLOCK.getKey(), false)) {
                         if (!isMaxAcActive) enableMaxAcOn();
                     }
@@ -1612,6 +1621,44 @@ public class ServiceManager {
         } catch (Exception e) {
             Log.e(TAG, "Error checking Bluetooth state", e);
             return false;
+        }
+    }
+
+    private volatile boolean wifiTetherEnabled = false;
+
+    // Salva o estado atual e desliga (usado no power-off OU no recolher do retrovisor).
+    private void shutdownBluetoothIfEnabled() {
+        boolean wasOn = currentBluetoothState();
+        sharedPreferences.edit().putBoolean(SharedPreferencesKeys.BLUETOOTH_STATE_ON_POWER_OFF.getKey(), wasOn).apply();
+        if (wasOn) {
+            disableBluetooth();
+        }
+    }
+
+    private void shutdownWifiTetherIfEnabled() {
+        boolean wasOn = wifiTetherEnabled;
+        sharedPreferences.edit().putBoolean(SharedPreferencesKeys.WIFI_TETHER_STATE_ON_POWER_OFF.getKey(), wasOn).apply();
+        if (wasOn) {
+            disableWifiTether();
+        }
+    }
+
+    // Religa ao ligar o carro SOMENTE o que estava ligado; depois limpa o flag.
+    private void restoreBluetoothIfWasEnabled() {
+        if (sharedPreferences.getBoolean(SharedPreferencesKeys.BLUETOOTH_STATE_ON_POWER_OFF.getKey(), false)) {
+            if (!currentBluetoothState()) {
+                enableBluetooth();
+            }
+            sharedPreferences.edit().putBoolean(SharedPreferencesKeys.BLUETOOTH_STATE_ON_POWER_OFF.getKey(), false).apply();
+        }
+    }
+
+    private void restoreWifiTetherIfWasEnabled() {
+        if (sharedPreferences.getBoolean(SharedPreferencesKeys.WIFI_TETHER_STATE_ON_POWER_OFF.getKey(), false)) {
+            if (!wifiTetherEnabled) {
+                enableWifiTether();
+            }
+            sharedPreferences.edit().putBoolean(SharedPreferencesKeys.WIFI_TETHER_STATE_ON_POWER_OFF.getKey(), false).apply();
         }
     }
 

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -94,13 +94,25 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
             "disableBluetoothOnPowerOff",
             "Desativar Bluetooth ao desligar o veículo"
     ),
+    DISABLE_BLUETOOTH_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR(
+            "disableBluetoothOnPowerOffOnlyOnFoldMirror",
+            "Desligar o Bluetooth somente ao recolher o retrovisor (carro travado)"
+    ),
     DISABLE_HOTSPOT_ON_POWER_OFF(
             "disableHotspotOnPowerOff",
             "Desativar ponto de acesso ao desligar o veículo"
     ),
+    DISABLE_HOTSPOT_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR(
+            "disableHotspotOnPowerOffOnlyOnFoldMirror",
+            "Desligar o ponto de acesso somente ao recolher o retrovisor (carro travado)"
+    ),
     BLUETOOTH_STATE_ON_POWER_OFF(
             "bluetoothStateOnPowerOff",
             "Estado do Bluetooth ao desligar o veículo"
+    ),
+    WIFI_TETHER_STATE_ON_POWER_OFF(
+            "wifiTetherStateOnPowerOff",
+            "Estado do ponto de acesso ao desligar o veículo"
     ),
     ENABLE_SEAT_VENTILATION_ON_AC_ON(
             "enableSeatVentilationOnAcOn",

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -183,6 +183,22 @@ fun BasicSettingsTab() {
                         )
                 )
         }
+        var disableBluetoothOnlyOnFold by remember {
+                mutableStateOf(
+                        prefs.getBoolean(
+                                SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR.key,
+                                false
+                        )
+                )
+        }
+        var disableHotspotOnlyOnFold by remember {
+                mutableStateOf(
+                        prefs.getBoolean(
+                                SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR.key,
+                                false
+                        )
+                )
+        }
         var nightBrightnessLevel by remember {
                 mutableIntStateOf(
                         prefs.getInt(SharedPreferencesKeys.AUTO_BRIGHTNESS_LEVEL_NIGHT.key, 1)
@@ -1295,6 +1311,34 @@ fun BasicSettingsTab() {
                                                         it
                                                 )
                                         }
+                                },
+                                customContent = {
+                                        Row(
+                                                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                                                verticalAlignment = Alignment.CenterVertically,
+                                                horizontalArrangement = Arrangement.SpaceBetween
+                                        ) {
+                                                Text(
+                                                        "Apenas ao recolher o retrovisor (carro travado)",
+                                                        color = AppColors.TextPrimary,
+                                                        fontSize = 14.sp,
+                                                        modifier = Modifier.weight(1f).padding(end = 12.dp)
+                                                )
+                                                Switch(
+                                                        checked = disableBluetoothOnlyOnFold,
+                                                        onCheckedChange = {
+                                                                disableBluetoothOnlyOnFold = it
+                                                                prefs.edit {
+                                                                        putBoolean(
+                                                                                SharedPreferencesKeys
+                                                                                        .DISABLE_BLUETOOTH_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR
+                                                                                        .key,
+                                                                                it
+                                                                        )
+                                                                }
+                                                        }
+                                                )
+                                        }
                                 }
                         ),
                         SettingItem(
@@ -1311,6 +1355,34 @@ fun BasicSettingsTab() {
                                                                 .DISABLE_HOTSPOT_ON_POWER_OFF
                                                                 .key,
                                                         it
+                                                )
+                                        }
+                                },
+                                customContent = {
+                                        Row(
+                                                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                                                verticalAlignment = Alignment.CenterVertically,
+                                                horizontalArrangement = Arrangement.SpaceBetween
+                                        ) {
+                                                Text(
+                                                        "Apenas ao recolher o retrovisor (carro travado)",
+                                                        color = AppColors.TextPrimary,
+                                                        fontSize = 14.sp,
+                                                        modifier = Modifier.weight(1f).padding(end = 12.dp)
+                                                )
+                                                Switch(
+                                                        checked = disableHotspotOnlyOnFold,
+                                                        onCheckedChange = {
+                                                                disableHotspotOnlyOnFold = it
+                                                                prefs.edit {
+                                                                        putBoolean(
+                                                                                SharedPreferencesKeys
+                                                                                        .DISABLE_HOTSPOT_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR
+                                                                                        .key,
+                                                                                it
+                                                                        )
+                                                                }
+                                                        }
                                                 )
                                         }
                                 }


### PR DESCRIPTION
## O que faz

Adiciona dois refinamentos às opções existentes de "desligar Bluetooth/ponto de acesso ao desligar o veículo":

1. **Sub-toggle "Apenas ao recolher o retrovisor (carro travado)"** dentro de cada opção: em vez de desligar BT/WiFi assim que o veículo é desligado, desliga só quando o retrovisor recolhe (carro efetivamente travado/estacionado). Útil para quem fica no carro desligado e não quer perder o BT/WiFi.

2. **Restauração de estado ao ligar**: se o BT/ponto de acesso estava **ligado** quando o carro foi desligado/travado, ele é **reativado automaticamente** ao ligar o carro de novo. Se já estava desligado, permanece desligado.

## Detalhes

- Novas prefs: `DISABLE_BLUETOOTH_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR`, `DISABLE_HOTSPOT_ON_POWER_OFF_ONLY_ON_FOLD_MIRROR`, `WIFI_TETHER_STATE_ON_POWER_OFF`.
- Helpers em `ServiceManager`: `shutdownBluetoothIfEnabled` / `shutdownWifiTetherIfEnabled` / `restoreBluetoothIfWasEnabled` / `restoreWifiTetherIfWasEnabled`.
- O bloco de power-off passa a ser condicionado (`!onlyOnFold`); o bloco de recolher retrovisor recebe as chamadas de shutdown quando `onlyOnFold`; os receivers rastreiam o estado real (BT e WiFi tether) para a restauração.
- Também corrige um bug existente: a flag `BLUETOOTH_STATE_ON_POWER_OFF` nunca era resetada, fazendo o BT religar sempre — agora a flag é atualizada/limpa corretamente.
- Dois sub-toggles em Config → Básico (dentro das opções de Bluetooth e de ponto de acesso).

## Arquivos

- `ServiceManager.java` — helpers + gating + rastreamento de estado + fix da flag
- `SharedPreferencesKeys.kt` — 3 novas prefs
- `BasicSettingsScreen.kt` — 2 sub-toggles

Testado em um Haval H6 (display físico).
