### PR TITLE
feat(HEV): persistir o % do HEV Prioritário + ajustá-lo pela barra estendida

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -205,6 +205,7 @@ public class ServiceManager {
             CarConstants.CAR_INTELLIGENT_DRIVING_SETTING_SRAS_RSA_RSB_STATE,
             CarConstants.CAR_INTELLIGENT_DRIVING_SETTING_SRAS_RSA_RSB_WARNING_STATE,
             CarConstants.CAR_EV_SETTING_CHARGE_SOC_TARGET_CONFIG,
+            CarConstants.CAR_EV_SETTING_POWER_RESERVE_CONFIG,
     };
     private static ServiceManager instance;
     private final List<IDataChanged> dataChangedListeners;
@@ -1668,6 +1669,8 @@ public class ServiceManager {
                     if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_OPEN_SUNROOF_CURTAIN_ON_START.getKey(), false)) {
                         autoOpenSunroofCurtain();
                     }
+                    // Ao ligar o carro, reaplica o % de bateria do HEV Prioritario (o carro costuma resetar).
+                    applyHevSocTargetIfActive("POWER_ON");
                 }
             } else if (key.equals(CarConstants.CAR_HVAC_POWER_MODE.getValue()) && value.equals("1") && sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_SEAT_VENTILATION_ON_AC_ON.getKey(), false)) {
                 updateData(CarConstants.CAR_COMFORT_SETTING_DRIVER_SEAT_VENTILATION_LEVEL.getValue(), "3");
@@ -1675,9 +1678,49 @@ public class ServiceManager {
                 updateData(CarConstants.CAR_COMFORT_SETTING_DRIVER_SEAT_VENTILATION_LEVEL.getValue(), "0");
             } else if (key.equals(CarConstants.CAR_BASIC_INSIDE_TEMP.getValue()) && sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_MAX_AC_ON_UNLOCK.getKey(), false)) {
                 if (isMaxAcActive) updateMaxAcSmoothing();
+            } else if (key.equals(CarConstants.CAR_EV_SETTING_CHARGE_SOC_TARGET_CONFIG.getValue())) {
+                // O carro (ou o usuario) alterou o % alvo de bateria do HEV. Se a persistencia estiver
+                // ligada e o sub-modo for Prioritario, reaplica o valor que o usuario escolheu.
+                applyHevSocTargetIfActive("SOC_CHANGED");
+            } else if (key.equals(CarConstants.CAR_EV_SETTING_POWER_RESERVE_CONFIG.getValue()) && value.trim().equals("2")) {
+                // Entrou em HEV Prioritario -> aplica o % desejado.
+                applyHevSocTargetIfActive("ENTER_PRIORITARIO");
             }
         } catch (Exception e) {
             Log.e(TAG, "Error in OnDataChanged", e);
+        }
+    }
+
+    // Reaplica o % de bateria escolhido pelo usuario no HEV Prioritario, caso o carro o tenha
+    // alterado sozinho. So atua quando a persistencia esta ligada E o carro JA esta em HEV
+    // Prioritario (modo HEV + sub-modo Prioritario). NUNCA escreve o modo nem o sub-modo: se nao
+    // estiver exatamente em HEV Prioritario, sai sem fazer nada (o modo quem define e o usuario no
+    // carro). O eco da propria escrita nao re-dispara (current == desired).
+    public void applyHevSocTargetIfActive(String reason) {
+        try {
+            if (!sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_PERSIST_HEV_SOC_TARGET.getKey(), false)) {
+                return;
+            }
+            // 1) tem que estar em HEV (power_model_config == 0). Em EV/Prioridade EV, nao mexe em nada.
+            String driveMode = getUpdatedData(CarConstants.CAR_EV_SETTING_POWER_MODEL_CONFIG.getValue());
+            if (driveMode == null || !driveMode.trim().equals("0")) {
+                return;
+            }
+            // 2) e o sub-modo tem que ser Prioritario (power_reserve_config == 2).
+            String subMode = getUpdatedData(CarConstants.CAR_EV_SETTING_POWER_RESERVE_CONFIG.getValue());
+            if (subMode == null || !subMode.trim().equals("2")) {
+                return;
+            }
+            int desired = sharedPreferences.getInt(SharedPreferencesKeys.HEV_SOC_TARGET_VALUE.getKey(), 50);
+            String currentStr = getUpdatedData(CarConstants.CAR_EV_SETTING_CHARGE_SOC_TARGET_CONFIG.getValue());
+            int current = Integer.MIN_VALUE;
+            try { current = Integer.parseInt(currentStr.trim()); } catch (Exception ignored) {}
+            if (current != desired) {
+                updateData(CarConstants.CAR_EV_SETTING_CHARGE_SOC_TARGET_CONFIG.getValue(), String.valueOf(desired));
+                Log.w(TAG, "[HEV-SOC " + reason + "] alvo estava " + current + ", reaplicado " + desired);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "applyHevSocTargetIfActive falhou", e);
         }
     }
 

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -1685,6 +1685,10 @@ public class ServiceManager {
             } else if (key.equals(CarConstants.CAR_EV_SETTING_POWER_RESERVE_CONFIG.getValue()) && value.trim().equals("2")) {
                 // Entrou em HEV Prioritario -> aplica o % desejado.
                 applyHevSocTargetIfActive("ENTER_PRIORITARIO");
+            } else if (key.equals(CarConstants.CAR_EV_SETTING_POWER_MODEL_CONFIG.getValue()) && value.trim().equals("0")) {
+                // Mudou de EV para HEV -> reaplica o % desejado (o carro costuma cair pra 20%).
+                // applyHevSocTargetIfActive se auto-gateia (so atua em HEV Prioritario + persistencia ON).
+                applyHevSocTargetIfActive("ENTER_HEV");
             }
         } catch (Exception e) {
             Log.e(TAG, "Error in OnDataChanged", e);
@@ -1722,6 +1726,15 @@ public class ServiceManager {
         } catch (Exception e) {
             Log.e(TAG, "applyHevSocTargetIfActive falhou", e);
         }
+    }
+
+    // Define o % alvo do HEV Prioritario a partir da UI (barra estendida/config): salva a pref
+    // e escreve no carro. Clampa em 20..80.
+    public void setHevSocTargetValue(int value) {
+        int v = Math.max(20, Math.min(80, value));
+        sharedPreferences.edit().putInt(SharedPreferencesKeys.HEV_SOC_TARGET_VALUE.getKey(), v).apply();
+        updateData(CarConstants.CAR_EV_SETTING_CHARGE_SOC_TARGET_CONFIG.getValue(), String.valueOf(v));
+        Log.w(TAG, "[HEV-SOC UI_SET] alvo definido = " + v);
     }
 
     public boolean closeAllWindow() {

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -258,5 +258,7 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
     AMBIENT_LIGHT_AUTO_RECONNECT(
             "ambientLightAutoReconnect",
             "Reconectar automaticamente o Ambient Light"
-    )
+    ),
+    ENABLE_PERSIST_HEV_SOC_TARGET("enablePersistHevSocTarget", "Manter o % de bateria escolhido no HEV Prioritário"),
+    HEV_SOC_TARGET_VALUE("hevSocTargetValue", "% de bateria a manter no HEV Prioritário (20-80)")
 }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/components/BottomBarUI.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/components/BottomBarUI.kt
@@ -1873,6 +1873,8 @@ private data class DashboardVehicleSnapshot(
         val gear: String,
         val driveMode: String,
         val powerModel: String,
+        val powerReserve: String,
+        val socTarget: String,
         val energyRecovery: String,
         val steeringMode: String,
         val driverTemp: String,
@@ -1928,6 +1930,22 @@ private fun rememberDashboardVehicleSnapshot(
                                 CarConstants.CAR_EV_SETTING_POWER_MODEL_CONFIG.getValue()
                         )
                                 ?: "0"
+                )
+        }
+        var powerReserve by remember {
+                mutableStateOf(
+                        serviceManager.getData(
+                                CarConstants.CAR_EV_SETTING_POWER_RESERVE_CONFIG.getValue()
+                        )
+                                ?: "1"
+                )
+        }
+        var socTarget by remember {
+                mutableStateOf(
+                        serviceManager.getData(
+                                CarConstants.CAR_EV_SETTING_CHARGE_SOC_TARGET_CONFIG.getValue()
+                        )
+                                ?: "50"
                 )
         }
         var energyRecovery by remember {
@@ -2125,6 +2143,10 @@ private fun rememberDashboardVehicleSnapshot(
                                                         .getValue() -> driveMode = value
                                                 CarConstants.CAR_EV_SETTING_POWER_MODEL_CONFIG
                                                         .getValue() -> powerModel = value
+                                                CarConstants.CAR_EV_SETTING_POWER_RESERVE_CONFIG
+                                                        .getValue() -> powerReserve = value
+                                                CarConstants.CAR_EV_SETTING_CHARGE_SOC_TARGET_CONFIG
+                                                        .getValue() -> socTarget = value
                                                 CarConstants.CAR_EV_SETTING_ENERGY_RECOVERY_LEVEL
                                                         .getValue() -> energyRecovery = value
                                                 CarConstants
@@ -2221,6 +2243,8 @@ private fun rememberDashboardVehicleSnapshot(
                 gear = gear,
                 driveMode = driveMode,
                 powerModel = powerModel,
+                powerReserve = powerReserve,
+                socTarget = socTarget,
                 energyRecovery = energyRecovery,
                 steeringMode = steeringMode,
                 driverTemp = driverTemp,
@@ -3070,7 +3094,7 @@ private fun DashboardDrivePanel(snapshot: DashboardVehicleSnapshot, modifier: Mo
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                                 DashboardStatPill(
                                         label = "EV",
-                                        value = powerModelLabel(snapshot.powerModel),
+                                        value = powerModelLabel(snapshot.powerModel, snapshot.powerReserve, snapshot.socTarget),
                                         icon = Icons.Default.ElectricBolt,
                                         accent = Color(0xFF78E08F),
                                         modifier = Modifier.weight(1f)
@@ -3168,6 +3192,14 @@ private fun DashboardSettingsPanel(
                 val powerOptions = listOf("0" to "HEV", "1" to "EV Prior.", "3" to "EV")
                 val regenOptions = listOf("2" to "Baixo", "0" to "Normal", "1" to "Alto")
                 val steeringOptions = listOf("2" to "Conforto", "0" to "Normal", "1" to "Sport")
+                var showHevDialog by remember { mutableStateOf(false) }
+                if (showHevDialog) {
+                        HevModeDialog(
+                                snapshot = snapshot,
+                                serviceManager = serviceManager,
+                                onDismiss = { showHevDialog = false }
+                        )
+                }
 
                 Column(
                         modifier = Modifier.fillMaxSize(),
@@ -3246,7 +3278,7 @@ private fun DashboardSettingsPanel(
                                         }
                                         DashboardPremiumCycleControl(
                                                 label = "Energia",
-                                                value = powerModelLabel(snapshot.powerModel),
+                                                value = powerModelLabel(snapshot.powerModel, snapshot.powerReserve, snapshot.socTarget),
                                                 nextValue =
                                                         nextDashboardOptionLabel(
                                                                 snapshot.powerModel,
@@ -3254,7 +3286,14 @@ private fun DashboardSettingsPanel(
                                                         ),
                                                 icon = Icons.Default.ElectricBolt,
                                                 accent = Color(0xFF78E08F),
-                                                modifier = Modifier.weight(1f)
+                                                modifier = Modifier.weight(1f),
+                                                onLongClick = {
+                                                        // Toque longo em HEV -> popup do sub-modo
+                                                        // (Inteligente/Prioritário + % de bateria).
+                                                        if (snapshot.powerModel.trim() == "0") {
+                                                                showHevDialog = true
+                                                        }
+                                                }
                                         ) {
                                                 serviceManager.updateData(
                                                         CarConstants
@@ -4726,6 +4765,73 @@ private fun DashboardQuickCycleControl(
 }
 
 @Composable
+private fun HevModeDialog(
+        snapshot: DashboardVehicleSnapshot,
+        serviceManager: ServiceManager,
+        onDismiss: () -> Unit
+) {
+        val reserve = snapshot.powerReserve
+        val pct = snapshot.socTarget.trim().toIntOrNull()?.coerceIn(20, 80) ?: 50
+        var dragging by remember { mutableStateOf(false) }
+        var sliderPos by remember { mutableFloatStateOf(pct.toFloat()) }
+        LaunchedEffect(pct) { if (!dragging) sliderPos = pct.toFloat() }
+        AlertDialog(
+                onDismissRequest = onDismiss,
+                containerColor = Color(0xFF161B24),
+                titleContentColor = Color.White,
+                textContentColor = Color.White,
+                confirmButton = {
+                        TextButton(onClick = onDismiss) {
+                                Text("Fechar", color = Color(0xFF78E08F))
+                        }
+                },
+                title = { Text("Modo HEV") },
+                text = {
+                        Column {
+                                SettingsCategoryRow(
+                                        "Reserva de bateria",
+                                        reserve,
+                                        listOf("1" to "Inteligente", "2" to "Prioritário")
+                                ) { newVal ->
+                                        serviceManager.updateData(
+                                                CarConstants.CAR_EV_SETTING_POWER_RESERVE_CONFIG
+                                                        .getValue(),
+                                                newVal
+                                        )
+                                }
+                                if (reserve.trim() == "2") {
+                                        Spacer(Modifier.height(14.dp))
+                                        Text(
+                                                text = "Bateria a manter: ${sliderPos.toInt()}%",
+                                                style =
+                                                        labelStyle.copy(
+                                                                fontWeight = FontWeight.Bold
+                                                        )
+                                        )
+                                        Spacer(Modifier.height(8.dp))
+                                        Slider(
+                                                value = sliderPos,
+                                                onValueChange = { v ->
+                                                        dragging = true
+                                                        sliderPos = v
+                                                },
+                                                onValueChangeFinished = {
+                                                        dragging = false
+                                                        serviceManager.setHevSocTargetValue(
+                                                                sliderPos.toInt()
+                                                        )
+                                                },
+                                                valueRange = 20f..80f,
+                                                steps = 11
+                                        )
+                                }
+                        }
+                }
+        )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
 private fun DashboardPremiumCycleControl(
         label: String,
         value: String,
@@ -4733,11 +4839,16 @@ private fun DashboardPremiumCycleControl(
         icon: ImageVector,
         accent: Color,
         modifier: Modifier = Modifier,
+        onLongClick: (() -> Unit)? = null,
         onClick: () -> Unit
 ) {
         Surface(
-                onClick = onClick,
-                modifier = modifier.fillMaxHeight(),
+                modifier =
+                        modifier.fillMaxHeight()
+                                .combinedClickable(
+                                        onClick = onClick,
+                                        onLongClick = onLongClick
+                                ),
                 color = Color.White.copy(alpha = 0.052f),
                 shape = RoundedCornerShape(8.dp),
                 border = BorderStroke(1.dp, accent.copy(alpha = 0.24f))
@@ -5342,11 +5453,23 @@ private fun driveModeLabel(value: String): String {
         }
 }
 
-private fun powerModelLabel(value: String): String {
+private fun powerModelLabel(
+        value: String,
+        reserve: String = "1",
+        socTarget: String = "50"
+): String {
         return when (value) {
                 "1" -> "EV Prior."
                 "3" -> "EV"
-                else -> "HEV"
+                else -> {
+                        // HEV: mostra o sub-modo; se Prioritário, anexa o % de bateria alvo.
+                        if (reserve.trim() == "2") {
+                                val pct = socTarget.trim().toIntOrNull()?.coerceIn(20, 80) ?: 50
+                                "HEV Prior. $pct%"
+                        } else {
+                                "HEV Intel."
+                        }
+                }
         }
 }
 

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -419,8 +419,59 @@ fun BasicSettingsTab() {
                         prefs.getFloat(SharedPreferencesKeys.OPEN_SUNROOF_CURTAIN_MAX_TEMP.key, -1f)
                 )
         }
+        var enablePersistHevSoc by remember {
+                mutableStateOf(
+                        prefs.getBoolean(SharedPreferencesKeys.ENABLE_PERSIST_HEV_SOC_TARGET.key, false)
+                )
+        }
+        var hevSocTarget by remember {
+                mutableIntStateOf(
+                        prefs.getInt(SharedPreferencesKeys.HEV_SOC_TARGET_VALUE.key, 50)
+                )
+        }
 
         val settingsList = mutableListOf<SettingItem>()
+
+        settingsList.add(
+                SettingItem(
+                        title = "Manter % de bateria no HEV Prioritário",
+                        description = "Se o carro alterar sozinho o % a salvar, o app reaplica o valor que você escolheu. Só vale em HEV Prioritário.",
+                        checked = enablePersistHevSoc,
+                        onCheckedChange = {
+                                enablePersistHevSoc = it
+                                prefs.edit {
+                                        putBoolean(SharedPreferencesKeys.ENABLE_PERSIST_HEV_SOC_TARGET.key, it)
+                                }
+                                if (it) ServiceManager.getInstance().applyHevSocTargetIfActive("UI_TOGGLE")
+                        },
+                        customContent = {
+                                Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+                                        Text(
+                                                "Salvar bateria em: $hevSocTarget%",
+                                                color = AppColors.TextPrimary,
+                                                fontSize = 14.sp
+                                        )
+                                        Slider(
+                                                value = hevSocTarget.toFloat(),
+                                                onValueChange = { hevSocTarget = it.toInt() },
+                                                onValueChangeFinished = {
+                                                        prefs.edit {
+                                                                putInt(SharedPreferencesKeys.HEV_SOC_TARGET_VALUE.key, hevSocTarget)
+                                                        }
+                                                        ServiceManager.getInstance().applyHevSocTargetIfActive("UI_SLIDER")
+                                                },
+                                                valueRange = 20f..80f,
+                                                steps = 11,
+                                                colors = SliderDefaults.colors(
+                                                        thumbColor = AppColors.Primary,
+                                                        activeTrackColor = AppColors.Primary,
+                                                        inactiveTrackColor = Color(0xFF2C3139)
+                                                )
+                                        )
+                                }
+                        }
+                )
+        )
 
         if (isAdvancedUse && !selfInstallationCheck) {
                 settingsList.add(


### PR DESCRIPTION
Mantém o % de bateria do HEV Prioritário (que o carro reseta sozinho para 20/80) **e** adiciona o ajuste do sub-modo HEV e do % direto pela barra estendida.

## Persistência
- Quando o app está em **HEV** (`power_model_config==0`) + **Prioritário** (`power_reserve_config==2`) e a persistência está ligada, reaplica o % salvo (`charge_soc_target_config`) sempre que o carro o altera. **Nunca** escreve o modo nem o sub-modo — o usuário é o dono dessas escolhas.
- Gatilhos: alteração do % (reset do carro), entrar em Prioritário, ligar o carro, e mudar de **EV→HEV** (o carro costuma cair para 20%).
- UI: toggle + slider (20–80) em Config → Básico. Prefs `ENABLE_PERSIST_HEV_SOC_TARGET`, `HEV_SOC_TARGET_VALUE`.

## Ajuste pela barra estendida (novo)
- **Toque longo** no botão "Energia" do dashboard (quando em HEV) abre um popup para escolher **HEV Inteligente/Prioritário** e, em Prioritário, ajustar o **%** (slider 20–80, passos de 5%).
- O **card** passa a mostrar "HEV Intel." / "HEV Prior. X%" em vez de só "HEV".
- Bidirecional: ajustar aqui escreve no carro; mudar na config oficial reflete aqui (as chaves `power_reserve_config` + `charge_soc_target_config` são observadas).

CAN keys (confirmados no carro): `power_model_config` (0=HEV, 1=EV Prior., 3=EV), `power_reserve_config` (1=Inteligente, 2=Prioritário), `charge_soc_target_config` (% 20–80).

Rodando em um Haval H6 PHEV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
