### PR TITLE
Fix Play/Pause Android Auto and Supabase report logs for preview

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,6 +20,14 @@ val impulseReportSupabasePublishableKey =
         .orElse("sb_publishable_2fp6Nav76kCNXklyKtCnYA_ZiM3z5l8")
 val impulseReportFunctionName =
     providers.gradleProperty("impulseReportFunctionName").orElse("impulse-report-problem")
+val impulseReportDiagnosticsEnabled =
+    providers.gradleProperty("impulseReportDiagnosticsEnabled")
+        .map(String::toBoolean)
+        .orElse(
+            appVersionName.map { versionName ->
+                versionName.contains("preview", ignoreCase = true)
+            }
+        )
 
 fun buildConfigString(value: String): String =
     "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
@@ -51,6 +59,11 @@ android {
             "IMPULSE_REPORT_FUNCTION_NAME",
             buildConfigString(impulseReportFunctionName.get())
         )
+        buildConfigField(
+            "boolean",
+            "IMPULSE_REPORT_DIAGNOSTICS_ENABLED",
+            impulseReportDiagnosticsEnabled.get().toString()
+        )
     }
 
     signingConfigs {
@@ -65,11 +78,13 @@ android {
     buildTypes {
         named("debug") {
             buildConfigField("boolean", "EMBED_FRIDA_TOOLS", "true")
+            buildConfigField("boolean", "IMPULSE_REPORT_DIAGNOSTICS_ENABLED", "true")
         }
         create("leanDebug") {
             initWith(getByName("debug"))
             matchingFallbacks += listOf("debug")
             buildConfigField("boolean", "EMBED_FRIDA_TOOLS", "false")
+            buildConfigField("boolean", "IMPULSE_REPORT_DIAGNOSTICS_ENABLED", "true")
         }
         named("release") {
             signingConfig = signingConfigs.getByName("release")

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/diagnostics/ClusterPersistentEventLogger.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/diagnostics/ClusterPersistentEventLogger.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 data class ClusterLogCaptureStatus(
-        val debugBuild: Boolean,
+        val diagnosticLoggingAvailable: Boolean,
         val enabled: Boolean,
         val directoryPath: String,
         val filePath: String,
@@ -26,7 +26,7 @@ data class ClusterLogCaptureStatus(
         val lastModifiedMs: Long
 ) {
     val captureActive: Boolean
-        get() = debugBuild && enabled
+        get() = diagnosticLoggingAvailable && enabled
 }
 
 object ClusterPersistentEventLogger {
@@ -59,7 +59,7 @@ object ClusterPersistentEventLogger {
 
     @JvmStatic
     fun log(event: String, details: Map<String, *>) {
-        if (!BuildConfig.DEBUG) return
+        if (!isDiagnosticLoggingAvailable()) return
 
         val context =
                 runCatching { App.getDeviceProtectedContext() }
@@ -101,13 +101,18 @@ object ClusterPersistentEventLogger {
 
     @JvmStatic
     fun isPersistentCaptureEnabled(context: Context): Boolean {
-        if (!BuildConfig.DEBUG) return false
+        if (!isDiagnosticLoggingAvailable()) return false
         return runCatching {
                     deviceProtectedContext(context)
                             .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
                             .getBoolean(CAPTURE_ENABLED_KEY, true)
                 }
                 .getOrDefault(false)
+    }
+
+    @JvmStatic
+    fun isDiagnosticLoggingAvailable(): Boolean {
+        return BuildConfig.DEBUG || BuildConfig.IMPULSE_REPORT_DIAGNOSTICS_ENABLED
     }
 
     @JvmStatic
@@ -128,7 +133,7 @@ object ClusterPersistentEventLogger {
         val fileName = buildFileName(nowMs)
         val file = File(dir, fileName)
         return ClusterLogCaptureStatus(
-                debugBuild = BuildConfig.DEBUG,
+                diagnosticLoggingAvailable = isDiagnosticLoggingAvailable(),
                 enabled = isPersistentCaptureEnabled(context),
                 directoryPath = dir.absolutePath,
                 filePath = file.absolutePath,

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/diagnostics/ProblemReportBuilder.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/diagnostics/ProblemReportBuilder.kt
@@ -112,13 +112,20 @@ object ProblemReportBuilder {
             appendLine("- Version code: ${BuildConfig.VERSION_CODE}")
             appendLine("- Build type: ${BuildConfig.BUILD_TYPE}")
             appendLine("- Debug: ${BuildConfig.DEBUG}")
+            appendLine(
+                    "- Diagnostico de logs habilitado: " +
+                            yesNo(captureStatus.diagnosticLoggingAvailable)
+            )
             appendLine("- Relatorio gerado em: $generatedAt")
             appendLine("- Timezone: $timeZoneId")
             appendLine()
             appendLine("## Log persistente do dia atual")
             appendLine("- Arquivo esperado: ${logFile.absolutePath}")
             appendLine("- Captura persistente ativa: ${yesNo(captureStatus.captureActive)}")
-            appendLine("- Build debug/internal: ${yesNo(captureStatus.debugBuild)}")
+            appendLine(
+                    "- Build com diagnostico de logs: " +
+                            yesNo(captureStatus.diagnosticLoggingAvailable)
+            )
             appendLine("- Arquivo existe: ${yesNo(captureStatus.fileExists)}")
             appendLine("- Tamanho do arquivo: ${captureStatus.fileSizeBytes} bytes")
             appendLine("- Observacao: o app anexa somente o log persistente do dia atual para manter o envio leve.")
@@ -155,7 +162,7 @@ object ProblemReportBuilder {
     }
 
     private fun readLogcatSnapshot(): String {
-        if (!BuildConfig.DEBUG) return ""
+        if (!ClusterPersistentEventLogger.isDiagnosticLoggingAvailable()) return ""
         return runCatching {
                     val process =
                             ProcessBuilder("logcat", "-d", "-v", "time", "-t", "320")

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/ProblemReportScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/ProblemReportScreen.kt
@@ -307,7 +307,7 @@ private fun LogCaptureStatusCard(
                 }
                 Switch(
                         checked = status.captureActive,
-                        enabled = status.debugBuild,
+                        enabled = status.diagnosticLoggingAvailable,
                         onCheckedChange = onEnabledChange,
                         colors =
                                 SwitchDefaults.colors(
@@ -364,7 +364,7 @@ private fun LogStatusLine(label: String, value: String) {
 }
 
 private fun logCaptureStatusText(status: ClusterLogCaptureStatus): String {
-    if (!status.debugBuild) return "Indisponível nesta build."
+    if (!status.diagnosticLoggingAvailable) return "Indisponível nesta build."
     return if (status.captureActive) {
         "Ativa: eventos novos entram no log persistente do dia."
     } else {

--- a/docs/architecture/android-flow.md
+++ b/docs/architecture/android-flow.md
@@ -1,6 +1,6 @@
 # Android Flow
 
-Atualizado em: 2026-06-18
+Atualizado em: 2026-06-25
 
 ## Fluxo Identificado
 
@@ -75,15 +75,24 @@ Atualizado em: 2026-06-18
      atual e snapshot recente/filtrado de `logcat`;
   6. app faz `POST` para a Edge Function com publishable key;
   7. Edge Function valida payload/rate limit, grava em `public.impulse_problem_reports` com
-     service role e, se secrets GitHub existirem, cria issue server-side.
+     service role e, se secrets GitHub existirem, cria issue server-side;
+  8. Edge Function salva uma copia `.txt` do corpo do relatorio/logs no bucket privado
+     `impulse-problem-report-logs` e grava `log_storage_bucket`, `log_storage_path` e
+     `log_storage_size_bytes` na linha do report.
 - A tabela `public.impulse_problem_reports` tem RLS habilitado e policy apenas para `service_role`.
   `anon`/`authenticated` nao tem permissao direta na tabela; envio publico passa somente pela Edge
   Function.
+- O bucket `impulse-problem-report-logs` e privado. O APK nao acessa Storage diretamente; upload
+  do arquivo e feito somente pela Edge Function usando service role.
 - Rate limit inicial: ate `8` relatos por `installationId` em 24h.
 - Se o envio falhar ou a build nao estiver configurada, o app copia o relatorio completo para a
   area de transferencia.
 - O log persistente diario tambem inclui `webview_console`, capturado via `WebChromeClient`, para
   registrar `console.log/warn/error` do dashboard sem alterar o contrato Kotlin/JS.
+- A captura persistente fica disponivel em `debug`/`leanDebug` e em builds release com
+  `IMPULSE_REPORT_DIAGNOSTICS_ENABLED=true`. Por padrao, esse campo fica ativo quando
+  `appVersionName` contem `preview`; release final sem `preview` continua sem diagnostico, salvo
+  override explicito por `-PimpulseReportDiagnosticsEnabled=true`.
 - A tela mostra o status do log persistente do dia atual: captura ativa/desativada, arquivo,
   tamanho e ultima atualizacao. O usuario pode desligar a captura persistente; isso para novas
   escritas no arquivo diario, mas nao executa limpeza retroativa.
@@ -381,11 +390,13 @@ Atualizado em: 2026-06-18
   estado que o usuario acabou de pedir.
 - Esses comandos sao restritos a midia. Eles nao autorizam abrir/mover Activity, alterar Surface,
   foco, display, watchdog ou handoff D0/D3 do CarPlay.
-- Para preview/release, logs de diagnostico do app ficam desligados. O build release usa R8 com
-  `-maximumremovedandroidloglevel 7`; `ClusterPerfEventLogger` nao executa fora de debug e os logs
-  do `CarPlayNowPlayingMonitor` ficam em lazy debug logging. Em 2026-06-12, `dexdump` do
-  `minifyReleaseWithR8` confirmou ausencia de chamadas de emissao `Log.e/w/d/i` do app e ausencia
-  dos marcadores `ClusterPerf`, `[PERF_EVENT]`, `CarPlay now playing...` e loop loggers no dex.
+- Para release final sem `preview`, logs de diagnostico do app continuam desligados por padrao. O
+  build release usa R8 com `-maximumremovedandroidloglevel 7`; `ClusterPerfEventLogger` nao executa
+  fora de debug e os logs do `CarPlayNowPlayingMonitor` ficam em lazy debug logging. Em
+  2026-06-12, `dexdump` do `minifyReleaseWithR8` confirmou ausencia de chamadas de emissao
+  `Log.e/w/d/i` do app e ausencia dos marcadores `ClusterPerf`, `[PERF_EVENT]`,
+  `CarPlay now playing...` e loop loggers no dex. Builds `*-preview` agora podem manter a trilha
+  persistente leve de `Reportar problema` via `IMPULSE_REPORT_DIAGNOSTICS_ENABLED=true`.
 
 ## Arquivos Relacionados
 

--- a/docs/architecture/performance-considerations.md
+++ b/docs/architecture/performance-considerations.md
@@ -14,18 +14,21 @@ Atualizado em: 2026-06-15
 - Modo grafico usa Chart.js/canvas/SVG e deve ter limite explicito de frequencia.
 - `ClusterPerfEventLogger` registra eventos operacionais com snapshot de CPU/memoria no logcat
   usando tag `ClusterPerf` e prefixo `[PERF_EVENT]` somente em builds debug/internal.
-- `ClusterPersistentEventLogger` grava uma trilha leve de diagnostico em arquivo por dia, somente
-  em builds debug/internal:
+- `ClusterPersistentEventLogger` grava uma trilha leve de diagnostico em arquivo por dia em
+  builds debug/leanDebug e em releases de preview com
+  `IMPULSE_REPORT_DIAGNOSTICS_ENABLED=true`:
   `/sdcard/Android/data/br.com.redesurftank.havalshisuku/files/cluster-diagnostics/cluster-events-YYYYMMDD.log`.
   A retencao preserva hoje + dois dias anteriores e remove arquivos mais antigos.
 - A captura persistente pode ser desligada pelo usuario na tela `Reportar problema`. Quando
   desligada, o logger retorna antes de enfileirar qualquer escrita em `Dispatchers.IO`.
 - `WebChromeClient.onConsoleMessage` grava `webview_console` nesse mesmo log persistente diario,
   permitindo correlacionar erros do frontend com `WEBVIEW_STATE_SYNC`, cards e projecao.
-- Builds preview/release nao devem emitir logs de diagnostico do app: `ClusterPerfEventLogger`
-  e `ClusterPersistentEventLogger` retornam imediatamente quando `BuildConfig.DEBUG=false`, logs
-  CarPlay de Now Playing usam lazy debug logging e o R8 remove chamadas `android.util.Log` por
-  `-maximumremovedandroidloglevel 7`.
+- Release final sem `preview` nao deve emitir logs de diagnostico do app por padrao:
+  `ClusterPerfEventLogger` retorna imediatamente quando `BuildConfig.DEBUG=false`, logs CarPlay de
+  Now Playing usam lazy debug logging e o R8 remove chamadas `android.util.Log` por
+  `-maximumremovedandroidloglevel 7`. A excecao operacional e a trilha persistente leve de
+  `Reportar problema` em builds `*-preview`, controlada por
+  `IMPULSE_REPORT_DIAGNOSTICS_ENABLED=true` e pelo toggle do usuario.
 
 ## Riscos de Performance
 
@@ -38,8 +41,8 @@ Atualizado em: 2026-06-15
 - `chartInstance.update(...)` em intervalos curtos por muitas horas de viagem.
 - Canvas/`requestAnimationFrame` com erro repetido em `try/catch`, gerando log/GC continuo.
 - Instrumentacao de performance em frequencia alta demais tambem pode virar custo; logs de
-  heartbeat devem continuar espaçados e eventos JS devem ser pontuais. Em preview/release, essa
-  instrumentacao deve permanecer desligada.
+  heartbeat devem continuar espaçados e eventos JS devem ser pontuais. Em release final, essa
+  instrumentacao deve permanecer desligada salvo decisao explicita.
 - O log persistente nao deve capturar `logcat` inteiro nem snapshots pesados a cada tick. Usar
   apenas eventos ja existentes, console do WebView e mudancas de estado para preservar I/O baixo
   durante viagens longas.
@@ -76,7 +79,7 @@ Atualizado em: 2026-06-15
 - Nao deixar `requestAnimationFrame` ativo fora da tela de grafico.
 - Para correlacionar travamentos/lentidao com recursos, usar build debug/internal e coletar logcat
   filtrando `ClusterPerf`/`[PERF_EVENT]`. A primeira amostra de CPU pode vir como `n/a`; as
-  seguintes usam delta entre eventos. Em preview/release esses eventos nao sao emitidos.
+  seguintes usam delta entre eventos. Em release final esses eventos nao sao emitidos por padrao.
 - Para diagnostico pos-reboot de eventos de cluster, puxar os arquivos persistentes:
 
 ```bash

--- a/supabase/functions/impulse-report-problem/index.ts
+++ b/supabase/functions/impulse-report-problem/index.ts
@@ -2,12 +2,14 @@ const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const MAX_DESCRIPTION_CHARS = 3000;
 const MAX_REPORT_BODY_CHARS = 2000000;
 const MAX_LOG_CHARS = 100000;
+const MAX_REPORT_STORAGE_CHARS = 1800000;
 const MAX_REPORTS_PER_INSTALLATION_PER_DAY = 8;
 const MAX_CHUNK_TEXT_CHARS = 700;
 const MAX_CHUNK_COUNT = 4000;
 const MAX_CHUNKED_PAYLOAD_CHARS = 2200000;
 const MAX_DECOMPRESSED_PAYLOAD_CHARS = 2200000;
 const CHUNK_RETENTION_HOURS = 6;
+const LOG_STORAGE_BUCKET = "impulse-problem-report-logs";
 
 const jsonHeaders = {
   "Content-Type": "application/json; charset=utf-8",
@@ -107,6 +109,11 @@ async function handleCompleteReport(
     return jsonResponse({ error: "insert_failed", detail: inserted.error }, 500);
   }
 
+  const logStorage = await uploadReportFile(serviceKey, inserted.id, payload, reportBody);
+  if (logStorage.ok) {
+    await updateReportLogStorage(serviceKey, inserted.id, logStorage);
+  }
+
   const issue = await maybeCreateGithubIssue(payload.title, reportBody, inserted.id);
   if (issue.githubIssueUrl) {
     await updateGithubIssue(serviceKey, inserted.id, issue.githubIssueUrl, issue.githubIssueNumber);
@@ -116,6 +123,8 @@ async function handleCompleteReport(
     id: inserted.id,
     githubIssueUrl: issue.githubIssueUrl,
     githubIssueNumber: issue.githubIssueNumber,
+    logStoragePath: logStorage.ok ? logStorage.path : null,
+    logStorageError: logStorage.ok ? null : logStorage.error,
   });
 }
 
@@ -160,6 +169,10 @@ type ReportChunkPayload = {
 type InsertResult = { ok: true; id: string } | { ok: false; error: string };
 
 type ChunkRow = { chunk_index: number; chunk_text: string };
+
+type ReportFileUploadResult =
+  | { ok: true; bucket: string; path: string; sizeBytes: number }
+  | { ok: false; error: string };
 
 function validatePayload(payload: ReportPayload): string | null {
   if (!payload || typeof payload !== "object") return "missing_payload";
@@ -451,6 +464,100 @@ async function updateGithubIssue(
       updated_at: new Date().toISOString(),
     }),
   });
+}
+
+async function updateReportLogStorage(
+  serviceKey: string,
+  id: string,
+  upload: Extract<ReportFileUploadResult, { ok: true }>,
+) {
+  const url = new URL(`${SUPABASE_URL}/rest/v1/impulse_problem_reports`);
+  url.searchParams.set("id", `eq.${id}`);
+  await fetch(url, {
+    method: "PATCH",
+    headers: serviceHeaders(serviceKey),
+    body: JSON.stringify({
+      log_storage_bucket: upload.bucket,
+      log_storage_path: upload.path,
+      log_storage_size_bytes: upload.sizeBytes,
+      updated_at: new Date().toISOString(),
+    }),
+  });
+}
+
+async function uploadReportFile(
+  serviceKey: string,
+  reportId: string,
+  payload: ReportPayload,
+  reportBody: string,
+): Promise<ReportFileUploadResult> {
+  const path = buildReportStoragePath(reportId, payload.logFileName);
+  const body = buildReportStorageBody(reportId, payload, reportBody);
+  const bytes = new TextEncoder().encode(body);
+  const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+  const url = `${SUPABASE_URL}/storage/v1/object/${LOG_STORAGE_BUCKET}/${encodedPath}`;
+
+  const headers: Record<string, string> = {
+    apikey: serviceKey,
+    "Content-Type": "text/plain",
+    "Cache-Control": "no-store",
+    "x-upsert": "true",
+  };
+  if (serviceKey.split(".").length === 3) {
+    headers.Authorization = `Bearer ${serviceKey}`;
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: bytes,
+  });
+
+  if (!response.ok) {
+    return { ok: false, error: await response.text() };
+  }
+
+  return {
+    ok: true,
+    bucket: LOG_STORAGE_BUCKET,
+    path,
+    sizeBytes: bytes.byteLength,
+  };
+}
+
+function buildReportStoragePath(reportId: string, logFileName: string | undefined): string {
+  const date = new Date().toISOString().slice(0, 10);
+  const primaryName = (logFileName ?? "problem-report.log").split(";")[0]?.trim();
+  const fileName = sanitizeStorageFileName(primaryName || "problem-report.log")
+    .replace(/\.log$/i, ".txt");
+  return `${date}/${reportId}/${fileName.endsWith(".txt") ? fileName : `${fileName}.txt`}`;
+}
+
+function buildReportStorageBody(
+  reportId: string,
+  payload: ReportPayload,
+  reportBody: string,
+): string {
+  const body = [
+    `Supabase report id: ${reportId}`,
+    `Installation id: ${payload.installationId}`,
+    `Generated at: ${payload.generatedAt ?? ""}`,
+    `Client timezone: ${payload.timeZone ?? ""}`,
+    `Log file name: ${payload.logFileName ?? ""}`,
+    "",
+    reportBody,
+  ].join("\n");
+
+  if (body.length <= MAX_REPORT_STORAGE_CHARS) return body;
+  return `${body.slice(0, MAX_REPORT_STORAGE_CHARS)}\n\n[arquivo truncado no Storage]`;
+}
+
+function sanitizeStorageFileName(value: string): string {
+  return value
+    .trim()
+    .replace(/[^A-Za-z0-9_.-]/g, "_")
+    .replace(/^_+/, "")
+    .slice(0, 120) || "problem-report.txt";
 }
 
 async function maybeCreateGithubIssue(title: string | undefined, body: string, reportId: string) {

--- a/supabase/migrations/20260625174524_add_impulse_problem_report_log_storage.sql
+++ b/supabase/migrations/20260625174524_add_impulse_problem_report_log_storage.sql
@@ -1,0 +1,25 @@
+insert into storage.buckets (
+  id,
+  name,
+  public,
+  file_size_limit,
+  allowed_mime_types
+)
+values (
+  'impulse-problem-report-logs',
+  'impulse-problem-report-logs',
+  false,
+  5000000,
+  array['text/plain']
+)
+on conflict (id) do update
+set
+  public = false,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types,
+  updated_at = now();
+
+alter table public.impulse_problem_reports
+  add column if not exists log_storage_bucket text,
+  add column if not exists log_storage_path text,
+  add column if not exists log_storage_size_bytes integer not null default 0;


### PR DESCRIPTION
## Summary

- Enable persistent problem-report diagnostics for preview release builds with `IMPULSE_REPORT_DIAGNOSTICS_ENABLED`.
- Store each new Supabase problem report as a private `.txt` object in `impulse-problem-report-logs` and persist the Storage path on the report row.
- Add the Supabase migration plus architecture/performance notes for the preview logging contract.

## Root Cause

`1.0.0.68-preview` is built as `release`, so `BuildConfig.DEBUG=false`. The app still used that debug flag to gate persistent logs and the recent logcat snapshot, leaving the log toggle unavailable for preview users and preventing the daily log file from being written.

The backend also stored report text in database columns only; it did not create a Storage object for the attached report/log file.

## Validation

- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:assembleDebug`
- `./gradlew :app:generateReleaseBuildConfig -PappVersionName=1.0.0.69-preview -PappVersionCode=70`
- Confirmed generated release preview BuildConfig has `DEBUG=false`, `BUILD_TYPE="release"`, `VERSION_NAME="1.0.0.69-preview"`, and `IMPULSE_REPORT_DIAGNOSTICS_ENABLED=true`.
- `git diff --check --cached`
- Supabase Edge Function was deployed/tested before opening this PR against project `eymyarugcfcwkezqjiba`: test request returned `HTTP 200`, `logStorageError=null`, and created `2026-06-25/42cc5325-56e9-4936-a3ed-98457ceaf6d0/cluster-events-20260625.txt`.
