### PR TITLE
feat: toque duplo/longo + seletor de apps nos botões personalizados do volante

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/DisplayAppLauncher.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/DisplayAppLauncher.kt
@@ -7486,6 +7486,26 @@ object DisplayAppLauncher {
         return getTopPackageOnDisplay(displayId) != null
     }
 
+    // Long-press do volante: a config da OEM SEMPRE abre. Pollamos o topo do display 0 ate ela
+    // aparecer (com.beantechs.settings) e entao executamos onConfigForeground (tipicamente um
+    // globalBack pra fecha-la sem flash). Se nao aparecer em ~3s, chama onGaveUp (fallback).
+    fun runWhenOemSteeringConfigForeground(
+        reason: String,
+        onConfigForeground: Runnable,
+        onGaveUp: Runnable?
+    ) {
+        scope.launch {
+            repeat(20) {
+                if (getTopPackageOnDisplay(0) == "com.beantechs.settings") {
+                    onConfigForeground.run()
+                    return@launch
+                }
+                delay(150)
+            }
+            onGaveUp?.run()
+        }
+    }
+
     fun getTopPackageOnDisplay(displayId: Int): String? {
         try {
             val stackList = getStackList()

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -576,6 +576,8 @@ public class ServiceManager {
                         switch (keyEvent.getKeyCode()) {
                             case 517: onSteeringCustomShortPress(1); break;   // botao 1 curto
                             case 1031: onSteeringCustomShortPress(2); break;  // botao 2 curto
+                            case 518: onSteeringCustomLongPress(1); break;    // botao 1 longo
+                            case 1032: onSteeringCustomLongPress(2); break;   // botao 2 longo
                         }
                     }
                     if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_CUSTOM_MENU.getKey(), false)) {
@@ -807,9 +809,9 @@ public class ServiceManager {
 
     public void ensureSteeringWheelButtonIntegration() {
         if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_STEERING_WHEEL_CUSTOM_BUTTONS.getKey(), false)) {
-            // habilita o botao se o toque CURTO ou DUPLO tiver acao configurada
-            boolean button1Used = steeringActionConfigured(1, "SHORT") || steeringActionConfigured(1, "DOUBLE");
-            boolean button2Used = steeringActionConfigured(2, "SHORT") || steeringActionConfigured(2, "DOUBLE");
+            // habilita o botao se o toque CURTO, DUPLO ou LONGO tiver acao configurada
+            boolean button1Used = steeringActionConfigured(1, "SHORT") || steeringActionConfigured(1, "DOUBLE") || steeringActionConfigured(1, "LONG");
+            boolean button2Used = steeringActionConfigured(2, "SHORT") || steeringActionConfigured(2, "DOUBLE") || steeringActionConfigured(2, "LONG");
             Log.w(TAG, "Ensuring steering wheel button integration. Button 1 used: " + button1Used + ", Button 2 used: " + button2Used);
             if (button1Used) {
                 enableSteeringWheelButton1Integration();
@@ -839,9 +841,11 @@ public class ServiceManager {
         SharedPreferencesKeys key;
         if (button == 1) {
             key = tapType.equals("DOUBLE") ? SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_1_ACTION_DOUBLE
+                    : tapType.equals("LONG") ? SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_1_ACTION_LONG
                     : SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_1_ACTION;
         } else {
             key = tapType.equals("DOUBLE") ? SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_2_ACTION_DOUBLE
+                    : tapType.equals("LONG") ? SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_2_ACTION_LONG
                     : SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_2_ACTION;
         }
         return sharedPreferences.getString(key.getKey(), SteeringWheelCustomActionType.DEFAULT.getKey());
@@ -850,9 +854,11 @@ public class ServiceManager {
     private String steeringOpenAppPackageKey(int button, String tapType) {
         if (button == 1) {
             return (tapType.equals("DOUBLE") ? SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_1_DOUBLE
+                    : tapType.equals("LONG") ? SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_1_LONG
                     : SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_1).getKey();
         }
         return (tapType.equals("DOUBLE") ? SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_2_DOUBLE
+                : tapType.equals("LONG") ? SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_2_LONG
                 : SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_2).getKey();
     }
 
@@ -891,6 +897,34 @@ public class ServiceManager {
             };
             steeringPendingSingle[idx] = r;
             backgroundHandler.postDelayed(r, STEERING_DOUBLE_WINDOW_MS);
+        }
+    }
+
+    // Toque longo. A config do volante da OEM SEMPRE abre no long-press e nao da pra cancelar o
+    // evento (so via Frida). Estrategia: pollar ate a config vir ao foco e entao fecha-la com um
+    // BACK in-process (AccessibilityService.globalBack), cortando o tempo visivel da tela.
+    private void onSteeringCustomLongPress(int button) {
+        if (!steeringActionConfigured(button, "LONG")) return; // sem acao de longo -> deixa a config do OEM
+        final String actionKey = steeringActionKey(button, "LONG");
+        final boolean isOpenApp =
+                SteeringWheelCustomActionType.Companion.fromKey(actionKey) == SteeringWheelCustomActionType.OPEN_APP;
+        final Runnable action = () -> handleSteeringWheelCustomButton(actionKey, button, "LONG");
+        final String reason = "STEER_LONG_b" + button;
+        if (isOpenApp) {
+            // OPEN_APP: quando a config vier ao foco, fecha (BACK) e reabre o app POR CIMA. Se a
+            // config nao aparecer (gaveup), abre o app mesmo assim.
+            Runnable onCfg = () -> {
+                br.com.redesurftank.havalshisuku.services.AccessibilityService.globalBack();
+                backgroundHandler.postDelayed(action, 350);
+            };
+            DisplayAppLauncher.INSTANCE.runWhenOemSteeringConfigForeground(reason, onCfg, action);
+        } else {
+            // Toggle: roda a acao JA (invisivel) e fecha a config quando vier ao foco.
+            backgroundHandler.post(action);
+            DisplayAppLauncher.INSTANCE.runWhenOemSteeringConfigForeground(
+                    reason,
+                    () -> br.com.redesurftank.havalshisuku.services.AccessibilityService.globalBack(),
+                    null);
         }
     }
 

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -574,8 +574,8 @@ public class ServiceManager {
                     }
                     if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_STEERING_WHEEL_CUSTOM_BUTTONS.getKey(), false)) {
                         switch (keyEvent.getKeyCode()) {
-                            case 517: handleSteeringWheelCustomButton(sharedPreferences.getString(SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_1_ACTION.getKey(), SteeringWheelCustomActionType.DEFAULT.name()), 1); break;
-                            case 1031: handleSteeringWheelCustomButton(sharedPreferences.getString(SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_2_ACTION.getKey(), SteeringWheelCustomActionType.DEFAULT.name()), 2); break;
+                            case 517: onSteeringCustomShortPress(1); break;   // botao 1 curto
+                            case 1031: onSteeringCustomShortPress(2); break;  // botao 2 curto
                         }
                     }
                     if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_CUSTOM_MENU.getKey(), false)) {
@@ -807,18 +807,19 @@ public class ServiceManager {
 
     public void ensureSteeringWheelButtonIntegration() {
         if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_STEERING_WHEEL_CUSTOM_BUTTONS.getKey(), false)) {
-            String button1Action = sharedPreferences.getString(SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_1_ACTION.getKey(), SteeringWheelCustomActionType.DEFAULT.getKey());
-            String button2Action = sharedPreferences.getString(SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_2_ACTION.getKey(), SteeringWheelCustomActionType.DEFAULT.getKey());
-            Log.w(TAG, "Ensuring steering wheel button integration. Button 1 action: " + button1Action + ", Button 2 action: " + button2Action);
-            if (button1Action.equals(SteeringWheelCustomActionType.DEFAULT.getKey())) {
-                disableNativeSteeringWheelButton1();
-            } else {
+            // habilita o botao se o toque CURTO ou DUPLO tiver acao configurada
+            boolean button1Used = steeringActionConfigured(1, "SHORT") || steeringActionConfigured(1, "DOUBLE");
+            boolean button2Used = steeringActionConfigured(2, "SHORT") || steeringActionConfigured(2, "DOUBLE");
+            Log.w(TAG, "Ensuring steering wheel button integration. Button 1 used: " + button1Used + ", Button 2 used: " + button2Used);
+            if (button1Used) {
                 enableSteeringWheelButton1Integration();
-            }
-            if (button2Action.equals(SteeringWheelCustomActionType.DEFAULT.getKey())) {
-                disableNativeSteeringWheelButton2();
             } else {
+                disableNativeSteeringWheelButton1();
+            }
+            if (button2Used) {
                 enableSteeringWheelButton2Integration();
+            } else {
+                disableNativeSteeringWheelButton2();
             }
         } else {
             Log.w(TAG, "Steering wheel button integration disabled, restoring native functions");
@@ -828,7 +829,72 @@ public class ServiceManager {
 
     }
 
-    private void handleSteeringWheelCustomButton(String string, int button) {
+    // ===== Toques nos botoes personalizados do volante: curto / duplo =====
+    private static final long STEERING_DOUBLE_WINDOW_MS = 500L;    // janela pra detectar o 2o toque (botao fisico: mais folgado que touchscreen)
+    private static final long STEERING_PRESS_DEBOUNCE_MS = 120L;   // ignora repique do mesmo toque
+    private final Runnable[] steeringPendingSingle = new Runnable[2];
+    private final long[] steeringLastPressAtMs = {0L, 0L};
+
+    private String steeringActionKey(int button, String tapType) {
+        SharedPreferencesKeys key;
+        if (button == 1) {
+            key = tapType.equals("DOUBLE") ? SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_1_ACTION_DOUBLE
+                    : SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_1_ACTION;
+        } else {
+            key = tapType.equals("DOUBLE") ? SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_2_ACTION_DOUBLE
+                    : SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_2_ACTION;
+        }
+        return sharedPreferences.getString(key.getKey(), SteeringWheelCustomActionType.DEFAULT.getKey());
+    }
+
+    private String steeringOpenAppPackageKey(int button, String tapType) {
+        if (button == 1) {
+            return (tapType.equals("DOUBLE") ? SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_1_DOUBLE
+                    : SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_1).getKey();
+        }
+        return (tapType.equals("DOUBLE") ? SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_2_DOUBLE
+                : SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_2).getKey();
+    }
+
+    private boolean steeringActionConfigured(int button, String tapType) {
+        String k = steeringActionKey(button, tapType);
+        return k != null
+                && !k.equals(SteeringWheelCustomActionType.DEFAULT.getKey())
+                && !k.equals(SteeringWheelCustomActionType.DEFAULT.name());
+    }
+
+    // Toque curto. Se houver acao de DUPLO configurada, espera STEERING_DOUBLE_WINDOW_MS pra ver se
+    // vem um 2o toque (senao dispara o curto na hora, sem atraso). 2o toque na janela vira DUPLO.
+    private void onSteeringCustomShortPress(int button) {
+        final int idx = button - 1;
+        long now = System.currentTimeMillis();
+        synchronized (steeringPendingSingle) {
+            if (now - steeringLastPressAtMs[idx] < STEERING_PRESS_DEBOUNCE_MS) {
+                return; // repique do mesmo toque
+            }
+            steeringLastPressAtMs[idx] = now;
+            if (steeringPendingSingle[idx] != null) {
+                backgroundHandler.removeCallbacks(steeringPendingSingle[idx]);
+                steeringPendingSingle[idx] = null;
+                handleSteeringWheelCustomButton(steeringActionKey(button, "DOUBLE"), button, "DOUBLE");
+                return;
+            }
+            if (!steeringActionConfigured(button, "DOUBLE")) {
+                handleSteeringWheelCustomButton(steeringActionKey(button, "SHORT"), button, "SHORT");
+                return;
+            }
+            Runnable r = () -> {
+                synchronized (steeringPendingSingle) {
+                    steeringPendingSingle[idx] = null;
+                }
+                handleSteeringWheelCustomButton(steeringActionKey(button, "SHORT"), button, "SHORT");
+            };
+            steeringPendingSingle[idx] = r;
+            backgroundHandler.postDelayed(r, STEERING_DOUBLE_WINDOW_MS);
+        }
+    }
+
+    private void handleSteeringWheelCustomButton(String string, int button, String tapType) {
         SteeringWheelCustomActionType action = SteeringWheelCustomActionType.Companion.fromKey(string);
         if (action == null || action == SteeringWheelCustomActionType.DEFAULT) {
             return;
@@ -891,7 +957,7 @@ public class ServiceManager {
                 }
                 break;
             case OPEN_APP:
-                String packageName = sharedPreferences.getString(button == 1 ? SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_1.getKey() : SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_2.getKey(), "");
+                String packageName = sharedPreferences.getString(steeringOpenAppPackageKey(button, tapType), "");
                 if (!packageName.isEmpty()) {
                     Intent launchIntent = App.getContext().getPackageManager().getLaunchIntentForPackage(packageName);
                     if (launchIntent != null) {

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -154,6 +154,22 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
             "steeringWheelOpenAppPackageButton2Double",
             "Pacote do app para o botão 2 do volante (toque duplo)"
     ),
+    STEERING_WHEEL_CUSTOM_BUTON_1_ACTION_LONG(
+            "steeringWheelCustomButon1ActionLong",
+            "Ação do botão personalizado 1 do volante (toque longo)"
+    ),
+    STEERING_WHEEL_CUSTOM_BUTON_2_ACTION_LONG(
+            "steeringWheelCustomButon2ActionLong",
+            "Ação do botão personalizado 2 do volante (toque longo)"
+    ),
+    STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_1_LONG(
+            "steeringWheelOpenAppPackageButton1Long",
+            "Pacote do app para o botão 1 do volante (toque longo)"
+    ),
+    STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_2_LONG(
+            "steeringWheelOpenAppPackageButton2Long",
+            "Pacote do app para o botão 2 do volante (toque longo)"
+    ),
     STEERING_WHEEL_CLIMATE_COMMAND_BUTTON_1(
             "steeringWheelClimateCommandButton1",
             "Comando do ar-condicionado para o botão personalizado 1 do volante"

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -138,6 +138,22 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
             "steeringWheelOpenAppPackageButton2",
             "Pacote do aplicativo para o botão personalizado 2 do volante"
     ),
+    STEERING_WHEEL_CUSTOM_BUTON_1_ACTION_DOUBLE(
+            "steeringWheelCustomButon1ActionDouble",
+            "Ação do botão personalizado 1 do volante (toque duplo)"
+    ),
+    STEERING_WHEEL_CUSTOM_BUTON_2_ACTION_DOUBLE(
+            "steeringWheelCustomButon2ActionDouble",
+            "Ação do botão personalizado 2 do volante (toque duplo)"
+    ),
+    STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_1_DOUBLE(
+            "steeringWheelOpenAppPackageButton1Double",
+            "Pacote do app para o botão 1 do volante (toque duplo)"
+    ),
+    STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_2_DOUBLE(
+            "steeringWheelOpenAppPackageButton2Double",
+            "Pacote do app para o botão 2 do volante (toque duplo)"
+    ),
     STEERING_WHEEL_CLIMATE_COMMAND_BUTTON_1(
             "steeringWheelClimateCommandButton1",
             "Comando do ar-condicionado para o botão personalizado 1 do volante"

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/services/AccessibilityService.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/services/AccessibilityService.java
@@ -10,6 +10,32 @@ public class AccessibilityService extends android.accessibilityservice.Accessibi
 
     private static final String TAG = "AccessibilityService";
 
+    private static volatile AccessibilityService instance;
+
+    @Override
+    public void onServiceConnected() {
+        super.onServiceConnected();
+        instance = this;
+    }
+
+    @Override
+    public void onDestroy() {
+        if (instance == this) instance = null;
+        super.onDestroy();
+    }
+
+    // BACK global IN-PROCESS (instantaneo) — bem mais rapido que spawnar "input keyevent 4"
+    // via Shizuku (~300ms). Usado para fechar o menu de config do volante da OEM sem flash.
+    public static boolean globalBack() {
+        AccessibilityService s = instance;
+        if (s == null) return false;
+        try {
+            return s.performGlobalAction(GLOBAL_ACTION_BACK);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     @Override
     public void onAccessibilityEvent(AccessibilityEvent event) {
         if (event.getEventType() == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/AppSelectorField.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/AppSelectorField.kt
@@ -1,0 +1,137 @@
+package br.com.redesurftank.havalshisuku.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Apps
+import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import br.com.redesurftank.havalshisuku.managers.DisplayAppLauncher
+import coil.compose.AsyncImage
+
+/**
+ * Campo clicável que mostra o app escolhido (ícone + nome) e, ao tocar, abre o mesmo
+ * [AppPickerDialog] da aba "Telas" para escolher um app de uma lista (com busca, apps
+ * pré-definidos e entrada MANUAL de pacote). O valor entregue por [onPackageSelected]
+ * é sempre o packageName (String), compatível com as prefs já existentes.
+ */
+@Composable
+fun AppSelectorField(
+        packageName: String,
+        onPackageSelected: (String) -> Unit,
+        label: String = "App a abrir",
+) {
+        val context = LocalContext.current
+        var showPicker by remember { mutableStateOf(false) }
+
+        // Resolve nome/ícone do app já escolhido (fallback p/ pacote vazio ou inválido/desinstalado).
+        val resolved =
+                remember(packageName) {
+                        if (packageName.isBlank()) null
+                        else
+                                try {
+                                        DisplayAppLauncher.resolveAppInfo(context, packageName)
+                                } catch (e: Exception) {
+                                        null
+                                }
+                }
+
+        Column {
+                Text(label, color = Color(0xFFB0B8C4), fontSize = 14.sp)
+                Row(
+                        modifier =
+                                Modifier.fillMaxWidth()
+                                        .padding(top = 4.dp)
+                                        .background(
+                                                Color(0xFF2A2F37),
+                                                RoundedCornerShape(6.dp)
+                                        )
+                                        .clickable { showPicker = true }
+                                        .padding(horizontal = 12.dp, vertical = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                        if (resolved?.icon != null) {
+                                AsyncImage(
+                                        model = resolved.icon,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(28.dp)
+                                )
+                        } else {
+                                Icon(
+                                        Icons.Default.Apps,
+                                        contentDescription = null,
+                                        tint = Color(0xFFB0B8C4),
+                                        modifier = Modifier.size(28.dp)
+                                )
+                        }
+                        Column(modifier = Modifier.weight(1f)) {
+                                val title =
+                                        when {
+                                                resolved != null && resolved.label.isNotBlank() ->
+                                                        resolved.label
+                                                packageName.isNotBlank() -> packageName
+                                                else -> "Selecionar app..."
+                                        }
+                                Text(
+                                        text = title,
+                                        color =
+                                                if (packageName.isBlank()) Color(0xFF8A93A0)
+                                                else Color.White,
+                                        fontSize = 15.sp,
+                                        fontWeight = FontWeight.Medium,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                )
+                                if (resolved != null &&
+                                                resolved.label.isNotBlank() &&
+                                                packageName.isNotBlank()
+                                ) {
+                                        Text(
+                                                text = packageName,
+                                                color = Color(0xFF6F7884),
+                                                fontSize = 11.sp,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis
+                                        )
+                                }
+                        }
+                        Icon(
+                                Icons.Default.KeyboardArrowRight,
+                                contentDescription = null,
+                                tint = Color(0xFFB0B8C4)
+                        )
+                }
+        }
+
+        if (showPicker) {
+                AppPickerDialog(
+                        onDismiss = { showPicker = false },
+                        onAppSelected = {
+                                onPackageSelected(it.packageName)
+                                showPicker = false
+                        }
+                )
+        }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -1606,6 +1606,35 @@ fun BasicSettingsTab() {
                                                                 )
                                                         }
 
+                                                        var steeringWheelButton1ActionLong by remember {
+                                                                mutableStateOf(
+                                                                        prefs.getString(
+                                                                                SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_1_ACTION_LONG.key,
+                                                                                SteeringWheelCustomActionType.DEFAULT.key
+                                                                        ) ?: SteeringWheelCustomActionType.DEFAULT.key
+                                                                )
+                                                        }
+                                                        var steeringWheelButton2ActionLong by remember {
+                                                                mutableStateOf(
+                                                                        prefs.getString(
+                                                                                SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_2_ACTION_LONG.key,
+                                                                                SteeringWheelCustomActionType.DEFAULT.key
+                                                                        ) ?: SteeringWheelCustomActionType.DEFAULT.key
+                                                                )
+                                                        }
+                                                        var steeringWheelButton1PackageLong by remember {
+                                                                mutableStateOf(
+                                                                        prefs.getString(SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_1_LONG.key, "")
+                                                                                ?: ""
+                                                                )
+                                                        }
+                                                        var steeringWheelButton2PackageLong by remember {
+                                                                mutableStateOf(
+                                                                        prefs.getString(SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_2_LONG.key, "")
+                                                                                ?: ""
+                                                                )
+                                                        }
+
                                                         Column(
                                                                 verticalArrangement =
                                                                         Arrangement.spacedBy(12.dp)
@@ -2003,6 +2032,51 @@ fun BasicSettingsTab() {
                                                                                 steeringWheelButton2PackageDouble = newPkg
                                                                                 prefs.edit {
                                                                                         putString(SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_2_DOUBLE.key, newPkg)
+                                                                                }
+                                                                        }
+                                                                )
+                                                                HorizontalDivider(
+                                                                        color = Color(0xFF3A3F47),
+                                                                        thickness = 1.dp
+                                                                )
+                                                                Text(
+                                                                        "Toque longo",
+                                                                        color = Color.White,
+                                                                        fontSize = 16.sp
+                                                                )
+                                                                SteeringActionPicker(
+                                                                        label = "Botão 1 (toque longo)",
+                                                                        actionKey = steeringWheelButton1ActionLong,
+                                                                        packageName = steeringWheelButton1PackageLong,
+                                                                        onActionSelected = { newKey ->
+                                                                                steeringWheelButton1ActionLong = newKey
+                                                                                prefs.edit {
+                                                                                        putString(SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_1_ACTION_LONG.key, newKey)
+                                                                                }
+                                                                                ServiceManager.getInstance().ensureSteeringWheelButtonIntegration()
+                                                                        },
+                                                                        onPackageChanged = { newPkg ->
+                                                                                steeringWheelButton1PackageLong = newPkg
+                                                                                prefs.edit {
+                                                                                        putString(SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_1_LONG.key, newPkg)
+                                                                                }
+                                                                        }
+                                                                )
+                                                                SteeringActionPicker(
+                                                                        label = "Botão 2 (toque longo)",
+                                                                        actionKey = steeringWheelButton2ActionLong,
+                                                                        packageName = steeringWheelButton2PackageLong,
+                                                                        onActionSelected = { newKey ->
+                                                                                steeringWheelButton2ActionLong = newKey
+                                                                                prefs.edit {
+                                                                                        putString(SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_2_ACTION_LONG.key, newKey)
+                                                                                }
+                                                                                ServiceManager.getInstance().ensureSteeringWheelButtonIntegration()
+                                                                        },
+                                                                        onPackageChanged = { newPkg ->
+                                                                                steeringWheelButton2PackageLong = newPkg
+                                                                                prefs.edit {
+                                                                                        putString(SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_2_LONG.key, newPkg)
                                                                                 }
                                                                         }
                                                                 )

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -1766,9 +1766,10 @@ fun BasicSettingsTab() {
                                                                                         .OPEN_APP
                                                                                         .key
                                                                 ) {
-                                                                        TextField(
-                                                                                value = steeringWheelButton1Package,
-                                                                                onValueChange = {
+                                                                        AppSelectorField(
+                                                                                packageName =
+                                                                                        steeringWheelButton1Package,
+                                                                                onPackageSelected = {
                                                                                         newPkg ->
                                                                                         steeringWheelButton1Package =
                                                                                                 newPkg
@@ -1780,38 +1781,7 @@ fun BasicSettingsTab() {
                                                                                                         newPkg
                                                                                                 )
                                                                                         }
-                                                                                },
-                                                                                label = {
-                                                                                        Text(
-                                                                                                "Pacote do App"
-                                                                                        )
-                                                                                },
-                                                                                colors =
-                                                                                        TextFieldDefaults
-                                                                                                .colors(
-                                                                                                        focusedContainerColor =
-                                                                                                                Color(
-                                                                                                                        0xFF2A2F37
-                                                                                                                ),
-                                                                                                        unfocusedContainerColor =
-                                                                                                                Color(
-                                                                                                                        0xFF2A2F37
-                                                                                                                ),
-                                                                                                        focusedTextColor =
-                                                                                                                Color.White,
-                                                                                                        unfocusedTextColor =
-                                                                                                                Color(
-                                                                                                                        0xFFB0B8C4
-                                                                                                                ),
-                                                                                                        focusedIndicatorColor =
-                                                                                                                Color(
-                                                                                                                        0xFF4A9EFF
-                                                                                                                ),
-                                                                                                        unfocusedIndicatorColor =
-                                                                                                                Color(
-                                                                                                                        0xFF3A3F47
-                                                                                                                )
-                                                                                                )
+                                                                                }
                                                                         )
                                                                 }
 
@@ -1942,9 +1912,10 @@ fun BasicSettingsTab() {
                                                                                         .OPEN_APP
                                                                                         .key
                                                                 ) {
-                                                                        TextField(
-                                                                                value = steeringWheelButton2Package,
-                                                                                onValueChange = {
+                                                                        AppSelectorField(
+                                                                                packageName =
+                                                                                        steeringWheelButton2Package,
+                                                                                onPackageSelected = {
                                                                                         newPkg ->
                                                                                         steeringWheelButton2Package =
                                                                                                 newPkg
@@ -1956,38 +1927,7 @@ fun BasicSettingsTab() {
                                                                                                         newPkg
                                                                                                 )
                                                                                         }
-                                                                                },
-                                                                                label = {
-                                                                                        Text(
-                                                                                                "Pacote do App"
-                                                                                        )
-                                                                                },
-                                                                                colors =
-                                                                                        TextFieldDefaults
-                                                                                                .colors(
-                                                                                                        focusedContainerColor =
-                                                                                                                Color(
-                                                                                                                        0xFF2A2F37
-                                                                                                                ),
-                                                                                                        unfocusedContainerColor =
-                                                                                                                Color(
-                                                                                                                        0xFF2A2F37
-                                                                                                                ),
-                                                                                                        focusedTextColor =
-                                                                                                                Color.White,
-                                                                                                        unfocusedTextColor =
-                                                                                                                Color(
-                                                                                                                        0xFFB0B8C4
-                                                                                                                ),
-                                                                                                        focusedIndicatorColor =
-                                                                                                                Color(
-                                                                                                                        0xFF4A9EFF
-                                                                                                                ),
-                                                                                                        unfocusedIndicatorColor =
-                                                                                                                Color(
-                                                                                                                        0xFF3A3F47
-                                                                                                                )
-                                                                                                )
+                                                                                }
                                                                         )
                                                                 }
                                                                 HorizontalDivider(
@@ -2537,18 +2477,9 @@ private fun SteeringActionPicker(
                 }
         }
         if (actionKey == SteeringWheelCustomActionType.OPEN_APP.key) {
-                TextField(
-                        value = packageName,
-                        onValueChange = { onPackageChanged(it) },
-                        label = { Text("Pacote do App") },
-                        colors = TextFieldDefaults.colors(
-                                focusedContainerColor = Color(0xFF2A2F37),
-                                unfocusedContainerColor = Color(0xFF2A2F37),
-                                focusedTextColor = Color.White,
-                                unfocusedTextColor = Color(0xFFB0B8C4),
-                                focusedIndicatorColor = Color(0xFF4A9EFF),
-                                unfocusedIndicatorColor = Color(0xFF3A3F47)
-                        )
+                AppSelectorField(
+                        packageName = packageName,
+                        onPackageSelected = onPackageChanged
                 )
         }
 }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -1577,6 +1577,35 @@ fun BasicSettingsTab() {
                                                                 mutableStateOf(false)
                                                         }
 
+                                                        var steeringWheelButton1ActionDouble by remember {
+                                                                mutableStateOf(
+                                                                        prefs.getString(
+                                                                                SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_1_ACTION_DOUBLE.key,
+                                                                                SteeringWheelCustomActionType.DEFAULT.key
+                                                                        ) ?: SteeringWheelCustomActionType.DEFAULT.key
+                                                                )
+                                                        }
+                                                        var steeringWheelButton2ActionDouble by remember {
+                                                                mutableStateOf(
+                                                                        prefs.getString(
+                                                                                SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_2_ACTION_DOUBLE.key,
+                                                                                SteeringWheelCustomActionType.DEFAULT.key
+                                                                        ) ?: SteeringWheelCustomActionType.DEFAULT.key
+                                                                )
+                                                        }
+                                                        var steeringWheelButton1PackageDouble by remember {
+                                                                mutableStateOf(
+                                                                        prefs.getString(SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_1_DOUBLE.key, "")
+                                                                                ?: ""
+                                                                )
+                                                        }
+                                                        var steeringWheelButton2PackageDouble by remember {
+                                                                mutableStateOf(
+                                                                        prefs.getString(SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_2_DOUBLE.key, "")
+                                                                                ?: ""
+                                                                )
+                                                        }
+
                                                         Column(
                                                                 verticalArrangement =
                                                                         Arrangement.spacedBy(12.dp)
@@ -1932,6 +1961,51 @@ fun BasicSettingsTab() {
                                                                                                 )
                                                                         )
                                                                 }
+                                                                HorizontalDivider(
+                                                                        color = Color(0xFF3A3F47),
+                                                                        thickness = 1.dp
+                                                                )
+                                                                Text(
+                                                                        "Toque duplo",
+                                                                        color = Color.White,
+                                                                        fontSize = 16.sp
+                                                                )
+                                                                SteeringActionPicker(
+                                                                        label = "Botão 1 (toque duplo)",
+                                                                        actionKey = steeringWheelButton1ActionDouble,
+                                                                        packageName = steeringWheelButton1PackageDouble,
+                                                                        onActionSelected = { newKey ->
+                                                                                steeringWheelButton1ActionDouble = newKey
+                                                                                prefs.edit {
+                                                                                        putString(SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_1_ACTION_DOUBLE.key, newKey)
+                                                                                }
+                                                                                ServiceManager.getInstance().ensureSteeringWheelButtonIntegration()
+                                                                        },
+                                                                        onPackageChanged = { newPkg ->
+                                                                                steeringWheelButton1PackageDouble = newPkg
+                                                                                prefs.edit {
+                                                                                        putString(SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_1_DOUBLE.key, newPkg)
+                                                                                }
+                                                                        }
+                                                                )
+                                                                SteeringActionPicker(
+                                                                        label = "Botão 2 (toque duplo)",
+                                                                        actionKey = steeringWheelButton2ActionDouble,
+                                                                        packageName = steeringWheelButton2PackageDouble,
+                                                                        onActionSelected = { newKey ->
+                                                                                steeringWheelButton2ActionDouble = newKey
+                                                                                prefs.edit {
+                                                                                        putString(SharedPreferencesKeys.STEERING_WHEEL_CUSTOM_BUTON_2_ACTION_DOUBLE.key, newKey)
+                                                                                }
+                                                                                ServiceManager.getInstance().ensureSteeringWheelButtonIntegration()
+                                                                        },
+                                                                        onPackageChanged = { newPkg ->
+                                                                                steeringWheelButton2PackageDouble = newPkg
+                                                                                prefs.edit {
+                                                                                        putString(SharedPreferencesKeys.STEERING_WHEEL_OPEN_APP_PACKAGE_BUTTON_2_DOUBLE.key, newPkg)
+                                                                                }
+                                                                        }
+                                                                )
                                                         }
                                                 }
                                         } else null
@@ -2343,6 +2417,65 @@ fun BasicSettingsTab() {
                         dialog.setOnDismissListener { showEndPicker = false }
                         dialog.show()
                 }
+        }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SteeringActionPicker(
+        label: String,
+        actionKey: String,
+        packageName: String,
+        onActionSelected: (String) -> Unit,
+        onPackageChanged: (String) -> Unit,
+) {
+        var expanded by remember { mutableStateOf(false) }
+        Text(label, color = Color(0xFFB0B8C4), fontSize = 14.sp)
+        ExposedDropdownMenuBox(
+                expanded = expanded,
+                onExpandedChange = { expanded = !expanded }
+        ) {
+                TextField(
+                        value = SteeringWheelCustomActionType.entries
+                                .find { it.key == actionKey }?.description ?: "",
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Tipo de Ação") },
+                        trailingIcon = {
+                                ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                        },
+                        colors = ExposedDropdownMenuDefaults.textFieldColors(),
+                        modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                )
+                ExposedDropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false }
+                ) {
+                        SteeringWheelCustomActionType.entries.forEach { type ->
+                                DropdownMenuItem(
+                                        text = { Text(type.description) },
+                                        onClick = {
+                                                onActionSelected(type.key)
+                                                expanded = false
+                                        }
+                                )
+                        }
+                }
+        }
+        if (actionKey == SteeringWheelCustomActionType.OPEN_APP.key) {
+                TextField(
+                        value = packageName,
+                        onValueChange = { onPackageChanged(it) },
+                        label = { Text("Pacote do App") },
+                        colors = TextFieldDefaults.colors(
+                                focusedContainerColor = Color(0xFF2A2F37),
+                                unfocusedContainerColor = Color(0xFF2A2F37),
+                                focusedTextColor = Color.White,
+                                unfocusedTextColor = Color(0xFFB0B8C4),
+                                focusedIndicatorColor = Color(0xFF4A9EFF),
+                                unfocusedIndicatorColor = Color(0xFF3A3F47)
+                        )
+                )
         }
 }
 


### PR DESCRIPTION
Hoje os botões personalizados do volante disparam uma ação só no toque curto.
Este PR adiciona toque **DUPLO** e **LONGO** a cada botão (1 e 2), cada um
mapeável para a mesma lista de ações (`SteeringWheelCustomActionType`),
incluindo abrir apps diferentes por tipo de toque.

## Dois commits separados (de propósito)
Pra facilitar caso você queira implementar só o duplo:
- **Commit 1 — toque duplo:** auto-suficiente, só o duplo.
- **Commit 2 — toque longo:** só o longo (depende do commit 1).

Se quiser **só o duplo**, é só dropar o commit 2 antes de mergear.

## Comportamento
- **Curto:** mantém o atual. Sem latência se não houver duplo configurado;
  se houver, espera **500ms** pra detectar o 2º toque (debounce de 120ms p/ repique).
- **Duplo:** 2 toques curtos dentro de 500ms.
- **Longo:** o OEM **sempre** abre a tela de config do volante no longo
  (hardcoded; não dá pra cancelar o evento sem Frida). Então pollamos o topo do
  display 0 até a config (`com.beantechs.settings`) vir ao foco e a fechamos com
  um BACK in-process (`AccessibilityService.globalBack`), cortando o tempo
  visível da tela. Se a ação for "abrir app", o app sobe por cima da config; se
  for um toggle, a ação roda e a config é fechada.

Keycodes (capturados no carro): botão 1 curto=517/longo=518;
botão 2 curto=1031/longo=1032; duplo = dois curtos.

## Mudanças
- **SharedPreferencesKeys:** +8 prefs (ação + pacote de app, para duplo e longo, por botão).
- **ServiceManager:** detecção de duplo (`onSteeringCustomShortPress`) e longo
  (`onSteeringCustomLongPress` com poll-close); `handleSteeringWheelCustomButton`
  recebe o `tapType`; `ensureSteeringWheelButtonIntegration` habilita o botão se
  qualquer toque (curto/duplo/longo) estiver configurado.
- **AccessibilityService:** `globalBack()` in-process (commit do longo).
- **DisplayAppLauncher:** `runWhenOemSteeringConfigForeground` (poll 20×150ms, commit do longo).
- **BasicSettingsScreen:** seções "Toque duplo" e "Toque longo" (composable `SteeringActionPicker` reutilizável).

Rebaseado na `preview` atual. Testado no carro real (Haval H6 PHEV).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
