### PR TITLE
feat: desligar Bluetooth/Hotspot ao recolher retrovisores + corrige restauração ao ligar

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -3,6 +3,7 @@ package br.com.redesurftank.havalshisuku.managers;
 import android.annotation.SuppressLint;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothManager;
+import android.net.wifi.WifiManager;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
@@ -225,6 +226,16 @@ public class ServiceManager {
     private static long timeBootReceived;
     private long timeStartInitialization;
     private long timeInitialized;
+    // Estado real processado do carro (power-off vs power-on). Usado pelos receivers de BT/hotspot
+    // em vez do cache de driving_ready (que fica defasado no boot e fazia o BT ser re-desligado).
+    private volatile boolean carPoweredOff = false;
+    // Estado atual do hotspot (Wi-Fi AP), alimentado pelo receiver WIFI_AP_STATE_CHANGED e
+    // semeado no init via getWifiApState(); usado pra saber se o hotspot estava ligado ao recolher/desligar.
+    private volatile boolean wifiTetherEnabled = false;
+    private static final long RADIO_RESTORE_RETRY_MS = 4000L;
+    // 8 tentativas x 4s ≈ 28s: o tether (hotspot) pode demorar a subir no boot deste OEM.
+    // O loop para assim que o rádio liga, então tentativas extras são de graça p/ o BT (rápido).
+    private static final int RADIO_RESTORE_MAX_ATTEMPTS = 8;
     private CarInfo carInfo;
     private IIntelligentVehicleControlService controlService;
     private IVehicle vehicle;
@@ -746,8 +757,9 @@ public class ServiceManager {
                     if (intent.getAction().equals(BluetoothAdapter.ACTION_STATE_CHANGED) || intent.getAction().equals(BluetoothAdapter.ACTION_CONNECTION_STATE_CHANGED)) {
                         int state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR);
                         if (state == BluetoothAdapter.STATE_ON) {
-                            String drivingReady = getUpdatedData(CarConstants.CAR_BASIC_DRIVING_READY_STATE.getValue());
-                            if ((drivingReady.equals("-1") || drivingReady.equals("0")) && sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF.getKey(), false)) {
+                            // Só re-desliga se o carro está REALMENTE desligado (estado já processado),
+                            // não pelo cache de driving_ready (que fica defasado no boot e matava o BT).
+                            if (carPoweredOff && sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF.getKey(), false)) {
                                 disableBluetooth();
                             }
                         }
@@ -760,11 +772,15 @@ public class ServiceManager {
                 @Override
                 public void onReceive(Context context, Intent intent) {
                     if ("android.net.wifi.WIFI_AP_STATE_CHANGED".equals(intent.getAction())) {
-                        if (intent.getIntExtra("wifi_state", 0) == 13) {
-                            String drivingReady = getUpdatedData(CarConstants.CAR_BASIC_DRIVING_READY_STATE.getValue());
-                            if ((drivingReady.equals("-1") || drivingReady.equals("0")) && sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF.getKey(), false)) {
+                        int apState = intent.getIntExtra("wifi_state", 0);
+                        // 13 = WIFI_AP_STATE_ENABLED, 11 = WIFI_AP_STATE_DISABLED
+                        if (apState == 13) {
+                            wifiTetherEnabled = true;
+                            if (carPoweredOff && sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF.getKey(), false)) {
                                 disableWifiTether();
                             }
+                        } else if (apState == 11) {
+                            wifiTetherEnabled = false;
                         }
                     }
                 }
@@ -794,6 +810,9 @@ public class ServiceManager {
         }
         MainUiManager.getInstance().updateScreen();
         timeInitialized = SystemClock.uptimeMillis();
+        // Semeia o estado atual do hotspot (o receiver WIFI_AP só dispara em MUDANÇA; se já estava
+        // ligado antes do serviço subir, a flag ficaria falsa).
+        wifiTetherEnabled = currentWifiTetherState();
         Log.w(TAG, "Services initialized successfully");
         backgroundHandler.post(() -> {
             try {
@@ -1609,6 +1628,13 @@ public class ServiceManager {
                 if (closeSunRoofOnFoldMirror) {
                     closeSunRoof(true);
                 }
+                // Desligar BT/hotspot ao recolher retrovisores (salvam o estado p/ religar ao ligar o carro).
+                if (sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_FOLD_MIRROR.getKey(), false)) {
+                    shutdownBluetoothForRestore();
+                }
+                if (sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_FOLD_MIRROR.getKey(), false)) {
+                    shutdownWifiTetherForRestore();
+                }
             } else if (key.equals(CarConstants.CAR_BASIC_VEHICLE_SPEED.getValue())) {
                 float currentSpeed = Float.parseFloat(value);
                 boolean closeWindowOnSpeed = sharedPreferences.getBoolean(SharedPreferencesKeys.CLOSE_WINDOWS_ON_SPEED.getKey(), false);
@@ -1644,25 +1670,22 @@ public class ServiceManager {
                 }
             } else if (key.equals(CarConstants.CAR_BASIC_DRIVING_READY_STATE.getValue())) {
                 if ((value.equals("-1") || value.equals("0"))) {
-                    boolean disableBluetoothOnPowerOff = sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF.getKey(), false);
-                    boolean currentBluetoothState = currentBluetoothState();
-                    if (currentBluetoothState && disableBluetoothOnPowerOff) {
-                        sharedPreferences.edit().putBoolean(SharedPreferencesKeys.BLUETOOTH_STATE_ON_POWER_OFF.getKey(), true).apply();
-                        disableBluetooth();
+                    carPoweredOff = true;
+                    if (sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF.getKey(), false)) {
+                        shutdownBluetoothForRestore();
                     }
-                    boolean disableHotspotOnPowerOff = sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF.getKey(), false);
-                    if (disableHotspotOnPowerOff) {
-                        disableWifiTether();
+                    if (sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF.getKey(), false)) {
+                        shutdownWifiTetherForRestore();
                     }
                     if (isMaxAcActive) {
                         cancelMaxAcMode();
                     }
                 } else {
-                    boolean disableBluetoothOnPowerOff = sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF.getKey(), false);
-                    boolean bluetoothStateOnPowerOff = sharedPreferences.getBoolean(SharedPreferencesKeys.BLUETOOTH_STATE_ON_POWER_OFF.getKey(), false);
-                    if (disableBluetoothOnPowerOff && bluetoothStateOnPowerOff && !currentBluetoothState()) {
-                        enableBluetooth();
-                    }
+                    carPoweredOff = false;
+                    // Religa BT/hotspot que NÓS desligamos (por power-off OU ao recolher retrovisor),
+                    // com delay+retry: no power-on o adapter/serviços podem não estar prontos ainda.
+                    restoreBluetoothIfWasDisabled();
+                    restoreWifiTetherIfWasDisabled();
                     if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_MAX_AC_ON_UNLOCK.getKey(), false)) {
                         if (!isMaxAcActive) enableMaxAcOn();
                     }
@@ -1897,6 +1920,7 @@ public class ServiceManager {
     }
 
     public void disableWifiTether() {
+        if (connectivityManager == null) return;
         try {
             connectivityManager.stopTethering(0, "br.com.redesurftank.havalshisuku");
         } catch (NoSuchMethodError e) {
@@ -1913,6 +1937,7 @@ public class ServiceManager {
     }
 
     public void enableWifiTether() {
+        if (connectivityManager == null) return;
         try {
             ResultReceiver receiver = new ResultReceiver(new Handler(Looper.getMainLooper())) {
                 @Override
@@ -1927,6 +1952,89 @@ public class ServiceManager {
             connectivityManager.startTethering(0, receiver, false, "br.com.redesurftank.havalshisuku");
         } catch (Exception e) {
             Log.e(TAG, "Error enabling Wi-Fi", e);
+        }
+    }
+
+    // ---- BT/Hotspot: estado, desligamento com tracking e restauração com retry ----
+
+    private boolean currentWifiTetherState() {
+        try {
+            WifiManager wifiManager = (WifiManager) App.getContext().getSystemService(Context.WIFI_SERVICE);
+            if (wifiManager != null) {
+                Object r = wifiManager.getClass().getMethod("getWifiApState").invoke(wifiManager);
+                if (r instanceof Integer) {
+                    return ((Integer) r) == 13; // 13 = WIFI_AP_STATE_ENABLED
+                }
+            }
+        } catch (Throwable t) {
+            Log.e(TAG, "Error reading Wi-Fi AP state", t);
+        }
+        return wifiTetherEnabled;
+    }
+
+    // Desliga o BT salvando que estava ligado (p/ religar no próximo power-on). Não sobrescreve um
+    // "estava ligado" anterior com false (caso recolher-retrovisor + power-off no mesmo ciclo).
+    private void shutdownBluetoothForRestore() {
+        if (currentBluetoothState()) {
+            sharedPreferences.edit().putBoolean(SharedPreferencesKeys.BLUETOOTH_STATE_ON_POWER_OFF.getKey(), true).apply();
+            disableBluetooth();
+        }
+    }
+
+    private void shutdownWifiTetherForRestore() {
+        if (currentWifiTetherState()) {
+            sharedPreferences.edit().putBoolean(SharedPreferencesKeys.HOTSPOT_STATE_ON_POWER_OFF.getKey(), true).apply();
+            disableWifiTether();
+        }
+    }
+
+    private void restoreBluetoothIfWasDisabled() {
+        if (sharedPreferences.getBoolean(SharedPreferencesKeys.BLUETOOTH_STATE_ON_POWER_OFF.getKey(), false)) {
+            attemptRestoreBluetooth(0);
+        }
+    }
+
+    private void attemptRestoreBluetooth(int attempt) {
+        if (!sharedPreferences.getBoolean(SharedPreferencesKeys.BLUETOOTH_STATE_ON_POWER_OFF.getKey(), false)) {
+            return; // flag limpa por outra restauração
+        }
+        if (carPoweredOff) {
+            return; // carro desligou no meio: mantém a intenção p/ o próximo power-on
+        }
+        if (currentBluetoothState()) {
+            sharedPreferences.edit().putBoolean(SharedPreferencesKeys.BLUETOOTH_STATE_ON_POWER_OFF.getKey(), false).apply();
+            return; // já ligou: sucesso
+        }
+        enableBluetooth();
+        if (attempt + 1 < RADIO_RESTORE_MAX_ATTEMPTS) {
+            backgroundHandler.postDelayed(() -> attemptRestoreBluetooth(attempt + 1), RADIO_RESTORE_RETRY_MS);
+        } else {
+            sharedPreferences.edit().putBoolean(SharedPreferencesKeys.BLUETOOTH_STATE_ON_POWER_OFF.getKey(), false).apply();
+        }
+    }
+
+    private void restoreWifiTetherIfWasDisabled() {
+        if (sharedPreferences.getBoolean(SharedPreferencesKeys.HOTSPOT_STATE_ON_POWER_OFF.getKey(), false)) {
+            attemptRestoreWifiTether(0);
+        }
+    }
+
+    private void attemptRestoreWifiTether(int attempt) {
+        if (!sharedPreferences.getBoolean(SharedPreferencesKeys.HOTSPOT_STATE_ON_POWER_OFF.getKey(), false)) {
+            return;
+        }
+        if (carPoweredOff) {
+            return;
+        }
+        if (currentWifiTetherState()) {
+            sharedPreferences.edit().putBoolean(SharedPreferencesKeys.HOTSPOT_STATE_ON_POWER_OFF.getKey(), false).apply();
+            return;
+        }
+        enableWifiTether();
+        if (attempt + 1 < RADIO_RESTORE_MAX_ATTEMPTS) {
+            backgroundHandler.postDelayed(() -> attemptRestoreWifiTether(attempt + 1), RADIO_RESTORE_RETRY_MS);
+        } else {
+            sharedPreferences.edit().putBoolean(SharedPreferencesKeys.HOTSPOT_STATE_ON_POWER_OFF.getKey(), false).apply();
         }
     }
 

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -102,6 +102,18 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
             "bluetoothStateOnPowerOff",
             "Estado do Bluetooth ao desligar o veículo"
     ),
+    HOTSPOT_STATE_ON_POWER_OFF(
+            "hotspotStateOnPowerOff",
+            "Estado do ponto de acesso ao desligar o veículo"
+    ),
+    DISABLE_BLUETOOTH_ON_FOLD_MIRROR(
+            "disableBluetoothOnFoldMirror",
+            "Desativar Bluetooth ao recolher retrovisores"
+    ),
+    DISABLE_HOTSPOT_ON_FOLD_MIRROR(
+            "disableHotspotOnFoldMirror",
+            "Desativar ponto de acesso ao recolher retrovisores"
+    ),
     ENABLE_SEAT_VENTILATION_ON_AC_ON(
             "enableSeatVentilationOnAcOn",
             "Habilitar ventilação do banco do motorista ao ligar o ar-condicionado"

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -101,6 +101,22 @@ fun BasicSettingsTab() {
                         )
                 )
         }
+        var disableBluetoothOnFoldMirror by remember {
+                mutableStateOf(
+                        prefs.getBoolean(
+                                SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_FOLD_MIRROR.key,
+                                false
+                        )
+                )
+        }
+        var disableHotspotOnFoldMirror by remember {
+                mutableStateOf(
+                        prefs.getBoolean(
+                                SharedPreferencesKeys.DISABLE_HOTSPOT_ON_FOLD_MIRROR.key,
+                                false
+                        )
+                )
+        }
         var closeSunroofSunShadeOnCloseSunroof by remember {
                 mutableStateOf(
                         prefs.getBoolean(
@@ -563,6 +579,42 @@ fun BasicSettingsTab() {
                                                 putBoolean(
                                                         SharedPreferencesKeys
                                                                 .CLOSE_SUNROOF_ON_FOLD_MIRROR
+                                                                .key,
+                                                        it
+                                                )
+                                        }
+                                }
+                        ),
+                        SettingItem(
+                                title = "Desativar Bluetooth ao recolher retrovisores",
+                                description =
+                                        SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_FOLD_MIRROR
+                                                .description,
+                                checked = disableBluetoothOnFoldMirror,
+                                onCheckedChange = {
+                                        disableBluetoothOnFoldMirror = it
+                                        prefs.edit {
+                                                putBoolean(
+                                                        SharedPreferencesKeys
+                                                                .DISABLE_BLUETOOTH_ON_FOLD_MIRROR
+                                                                .key,
+                                                        it
+                                                )
+                                        }
+                                }
+                        ),
+                        SettingItem(
+                                title = "Desativar ponto de acesso ao recolher retrovisores",
+                                description =
+                                        SharedPreferencesKeys.DISABLE_HOTSPOT_ON_FOLD_MIRROR
+                                                .description,
+                                checked = disableHotspotOnFoldMirror,
+                                onCheckedChange = {
+                                        disableHotspotOnFoldMirror = it
+                                        prefs.edit {
+                                                putBoolean(
+                                                        SharedPreferencesKeys
+                                                                .DISABLE_HOTSPOT_ON_FOLD_MIRROR
                                                                 .key,
                                                         it
                                                 )

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -586,42 +586,6 @@ fun BasicSettingsTab() {
                                 }
                         ),
                         SettingItem(
-                                title = "Desativar Bluetooth ao recolher retrovisores",
-                                description =
-                                        SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_FOLD_MIRROR
-                                                .description,
-                                checked = disableBluetoothOnFoldMirror,
-                                onCheckedChange = {
-                                        disableBluetoothOnFoldMirror = it
-                                        prefs.edit {
-                                                putBoolean(
-                                                        SharedPreferencesKeys
-                                                                .DISABLE_BLUETOOTH_ON_FOLD_MIRROR
-                                                                .key,
-                                                        it
-                                                )
-                                        }
-                                }
-                        ),
-                        SettingItem(
-                                title = "Desativar ponto de acesso ao recolher retrovisores",
-                                description =
-                                        SharedPreferencesKeys.DISABLE_HOTSPOT_ON_FOLD_MIRROR
-                                                .description,
-                                checked = disableHotspotOnFoldMirror,
-                                onCheckedChange = {
-                                        disableHotspotOnFoldMirror = it
-                                        prefs.edit {
-                                                putBoolean(
-                                                        SharedPreferencesKeys
-                                                                .DISABLE_HOTSPOT_ON_FOLD_MIRROR
-                                                                .key,
-                                                        it
-                                                )
-                                        }
-                                }
-                        ),
-                        SettingItem(
                                 title = "Fechar cortina do teto solar",
                                 description =
                                         SharedPreferencesKeys
@@ -1555,6 +1519,60 @@ fun BasicSettingsTab() {
                                 }
                         ),
                         SettingItem(
+                                title = "Desligar ponto de acesso ao desligar",
+                                description =
+                                        SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF
+                                                .description,
+                                checked = disableHotspotOnPowerOff,
+                                onCheckedChange = {
+                                        disableHotspotOnPowerOff = it
+                                        prefs.edit {
+                                                putBoolean(
+                                                        SharedPreferencesKeys
+                                                                .DISABLE_HOTSPOT_ON_POWER_OFF
+                                                                .key,
+                                                        it
+                                                )
+                                        }
+                                }
+                        ),
+                        SettingItem(
+                                title = "Desativar Bluetooth ao recolher retrovisores",
+                                description =
+                                        SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_FOLD_MIRROR
+                                                .description,
+                                checked = disableBluetoothOnFoldMirror,
+                                onCheckedChange = {
+                                        disableBluetoothOnFoldMirror = it
+                                        prefs.edit {
+                                                putBoolean(
+                                                        SharedPreferencesKeys
+                                                                .DISABLE_BLUETOOTH_ON_FOLD_MIRROR
+                                                                .key,
+                                                        it
+                                                )
+                                        }
+                                }
+                        ),
+                        SettingItem(
+                                title = "Desativar ponto de acesso ao recolher retrovisores",
+                                description =
+                                        SharedPreferencesKeys.DISABLE_HOTSPOT_ON_FOLD_MIRROR
+                                                .description,
+                                checked = disableHotspotOnFoldMirror,
+                                onCheckedChange = {
+                                        disableHotspotOnFoldMirror = it
+                                        prefs.edit {
+                                                putBoolean(
+                                                        SharedPreferencesKeys
+                                                                .DISABLE_HOTSPOT_ON_FOLD_MIRROR
+                                                                .key,
+                                                        it
+                                                )
+                                        }
+                                }
+                        ),
+                        SettingItem(
                                 title = "Ativar Ambient Light BLE",
                                 description =
                                         "Exibe o recurso opcional para LEDs externos instalados pelo usuario",
@@ -1573,24 +1591,6 @@ fun BasicSettingsTab() {
                                                 AmbientLightService.startIfEnabled(context)
                                         } else {
                                                 AmbientLightService.stop(context)
-                                        }
-                                }
-                        ),
-                        SettingItem(
-                                title = "Desligar ponto de acesso ao desligar",
-                                description =
-                                        SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF
-                                                .description,
-                                checked = disableHotspotOnPowerOff,
-                                onCheckedChange = {
-                                        disableHotspotOnPowerOff = it
-                                        prefs.edit {
-                                                putBoolean(
-                                                        SharedPreferencesKeys
-                                                                .DISABLE_HOTSPOT_ON_POWER_OFF
-                                                                .key,
-                                                        it
-                                                )
                                         }
                                 }
                         ),


### PR DESCRIPTION
feat: desligar Bluetooth/Hotspot ao recolher retrovisores + corrige restauração ao ligar

## O que muda

Duas opções novas em Configurações (no grupo "ao recolher retrovisores", ao lado de fechar vidro/teto), **separadas** das de "ao desligar o veículo":

- **Desativar Bluetooth ao recolher retrovisores**
- **Desativar ponto de acesso ao recolher retrovisores**

Ambas desligam o rádio ao recolher os retrovisores (carro parado, marcha P — mesma guarda do fechamento de vidros) e **religam automaticamente ao ligar o carro**, mas só o que estava ligado.

## Correções de bug (afetam também a função "ao desligar o veículo" já existente)

Aproveitei pra corrigir dois bugs da restauração no power-on:

1. **Bluetooth não religava sozinho.** O `BroadcastReceiver` de `STATE_ON` re-desligava o BT logo no boot porque lia o cache defasado de `driving_ready` (que ainda reporta "desligado" enquanto o serviço sobe). Agora os receivers de BT e de `WIFI_AP_STATE_CHANGED` usam um flag `carPoweredOff` (estado realmente processado: `true` no power-off, `false` no power-on), em vez do cache. Além disso a restauração do BT no power-on roda com **delay + retry** (o adapter costuma não estar pronto no instante do power-on) e a flag de estado só é limpa após confirmar.

2. **Hotspot não restaurava.** A restauração nunca tinha sido implementada (`enableWifiTether()` não tinha call site e o estado anterior não era salvo). Agora salva o estado (`HOTSPOT_STATE_ON_POWER_OFF`, lendo `getWifiApState()` por reflection + tracking pelo receiver `WIFI_AP_STATE_CHANGED`) e religa no power-on com o mesmo retry.

## Como funciona o tracking

Um flag de estado por rádio (`BLUETOOTH_STATE_ON_POWER_OFF` / `HOTSPOT_STATE_ON_POWER_OFF`), marcado por **qualquer** gatilho (recolher retrovisor OU desligar o veículo) com a semântica "estava ligado, religar no próximo power-on". O power-on restaura lendo só esses flags, então cobre os dois gatilhos com um caminho único. Os helpers nunca sobrescrevem um "estava ligado" com `false` no mesmo ciclo (caso recolher + desligar aconteçam juntos).

## Prefs novas
`DISABLE_BLUETOOTH_ON_FOLD_MIRROR`, `DISABLE_HOTSPOT_ON_FOLD_MIRROR`, `HOTSPOT_STATE_ON_POWER_OFF`.

## Teste
- Recolher retrovisores com BT/hotspot ligados → desligam; ao ligar o carro → religam (só os que estavam ligados).
- Boot normal (carro ligado) → o BT que sobe sozinho não é mais morto.
- Recolher e depois desligar no mesmo ciclo → a intenção de religar persiste.

## Organização da UI (2º commit)

Os 4 toggles de rede ficam num bloco contíguo, Bluetooth e ponto de acesso lado a lado por gatilho: "Desligar bluetooth ao desligar" → "Desligar ponto de acesso ao desligar" → "Desativar Bluetooth ao recolher retrovisores" → "Desativar ponto de acesso ao recolher retrovisores". O "Ativar Ambient Light BLE" (que ficava entre os dois de power-off) passou pra depois do bloco. Está no commit separado `chore(ui)` — fácil de dropar se preferir manter a ordem atual.

---

Obs.: o PR tem 2 commits — (1) a correção da restauração de BT/hotspot ao ligar (vale mesmo sem a feature nova) + a feature dos toggles ao recolher retrovisor; (2) o agrupamento dos toggles na UI. Dá pra pegar só o (1) se quiser.
