### PR TITLE
feat(steering): dedicated CarPlay / Android Auto steering-wheel actions

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/DisplayAppLauncher.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/DisplayAppLauncher.kt
@@ -122,7 +122,9 @@ object DisplayAppLauncher {
     )
 
     private const val TAG = "DisplayAppLauncher"
-    private const val ANDROID_AUTO_PACKAGE = "com.ts.androidauto.app"
+    // Public so callers (e.g. ServiceManager's steering wheel handler) can target
+    // these without duplicating the literal package name.
+    const val ANDROID_AUTO_PACKAGE = "com.ts.androidauto.app"
     private const val ANDROID_AUTO_MEDIA_PACKAGE = "com.ts.androidauto"
     private const val ANDROID_AUTO_SERVICE_PACKAGE = "com.ts.androidauto.projectionservice"
     private const val ANDROID_AUTO_ACTIVITY = "com.ts.androidauto.app.display.AapActivity"
@@ -306,7 +308,7 @@ object DisplayAppLauncher {
         }
     }
 
-    private const val CARPLAY_PACKAGE = "com.ts.carplay.app"
+    const val CARPLAY_PACKAGE = "com.ts.carplay.app"
     private const val CARPLAY_ACTIVITY = "com.ts.carplay.app.ui.display.view.CarPlayDisplayActivity"
     private const val CARPLAY_HOST_PROCESS = "com.ts.carplay"
     private const val CARPLAY_HOST_SERVICE = "com.ts.carplay/.CarPlayService"
@@ -7080,6 +7082,14 @@ object DisplayAppLauncher {
         } catch (e: Exception) {
             Log.e(TAG, "Error launching $packageName", e)
         }
+    }
+
+    /**
+     * Fire-and-forget entry point for callers that can't use coroutines directly (e.g. Java,
+     * such as ServiceManager's steering wheel button handler).
+     */
+    fun launchAnyAppFromJava(context: Context, packageName: String, activityName: String? = null) {
+        scope.launch { launchAnyApp(context, packageName, activityName) }
     }
 
     /**

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -1027,17 +1027,29 @@ public class ServiceManager {
             case OPEN_APP:
                 String packageName = sharedPreferences.getString(steeringOpenAppPackageKey(button, tapType), "");
                 if (!packageName.isEmpty()) {
-                    Intent launchIntent = App.getContext().getPackageManager().getLaunchIntentForPackage(packageName);
-                    if (launchIntent != null) {
-                        launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        App.getContext().startActivity(launchIntent);
-                        Log.w(TAG, "Launching app: " + packageName);
-                        DisplayAppLauncher.INSTANCE.preserveCarPlayClusterContract("SERVICE_OPEN_APP_" + packageName);
-                        DisplayAppLauncher.INSTANCE.preserveAndroidAutoClusterContract("SERVICE_OPEN_APP_" + packageName);
-                    } else {
-                        Log.e(TAG, "App not found: " + packageName);
+                    String target = packageName.trim();
+                    String pkg = target;
+                    String activity = null;
+                    int slashIdx = target.indexOf('/');
+                    if (slashIdx >= 0) {
+                        pkg = target.substring(0, slashIdx);
+                        String cls = target.substring(slashIdx + 1);
+                        activity = cls.startsWith(".") ? pkg + cls : cls;
                     }
+                    // Delegates to DisplayAppLauncher, which resolves PREDEFINED_APPS (and
+                    // saved configs) automatically; an explicit "pacote/Activity" override
+                    // still works here for anything not covered by that list.
+                    Log.w(TAG, "Launching app via DisplayAppLauncher: " + pkg + (activity != null ? " (" + activity + ")" : ""));
+                    DisplayAppLauncher.INSTANCE.launchAnyAppFromJava(App.getContext(), pkg, activity);
                 }
+                break;
+            case OPEN_CARPLAY:
+                Log.w(TAG, "Launching CarPlay via DisplayAppLauncher");
+                DisplayAppLauncher.INSTANCE.launchAnyAppFromJava(App.getContext(), DisplayAppLauncher.CARPLAY_PACKAGE, null);
+                break;
+            case OPEN_ANDROID_AUTO:
+                Log.w(TAG, "Launching Android Auto via DisplayAppLauncher");
+                DisplayAppLauncher.INSTANCE.launchAnyAppFromJava(App.getContext(), DisplayAppLauncher.ANDROID_AUTO_PACKAGE, null);
                 break;
             case CLIMATE_COMMAND:
                 handleSteeringWheelClimateCommand(button);

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SteeringWheelCustomActionType.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SteeringWheelCustomActionType.kt
@@ -11,6 +11,8 @@ enum class SteeringWheelCustomActionType(val key: String, val description: Strin
     TOGGLE_ESP("toggle_esp", "Alternar controle de estabilidade (ESP)."),
     TOGGLE_ONE_PEDAL_DRIVING("toggle_one_pedal_driving", "Alternar condução com um pedal."),
     OPEN_APP("open_app", "Abrir aplicativo de sua escolha."),
+    OPEN_CARPLAY("open_carplay", "Abrir CarPlay na mídia."),
+    OPEN_ANDROID_AUTO("open_android_auto", "Abrir Android Auto na mídia."),
     CLIMATE_COMMAND("climate_command", "Acionar comandos do ar-condicionado."),
     TOGGLE_PROJECTION_DISPLAY(
             "toggle_projection_display",

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -84,6 +84,13 @@ private fun SteeringActionPicker(
                         value = packageName,
                         onValueChange = { onPackageChanged(it) },
                         label = { Text("Pacote do App") },
+                        placeholder = { Text("com.exemplo.app ou com.exemplo.app/.MainActivity") },
+                        supportingText = {
+                                Text(
+                                        "Para CarPlay ou Android Auto, use as opções dedicadas na lista de ações acima. Para outros apps sem ícone/launcher, use pacote/Activity.",
+                                        color = Color(0xFFB0B8C4)
+                                )
+                        },
                         colors = TextFieldDefaults.colors(
                                 focusedContainerColor = Color(0xFF2A2F37),
                                 unfocusedContainerColor = Color(0xFF2A2F37),


### PR DESCRIPTION
## Objetivo

Adicionar duas ações de volante dedicadas para abrir o **CarPlay** e o **Android Auto** direto na tela principal da multimídia, selecionáveis pelo dropdown de ações — sem precisar digitar o nome do pacote no campo de texto livre do `OPEN_APP`.

## Mudanças

- **Novas ações `OPEN_CARPLAY` e `OPEN_ANDROID_AUTO`** (`SteeringWheelCustomActionType`): aparecem como opções próprias no seletor de ações. Ambas usam `DisplayAppLauncher.launchAnyAppFromJava(...)` com as constantes canônicas `CARPLAY_PACKAGE` / `ANDROID_AUTO_PACKAGE`, abrindo o app na tela principal da mídia (não apenas trocando de display).

- **`OPEN_APP` mais robusto**:
  - Passa a aceitar um override opcional no formato `pacote/Activity` (ou `pacote/.Activity`) e delega ao `DisplayAppLauncher`, que resolve automaticamente os `PREDEFINED_APPS` e configs salvas.
  - Antes, o `OPEN_APP` dependia só de `getLaunchIntentForPackage()`, que retorna `null` para apps sem uma launcher activity exportada — esses simplesmente não abriam.
  - Adicionada a dica do formato `pacote/Activity` no campo das configurações.

## Arquivos

- `models/SteeringWheelCustomActionType.kt`
- `managers/ServiceManager.java`
- `managers/DisplayAppLauncher.kt`
- `ui/screens/BasicSettingsScreen.kt`
