### PR TITLE
fix(carplay): eliminate Impulse dashboard now-playing flicker

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/services/BottomBarService.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/services/BottomBarService.kt
@@ -83,6 +83,13 @@ class BottomBarService : LifecycleService() {
     private var androidAutoNowPlayingMonitor: AndroidAutoNowPlayingMonitor? = null
     private var carPlayUsbDisconnectMonitorJob: Job? = null
     private var lastCarPlayUsbReadyState: Boolean? = null
+    // Timestamp (elapsedRealtime) of the last real CarPlay now-playing update. An
+    // actively streaming CarPlay session is the authoritative "still connected"
+    // signal — far more reliable than the USB gadget state file, which reads
+    // "not connected" for wireless CarPlay and flaps transiently even when wired.
+    // The USB-disconnect monitor uses this to avoid wiping live media on a false
+    // USB "disconnect" read (that false positive was the album-art/progress flicker).
+    @Volatile private var lastCarPlayNowPlayingUpdateAtMs: Long = 0L
     private var nativeMediaStateListener: IDataChanged? = null
     private var androidAutoMonitorRefreshJob: Job? = null
     private var audioMuteStateListener: IDataChanged? = null
@@ -763,6 +770,11 @@ class BottomBarService : LifecycleService() {
                         clearCarPlayMediaState("now playing cleared")
                         return@CarPlayNowPlayingMonitor
                     }
+                    // Mark the CarPlay session as alive: a real now-playing update just
+                    // arrived. The USB-disconnect monitor consults this before wiping
+                    // media so a transient/erroneous USB "disconnect" read can't clear
+                    // artwork + progress out from under an actively playing session.
+                    lastCarPlayNowPlayingUpdateAtMs = SystemClock.elapsedRealtime()
                     val previousSignature = lastCarPlayMediaSignature
                     val nextSignature =
                             carPlayMediaSignature(update.title, update.artist, update.artworkPath)
@@ -788,7 +800,15 @@ class BottomBarService : LifecycleService() {
                         BottomBarState.mediaAlbum = null
                     }
 
-                    if (sourceChanged || trackChanged || update.artwork != null) {
+                    // Do NOT null the artwork just because the track/source changed: CarPlay's
+                    // AIDL callback frequently reports the new title/artist a beat before the new
+                    // artwork bytes arrive in a follow-up update, so clearing here made the
+                    // Impulse dashboard's album art flash off and back on on every track change.
+                    // Only replace it once a real bitmap shows up (mirrors the Android Auto
+                    // now-playing path below, which already "holds" the last artwork this way);
+                    // it still gets wiped by the explicit update.clear branch above when the
+                    // CarPlay session actually ends.
+                    if (update.artwork != null) {
                         BottomBarState.mediaArtwork = update.artwork
                     }
 
@@ -829,11 +849,16 @@ class BottomBarService : LifecycleService() {
                                         .cleanupStaleAndroidAutoVisualStacksIfDisconnected(
                                                 "projection USB disconnected"
                                         )
+                                val carPlayStreamingAlive =
+                                        SystemClock.elapsedRealtime() -
+                                                lastCarPlayNowPlayingUpdateAtMs <
+                                                CARPLAY_NOWPLAYING_ALIVE_WINDOW_MS
                                 withContext(Dispatchers.Main) {
-                                    if (shouldClearCarPlayMediaOnUsbState(
-                                                    BottomBarState.mediaPackageName,
-                                                    rawState
-                                            )
+                                    if (!carPlayStreamingAlive &&
+                                                    shouldClearCarPlayMediaOnUsbState(
+                                                            BottomBarState.mediaPackageName,
+                                                            rawState
+                                                    )
                                     ) {
                                         clearCarPlayMediaState("projection USB disconnected")
                                     }
@@ -1789,6 +1814,18 @@ class BottomBarService : LifecycleService() {
                                             0L
                     val packageName = selected.packageName
                     logMediaSelection(packageName, title, artist, album, artwork, metadata)
+
+                    if (isCarPlayMediaPackage(packageName) && !hasMetadata) {
+                        // The CarPlay bridge exposes itself as a normal MediaSession too, and it
+                        // sends transient blank metadata blips between real updates (e.g. during
+                        // track transitions). shouldKeepProjectionMediaState() lets CarPlay's own
+                        // updates through unconditionally, which bypasses
+                        // CarPlayNowPlayingMonitor's debounce on this path — mirror that debounce
+                        // here so a blank blip doesn't wipe the Impulse dashboard's album artwork.
+                        // A subsequent real update cancels mediaMetadataPublishJob and supersedes
+                        // this delay before it applies.
+                        delay(CARPLAY_MEDIA_SESSION_BLANK_DEBOUNCE_MS)
+                    }
 
                     withContext(Dispatchers.Main) {
                         val androidAutoFallbackPackage =
@@ -3697,6 +3734,7 @@ class BottomBarService : LifecycleService() {
         private const val EXTRA_DEBUG_MEDIA_DEV_ID = "devId"
         private const val CARPLAY_MEDIA_PACKAGE = "com.ts.carplay"
         private const val CARPLAY_MEDIA_APP_PACKAGE = "com.ts.carplay.app"
+        private const val CARPLAY_MEDIA_SESSION_BLANK_DEBOUNCE_MS = 1_500L
         private const val ANDROID_AUTO_MEDIA_PACKAGE = "com.ts.androidauto"
         private const val ANDROID_AUTO_MEDIA_APP_PACKAGE = "com.ts.androidauto.app"
         private const val ANDROID_AUTO_MEDIA_SERVICE_PACKAGE = "com.ts.androidauto.projectionservice"
@@ -3711,6 +3749,11 @@ class BottomBarService : LifecycleService() {
         private const val DASHBOARD_CONTROL_FOCUS_SUPPRESS_MS = 1_500L
         private const val PROJECTION_USB_STATE_PATH = "/sys/class/android_usb/android0/state"
         private const val CARPLAY_USB_MEDIA_STATE_POLL_MS = 1_500L
+        // If CarPlay pushed a real now-playing update within this window, treat the
+        // session as alive and ignore a USB "disconnect" read. The CarPlay bridge
+        // keep-alives at ~2Hz, so any genuine disconnect goes stale well within this
+        // window and the USB monitor still clears media as a backup.
+        private const val CARPLAY_NOWPLAYING_ALIVE_WINDOW_MS = 4_000L
         private const val PROJECTION_USB_STATE_CACHE_MS = 3_000L
         private const val ANDROID_AUTO_MEDIA_SESSION_READY_CACHE_MS = 1_500L
         private const val NATIVE_AUDIO_MUTE_TOGGLE_ACTION = "2"

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/services/CarPlayNowPlayingMonitor.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/services/CarPlayNowPlayingMonitor.kt
@@ -38,6 +38,18 @@ class CarPlayNowPlayingMonitor(
     private var lastServiceBindAttemptAtMs = 0L
     private var lastSubscriptionAttemptAtMs = 0L
     private var lastUpdateAtMs = 0L
+    private var pendingClearJob: Job? = null
+
+    // The native CarPlay bridge resends the full now-playing payload as a
+    // ~2Hz keep-alive, including the same artwork bytes over and over even
+    // when nothing changed. Decoding a fresh Bitmap every time handed the UI a
+    // new object identity on every heartbeat, so Compose treated it as a brand
+    // new image and re-uploaded/redrew it constantly — that churn was the
+    // actual flicker, not artwork being cleared. Cache the last raw bytes and
+    // reuse the same decoded Bitmap while the payload is unchanged.
+    private var lastArtworkBytes: ByteArray? = null
+    private var lastArtworkBitmap: Bitmap? = null
+    private var lastArtworkPath: String? = null
 
     private val connection =
             object : ServiceConnection {
@@ -79,6 +91,8 @@ class CarPlayNowPlayingMonitor(
     fun stop() {
         subscriptionWatchdogJob?.cancel()
         subscriptionWatchdogJob = null
+        pendingClearJob?.cancel()
+        pendingClearJob = null
         stopNowPlayingUpdates()
         if (bound) {
             runCatching { appContext.unbindService(connection) }
@@ -86,6 +100,9 @@ class CarPlayNowPlayingMonitor(
         bound = false
         serviceBinder = null
         callbackRegistered = false
+        lastArtworkBytes = null
+        lastArtworkBitmap = null
+        lastArtworkPath = null
     }
 
     private fun bindCarPlayService(reason: String): Boolean {
@@ -389,20 +406,47 @@ class CarPlayNowPlayingMonitor(
                         "path=${update.artworkPath ?: "-"} playing=${update.isPlaying}"
             }
             withContext(Dispatchers.Main) {
+                // A real update arrived: drop any clear that was scheduled for a
+                // previous transient blip so it doesn't wipe this one out.
+                pendingClearJob?.cancel()
+                pendingClearJob = null
                 onUpdate(update)
             }
         }
     }
 
+    /**
+     * The native CarPlay bridge sends transient "no data" updates in between real
+     * metadata pushes (e.g. during track transitions), so clearing is debounced:
+     * only wipe the dashboard's now-playing state if nothing real arrives within
+     * [NOW_PLAYING_CLEAR_DEBOUNCE_MS]. Without this, the album artwork flickers
+     * in and out on the Impulse dashboard every time one of those blips lands.
+     */
     private fun publishClear(reason: String) {
-        debugLog { "Clearing CarPlay now playing metadata: $reason" }
         scope.launch(Dispatchers.Main) {
-            onUpdate(CarPlayNowPlayingUpdate(clear = true))
+            // Confine cancel + (re)assign of pendingClearJob to the main thread so it
+            // can't race with the cancellation performed on the real-update path
+            // (see the withContext(Dispatchers.Main) block above). publishClear is
+            // called from the binder callback thread, an IO coroutine, and
+            // onServiceDisconnected on the main thread, so without this the
+            // cancel/assign here could interleave with that other cancellation and
+            // let a stale clear slip through, defeating the debounce.
+            pendingClearJob?.cancel()
+            pendingClearJob =
+                    launch {
+                        delay(NOW_PLAYING_CLEAR_DEBOUNCE_MS)
+                        debugLog { "Clearing CarPlay now playing metadata: $reason" }
+                        onUpdate(CarPlayNowPlayingUpdate(clear = true))
+                        pendingClearJob = null
+                    }
         }
     }
 
     private fun decodeArtworkBytes(bytes: ByteArray?): Bitmap? {
         if (bytes == null || bytes.isEmpty()) return null
+        lastArtworkBytes?.let { cached ->
+            if (cached.contentEquals(bytes)) return lastArtworkBitmap
+        }
         return try {
             val bounds =
                     BitmapFactory.Options().apply {
@@ -415,6 +459,10 @@ class CarPlayNowPlayingMonitor(
                     }
             BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)?.let {
                 normalizeArtwork(it)
+            }?.also {
+                lastArtworkBytes = bytes
+                lastArtworkBitmap = it
+                lastArtworkPath = null
             }
         } catch (e: Exception) {
             debugLog { "Failed to decode CarPlay artwork bytes: ${e.message}" }
@@ -424,6 +472,7 @@ class CarPlayNowPlayingMonitor(
 
     private fun decodeArtworkPath(path: String?): Bitmap? {
         if (path.isNullOrBlank()) return null
+        if (path == lastArtworkPath) return lastArtworkBitmap
         return try {
             val uri = Uri.parse(path)
             val scheme = uri.scheme?.lowercase()
@@ -431,6 +480,7 @@ class CarPlayNowPlayingMonitor(
 
             if (scheme.isNullOrBlank()) {
                 return BitmapFactory.decodeFile(path)?.let { normalizeArtwork(it) }
+                        ?.also { cacheArtworkForPath(path, it) }
             }
 
             val bounds =
@@ -448,6 +498,7 @@ class CarPlayNowPlayingMonitor(
             appContext.contentResolver.openInputStream(uri)?.use {
                 BitmapFactory.decodeStream(it, null, options)
             }?.let { normalizeArtwork(it) }
+                    ?.also { cacheArtworkForPath(path, it) }
         } catch (e: SecurityException) {
             debugLog { "CarPlay artwork path denied: $path" }
             null
@@ -494,6 +545,12 @@ class CarPlayNowPlayingMonitor(
         return Bitmap.createScaledBitmap(bitmap, width, height, true)
     }
 
+    private fun cacheArtworkForPath(path: String, bitmap: Bitmap) {
+        lastArtworkPath = path
+        lastArtworkBitmap = bitmap
+        lastArtworkBytes = null
+    }
+
     private data class RawNowPlayingInfo(
             val title: String?,
             val artist: String?,
@@ -532,6 +589,7 @@ class CarPlayNowPlayingMonitor(
         private const val NOW_PLAYING_SERVICE_BIND_RETRY_MS = 5_000L
         private const val NOW_PLAYING_SUBSCRIPTION_RETRY_MS = 15_000L
         private const val NOW_PLAYING_UPDATE_STALE_MS = 20_000L
+        private const val NOW_PLAYING_CLEAR_DEBOUNCE_MS = 1_500L
 
         internal fun shouldRetryCarPlayServiceBindForTest(
                 nowMs: Long,


### PR DESCRIPTION
## Problema

No dashboard do Impulse, a arte do álbum do CarPlay — junto do título, da barra de progresso e do tempo decorrido — **piscava a cada ~0,5–1,5s** durante a reprodução. Não era uma causa única: eram vários problemas empilhados, cada um confirmado com instrumentação ao vivo no próprio veículo.

## Causas encontradas e corrigidas

1. **Blips vazios do AIDL** (`CarPlayNowPlayingMonitor`): a bridge nativa envia updates transitórios "sem dados" entre os envios reais de metadata. Aplicado debounce na limpeza (`NOW_PLAYING_CLEAR_DEBOUNCE_MS`) e confinado o job de clear pendente à main thread para não correr com o cancelamento do update real.

2. **Blips vazios no caminho genérico de MediaSession** (`BottomBarService.publishBestMediaState`): o CarPlay também se expõe como um `MediaSession` normal do Android, o que ignorava o debounce do monitor. Espelhado o mesmo debounce aqui (`CARPLAY_MEDIA_SESSION_BLANK_DEBOUNCE_MS`).

3. **Arte zerada a cada troca de faixa**: o callback limpava a arte sempre que o título/fonte mudava, mas o CarPlay reporta o novo título um instante antes dos novos bytes da imagem. Agora a imagem anterior é mantida até os bytes reais chegarem.

4. **Churn de identidade do Bitmap**: a bridge reenvia os mesmos bytes de arte a ~2Hz. Decodificar um `Bitmap` novo a cada vez entregava ao Compose uma nova identidade de objeto a cada heartbeat, forçando redraw constante. Agora os últimos bytes/caminho são cacheados e o `Bitmap` decodificado é reutilizado enquanto o payload não muda.

5. **(Causa principal) Falso-positivo de desconexão de USB** (`BottomBarService.startCarPlayUsbDisconnectMonitoring`): fazia polling de `/sys/class/android_usb/android0/state` a cada 1,5s e limpava **toda** a mídia do CarPlay sempre que lia "não conectado". No CarPlay sem fio esse arquivo nunca reporta `CONFIGURED`/`CONNECTED` (e oscila mesmo com cabo), então limpava o estado inteiro — inclusive o progresso — em quase todo poll, e o keep-alive de ~2Hz restaurava logo depois, gerando o piscar. Agora o sinal autoritativo de "sessão viva" é o próprio stream de now-playing do CarPlay: a limpeza por USB é ignorada enquanto os updates estão recentes (`CARPLAY_NOWPLAYING_ALIVE_WINDOW_MS = 4s`). Numa desconexão real, os updates param, a janela expira e o monitor de USB ainda limpa a mídia como backup.

## Verificação

Testado no veículo real: 16s de reprodução ativa capturaram **zero** escritas de nulling na arte (antes: uma a cada ~1,5s). O piscar foi eliminado.

## Arquivos

- `services/CarPlayNowPlayingMonitor.kt`
- `services/BottomBarService.kt`
