### PR TITLE
fix(HEV): reaplicar o % do Prioritário no init + monitor contínuo (não só por eventos)

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -217,6 +217,10 @@ public class ServiceManager {
     private Boolean closeSunroofDueToeSpeed = false;
     private HandlerThread handlerThread;
     private Handler backgroundHandler;
+    // Monitor periódico do % do HEV Prioritário: reaplica o valor salvo mesmo se algum evento
+    // (power-on/entrar no modo/carro resetar) tiver sido perdido — ex.: app subiu tarde no boot.
+    private static final long HEV_SOC_MONITOR_INTERVAL_MS = 30000L;
+    private volatile Runnable hevSocMonitorRunnable;
     private IListener.Stub listener;
     private IInputListener.Stub inputListener;
     private IClusterCallback.Stub clusterCallback;
@@ -831,6 +835,11 @@ public class ServiceManager {
         // ligado antes do serviço subir, a flag ficaria falsa).
         wifiTetherEnabled = currentWifiTetherState();
         Log.w(TAG, "Services initialized successfully");
+        // HEV Prioritário: no boot o carro costuma resetar o % (ex.: 45->80) e o app pode subir
+        // depois do evento -> reaplica o valor salvo no init e depois monitora continuamente.
+        backgroundHandler.postDelayed(() -> applyHevSocTargetIfActive("INIT+8s"), 8000);
+        backgroundHandler.postDelayed(() -> applyHevSocTargetIfActive("INIT+18s"), 18000);
+        startHevSocMonitor();
         backgroundHandler.post(() -> {
             try {
                 ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c", "settings put global enable_freeform_support 1"});
@@ -1885,6 +1894,33 @@ public class ServiceManager {
     // Prioritario (modo HEV + sub-modo Prioritario). NUNCA escreve o modo nem o sub-modo: se nao
     // estiver exatamente em HEV Prioritario, sai sem fazer nada (o modo quem define e o usuario no
     // carro). O eco da propria escrita nao re-dispara (current == desired).
+    // Monitor periódico: reaplica o % salvo enquanto o carro estiver em HEV Prioritário. É a rede de
+    // segurança para eventos perdidos (power-on com app subindo tarde, corrida ao entrar no modo,
+    // carro resetando o valor). Auto-gateado por applyHevSocTargetIfActive (retorna rápido se a
+    // persistência estiver desligada ou fora de HEV Prioritário) e idempotente (só escreve se drift).
+    private void startHevSocMonitor() {
+        if (backgroundHandler == null) return;
+        if (hevSocMonitorRunnable != null) {
+            backgroundHandler.removeCallbacks(hevSocMonitorRunnable);
+        }
+        hevSocMonitorRunnable = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    applyHevSocTargetIfActive("MONITOR");
+                } catch (Exception e) {
+                    Log.e(TAG, "HEV SOC monitor tick failed", e);
+                } finally {
+                    // Só o runnable corrente reagenda (no restart o handler é recriado e este é trocado).
+                    if (backgroundHandler != null && hevSocMonitorRunnable == this) {
+                        backgroundHandler.postDelayed(this, HEV_SOC_MONITOR_INTERVAL_MS);
+                    }
+                }
+            }
+        };
+        backgroundHandler.postDelayed(hevSocMonitorRunnable, HEV_SOC_MONITOR_INTERVAL_MS);
+    }
+
     public void applyHevSocTargetIfActive(String reason) {
         try {
             if (!sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_PERSIST_HEV_SOC_TARGET.getKey(), false)) {
@@ -1902,6 +1938,11 @@ public class ServiceManager {
             }
             int desired = sharedPreferences.getInt(SharedPreferencesKeys.HEV_SOC_TARGET_VALUE.getKey(), 50);
             String currentStr = getUpdatedData(CarConstants.CAR_EV_SETTING_CHARGE_SOC_TARGET_CONFIG.getValue());
+            // Sem leitura válida do valor atual, NÃO escreve às cegas (evita reescrever quando o
+            // control service piscou). Mesmo padrão dos gates de driveMode/subMode acima.
+            if (currentStr == null) {
+                return;
+            }
             int current = Integer.MIN_VALUE;
             try { current = Integer.parseInt(currentStr.trim()); } catch (Exception ignored) {}
             if (current != desired) {


### PR DESCRIPTION
## Problema

A persistência do % do HEV Prioritário (introduzida no #94) reage **apenas a eventos discretos** em `OnDataChanged` (`POWER_ON`, `ENTER_PRIORITARIO`, `ENTER_HEV`, `SOC_CHANGED`). Se o app inicializa **depois** do evento (startup lento do serviço no boot do carro), o reset que o carro faz no power-on (o % pula sozinho para 20/80) **não é corrigido** — o listener só fica ativo depois de o evento já ter passado. O mesmo acontece ao entrar em Prioritário enquanto os serviços ainda sobem (corrida com o evento).

Relato de campo: usuário deixou o carro em HEV Prioritário 45%; ao ligar no dia seguinte o carro definiu 80% e o app não reaplicou os 45%.

## Correção

- **Enforce no init:** `applyHevSocTargetIfActive` em `INIT+8s` e `INIT+18s` (`postDelayed`, após `servicesInitialized=true`) — pega o drift ocorrido enquanto o app ainda subia.
- **Monitor contínuo:** `startHevSocMonitor()` reaplica a cada 30s enquanto o carro estiver em HEV Prioritário. Auto-gateado (`applyHevSocTargetIfActive` retorna antes de qualquer leitura se a persistência estiver desligada ou fora do modo) e idempotente (só escreve em drift; `getUpdatedData` lê ao vivo do carro, sem loop de eco). Guard de reentrância (`== this`) + campo `volatile` para não duplicar no restart do serviço (o `handlerThread` é recriado).
- **Guard de null** na leitura de `charge_soc_target_config`: não reescrever às cegas se o control service piscar (alinha com os gates de `power_model`/`power_reserve`).

## Sem mudança de comportamento no resto

- Nunca escreve o modo (`power_model_config`) nem o sub-modo (`power_reserve_config`) — o usuário é dono disso.
- O valor salvo (`HEV_SOC_TARGET_VALUE`) continua só sendo alterado pelos sliders (Config → Básico e o slider da barra estendida). Ativar o modo / ligar o carro / o carro resetar → apenas **reaplica** o salvo.
- Quando a persistência está desligada, o monitor é 1 `getBoolean` a cada 30s (custo desprezível).

## Teste

1 arquivo alterado (`ServiceManager.java`). Com o toggle "Manter % de bateria no HEV Prioritário" ligado, em HEV Prioritário: definir 45% → o carro mudar (ou desligar/ligar) → volta a 45% em ≤30s (ou já no init).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
