### PR TITLE
feat: brilho automático por nascer/pôr do sol (transição suave)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -167,7 +167,12 @@
         <receiver
             android:name=".broadcastReceivers.AutoBrightnessReceiver"
             android:enabled="true"
-            android:exported="false" />
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.TIME_SET" />
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+            </intent-filter>
+        </receiver>
         <receiver
             android:name=".broadcastReceivers.OverscanReceiver"
             android:enabled="true"

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/broadcastReceivers/AutoBrightnessReceiver.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/broadcastReceivers/AutoBrightnessReceiver.kt
@@ -8,7 +8,19 @@ import br.com.redesurftank.havalshisuku.managers.AutoBrightnessManager
 
 class AutoBrightnessReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        Log.w("AutoBrightnessReceiver", "onReceive called with intent: $intent")
-        AutoBrightnessManager.getInstance().updateSchedule();
+        Log.w("AutoBrightnessReceiver", "onReceive: ${intent.action}")
+        // Fora da main thread: updateSchedule() pode fazer getLastKnownLocation (binder síncrono).
+        // goAsync mantém o receiver vivo enquanto a thread roda. Também trata TIME_SET/TIMEZONE_CHANGED
+        // (registrados no manifesto) pra re-armar quando o relógio do carro é corrigido.
+        val pending = goAsync()
+        Thread {
+            try {
+                AutoBrightnessManager.getInstance().updateSchedule()
+            } catch (e: Exception) {
+                Log.e("AutoBrightnessReceiver", "updateSchedule falhou", e)
+            } finally {
+                pending.finish()
+            }
+        }.also { it.isDaemon = true }.start()
     }
 }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/AutoBrightnessManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/AutoBrightnessManager.kt
@@ -158,16 +158,28 @@ class AutoBrightnessManager private constructor() {
 
     /** Info pra UI: cidade de referência + nascer/pôr do sol de hoje (horário local). Null se nunca
      *  houve localização. Usa o último lat/lon salvo -> funciona mesmo sem GPS no momento. */
-    data class SunDisplayInfo(val city: String, val sunrise: String, val sunset: String)
+    // cityResolved=false quando ainda é o fallback de coordenadas (geocode não resolveu) — a UI
+    // usa isso pra continuar tentando até virar o nome amigável da cidade.
+    data class SunDisplayInfo(
+        val city: String,
+        val sunrise: String,
+        val sunset: String,
+        val cityResolved: Boolean
+    )
 
     fun getSunInfoForDisplay(): SunDisplayInfo? {
         val loc = resolveLatLon() ?: return null
         val (lat, lon) = loc
         val sun = SolarCalculator.calculate(lat, lon, System.currentTimeMillis()) ?: return null
         val fmt = SimpleDateFormat("HH:mm", Locale.getDefault())
-        val city = prefs.getString(SharedPreferencesKeys.AUTO_BRIGHTNESS_CITY.key, null)
-            ?: String.format(Locale.US, "%.3f, %.3f", lat, lon)
-        return SunDisplayInfo(city, fmt.format(Date(sun.sunriseUtcMs)), fmt.format(Date(sun.sunsetUtcMs)))
+        val cached = prefs.getString(SharedPreferencesKeys.AUTO_BRIGHTNESS_CITY.key, null)
+        val city = cached ?: String.format(Locale.US, "%.3f, %.3f", lat, lon)
+        return SunDisplayInfo(
+            city,
+            fmt.format(Date(sun.sunriseUtcMs)),
+            fmt.format(Date(sun.sunsetUtcMs)),
+            cityResolved = !cached.isNullOrBlank()
+        )
     }
 
     private fun setBrightness(level: Int) {

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/AutoBrightnessManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/AutoBrightnessManager.kt
@@ -5,14 +5,26 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.icu.util.Calendar
+import android.location.Geocoder
+import android.location.LocationManager
 import android.util.Log
 import br.com.redesurftank.App
 import br.com.redesurftank.havalshisuku.broadcastReceivers.AutoBrightnessReceiver
 import br.com.redesurftank.havalshisuku.models.CarConstants
 import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys
+import br.com.redesurftank.havalshisuku.utils.BrightnessSchedule
+import br.com.redesurftank.havalshisuku.utils.SolarCalculator
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class AutoBrightnessManager private constructor() {
     companion object {
+        private const val TAG = "AutoBrightnessManager"
+        private const val REQ_START = 0
+        private const val REQ_END = 1
+        private const val REQ_SUN_TICK = 2
+
         @Volatile
         private var INSTANCE: AutoBrightnessManager? = null
         fun getInstance(): AutoBrightnessManager {
@@ -26,23 +38,147 @@ class AutoBrightnessManager private constructor() {
     private val alarmManager = App.getContext().getSystemService(Context.ALARM_SERVICE) as AlarmManager
 
     fun setEnabled(enabled: Boolean) {
-        if (enabled) {
-            updateSchedule()
-        } else {
-            cancelSchedules()
-        }
+        if (enabled) updateSchedule() else cancelSchedules()
     }
+
+    private fun useSun(): Boolean =
+        prefs.getBoolean(SharedPreferencesKeys.AUTO_BRIGHTNESS_USE_SUN.key, false)
+
+    private fun dayLevel() = prefs.getInt(SharedPreferencesKeys.AUTO_BRIGHTNESS_LEVEL_DAY.key, 10)
+    private fun nightLevel() = prefs.getInt(SharedPreferencesKeys.AUTO_BRIGHTNESS_LEVEL_NIGHT.key, 1)
+    private fun stepMs(): Long =
+        prefs.getInt(SharedPreferencesKeys.AUTO_BRIGHTNESS_STEP_MIN.key, BrightnessSchedule.DEFAULT_STEP_MIN)
+            .coerceIn(BrightnessSchedule.MIN_STEP_MIN, BrightnessSchedule.MAX_STEP_MIN) * 60_000L
 
     fun updateSchedule() {
         cancelSchedules()
-        if (isNightTime()) {
-            adjustBrightnessForNight()
-        } else {
-            adjustBrightnessForDay()
+        if (useSun() && applySunSchedule()) {
+            return // modo sol aplicou e agendou o próximo tick
         }
+        // Modo horário fixo (ou fallback quando não há localização/sol).
+        if (isNightTime()) adjustBrightnessForNight() else adjustBrightnessForDay()
         scheduleNextStart()
         scheduleNextEnd()
     }
+
+    // ---------------- MODO NASCER/PÔR DO SOL ----------------
+
+    /** Aplica o brilho por posição do sol e agenda o próximo tick. Retorna false se não deu (sem
+     *  localização nem cache, ou dia/noite polar) -> o chamador cai no modo horário fixo. */
+    private fun applySunSchedule(): Boolean {
+        val loc = resolveLatLon() ?: return false
+        val (lat, lon) = loc
+        val now = System.currentTimeMillis()
+        val sun = SolarCalculator.calculate(lat, lon, now) ?: return false
+
+        val day = dayLevel()
+        val night = nightLevel()
+        val step = stepMs()
+        val result = BrightnessSchedule.levelFor(now, sun.sunriseUtcMs, sun.sunsetUtcMs, day, night, step)
+        setBrightness(result.level)
+
+        val nextAt =
+            if (result.inTransition) {
+                now + step
+            } else {
+                val half = BrightnessSchedule.totalMs(day, night, step) / 2
+                val riseStart = sun.sunriseUtcMs - half
+                val setStart = sun.sunsetUtcMs - half
+                when {
+                    now < riseStart -> riseStart
+                    now < setStart -> setStart
+                    else -> {
+                        val tomorrow = SolarCalculator.calculate(lat, lon, now + 86_400_000L)
+                        ((tomorrow?.sunriseUtcMs ?: (sun.sunriseUtcMs + 86_400_000L)) - half)
+                    }
+                }
+            }
+        scheduleSunTick(nextAt.coerceAtLeast(now + 30_000L)) // nunca menos de 30s (evita loop)
+        Log.w(TAG, "sun brightness level=${result.level} transition=${result.inTransition} next=${Date(nextAt)}")
+        return true
+    }
+
+    /** Localização atual: tenta os providers (GPS/passive/network/fused), cacheia; senão usa o cache. */
+    private fun resolveLatLon(): Pair<Double, Double>? {
+        try {
+            val lm = App.getContext().getSystemService(Context.LOCATION_SERVICE) as LocationManager
+            val providers = listOf(
+                LocationManager.GPS_PROVIDER,
+                LocationManager.PASSIVE_PROVIDER,
+                LocationManager.NETWORK_PROVIDER,
+                "fused"
+            )
+            val best = providers
+                .mapNotNull { runCatching { lm.getLastKnownLocation(it) }.getOrNull() }
+                .maxByOrNull { it.time }
+            if (best != null) {
+                cacheLatLon(best.latitude, best.longitude)
+                return best.latitude to best.longitude
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "sem localização ao vivo: ${e.message}")
+        }
+        // Fallback: último válido salvo (funciona offline/garagem).
+        val lat = prefs.getString(SharedPreferencesKeys.AUTO_BRIGHTNESS_LAST_LAT.key, null)?.toDoubleOrNull()
+        val lon = prefs.getString(SharedPreferencesKeys.AUTO_BRIGHTNESS_LAST_LON.key, null)?.toDoubleOrNull()
+        return if (lat != null && lon != null) lat to lon else null
+    }
+
+    private fun cacheLatLon(lat: Double, lon: Double) {
+        prefs.edit()
+            .putString(SharedPreferencesKeys.AUTO_BRIGHTNESS_LAST_LAT.key, lat.toString())
+            .putString(SharedPreferencesKeys.AUTO_BRIGHTNESS_LAST_LON.key, lon.toString())
+            .apply()
+        // Geocode best-effort EM BACKGROUND (getFromLocation usa rede e pode bloquear vários segundos;
+        // roda em main thread do receiver/UI daria ANR). Atualiza a cidade cacheada quando resolver.
+        if (!Geocoder.isPresent()) return
+        Thread {
+            runCatching {
+                @Suppress("DEPRECATION")
+                val results = Geocoder(App.getContext(), Locale("pt", "BR")).getFromLocation(lat, lon, 1)
+                val addr = results?.firstOrNull()
+                val city = addr?.subAdminArea ?: addr?.locality ?: addr?.adminArea
+                if (!city.isNullOrBlank()) {
+                    prefs.edit().putString(SharedPreferencesKeys.AUTO_BRIGHTNESS_CITY.key, city).apply()
+                }
+            }
+        }.also { it.isDaemon = true }.start()
+    }
+
+    private fun scheduleSunTick(at: Long) {
+        val intent = Intent(App.getContext(), AutoBrightnessReceiver::class.java).apply {
+            putExtra("sunTick", true)
+        }
+        val pi = PendingIntent.getBroadcast(
+            App.getContext(), REQ_SUN_TICK, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        alarmManager.setExact(AlarmManager.RTC_WAKEUP, at, pi)
+    }
+
+    /** Info pra UI: cidade de referência + nascer/pôr do sol de hoje (horário local). Null se nunca
+     *  houve localização. Usa o último lat/lon salvo -> funciona mesmo sem GPS no momento. */
+    data class SunDisplayInfo(val city: String, val sunrise: String, val sunset: String)
+
+    fun getSunInfoForDisplay(): SunDisplayInfo? {
+        val loc = resolveLatLon() ?: return null
+        val (lat, lon) = loc
+        val sun = SolarCalculator.calculate(lat, lon, System.currentTimeMillis()) ?: return null
+        val fmt = SimpleDateFormat("HH:mm", Locale.getDefault())
+        val city = prefs.getString(SharedPreferencesKeys.AUTO_BRIGHTNESS_CITY.key, null)
+            ?: String.format(Locale.US, "%.3f, %.3f", lat, lon)
+        return SunDisplayInfo(city, fmt.format(Date(sun.sunriseUtcMs)), fmt.format(Date(sun.sunsetUtcMs)))
+    }
+
+    private fun setBrightness(level: Int) {
+        ServiceManager.getInstance().executeWithServicesRunning {
+            val v = level.toString()
+            ServiceManager.getInstance().updateData(CarConstants.SYS_SETTINGS_DISPLAY_BRIGHTNESS_LEVEL.value, v)
+            ServiceManager.getInstance().updateData(CarConstants.CAR_IPK_SETTING_BRIGHTNESS_CONFIG.value, v)
+        }
+    }
+
+    // ---------------- MODO HORÁRIO FIXO (original) ----------------
 
     private fun isNightTime(): Boolean {
         val now = Calendar.getInstance()
@@ -60,21 +196,9 @@ class AutoBrightnessManager private constructor() {
         }
     }
 
-    fun adjustBrightnessForNight() {
-        ServiceManager.getInstance().executeWithServicesRunning {
-            val brightness = prefs.getInt(SharedPreferencesKeys.AUTO_BRIGHTNESS_LEVEL_NIGHT.key, 1)
-            ServiceManager.getInstance().updateData(CarConstants.SYS_SETTINGS_DISPLAY_BRIGHTNESS_LEVEL.value, brightness.toString());
-            ServiceManager.getInstance().updateData(CarConstants.CAR_IPK_SETTING_BRIGHTNESS_CONFIG.value, brightness.toString());
-        };
-    }
+    fun adjustBrightnessForNight() = setBrightness(nightLevel())
 
-    fun adjustBrightnessForDay() {
-        ServiceManager.getInstance().executeWithServicesRunning {
-            val brightness = prefs.getInt(SharedPreferencesKeys.AUTO_BRIGHTNESS_LEVEL_DAY.key, 10)
-            ServiceManager.getInstance().updateData(CarConstants.SYS_SETTINGS_DISPLAY_BRIGHTNESS_LEVEL.value, brightness.toString());
-            ServiceManager.getInstance().updateData(CarConstants.CAR_IPK_SETTING_BRIGHTNESS_CONFIG.value, brightness.toString());
-        };
-    }
+    fun adjustBrightnessForDay() = setBrightness(dayLevel())
 
     private fun scheduleNextStart() {
         val calendar = Calendar.getInstance()
@@ -89,9 +213,8 @@ class AutoBrightnessManager private constructor() {
         val intent = Intent(App.getContext(), AutoBrightnessReceiver::class.java).apply {
             putExtra("isNight", true)
         }
-        val pendingIntent = PendingIntent.getBroadcast(App.getContext(), 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        val pendingIntent = PendingIntent.getBroadcast(App.getContext(), REQ_START, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
         alarmManager.setExact(AlarmManager.RTC_WAKEUP, calendar.timeInMillis, pendingIntent)
-        Log.w("AutoBrightnessManager", "Scheduled next start at: ${calendar.time}")
     }
 
     private fun scheduleNextEnd() {
@@ -107,17 +230,15 @@ class AutoBrightnessManager private constructor() {
         val intent = Intent(App.getContext(), AutoBrightnessReceiver::class.java).apply {
             putExtra("isNight", false)
         }
-        val pendingIntent = PendingIntent.getBroadcast(App.getContext(), 1, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        val pendingIntent = PendingIntent.getBroadcast(App.getContext(), REQ_END, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
         alarmManager.setExact(AlarmManager.RTC_WAKEUP, calendar.timeInMillis, pendingIntent)
-        Log.w("AutoBrightnessManager", "Scheduled next end at: ${calendar.time}")
     }
 
     private fun cancelSchedules() {
-        val intentStart = Intent(App.getContext(), AutoBrightnessReceiver::class.java)
-        val pendingStart = PendingIntent.getBroadcast(App.getContext(), 0, intentStart, PendingIntent.FLAG_IMMUTABLE)
-        alarmManager.cancel(pendingStart)
-        val intentEnd = Intent(App.getContext(), AutoBrightnessReceiver::class.java)
-        val pendingEnd = PendingIntent.getBroadcast(App.getContext(), 1, intentEnd, PendingIntent.FLAG_IMMUTABLE)
-        alarmManager.cancel(pendingEnd)
+        for (req in listOf(REQ_START, REQ_END, REQ_SUN_TICK)) {
+            val intent = Intent(App.getContext(), AutoBrightnessReceiver::class.java)
+            val pi = PendingIntent.getBroadcast(App.getContext(), req, intent, PendingIntent.FLAG_IMMUTABLE)
+            alarmManager.cancel(pi)
+        }
     }
 }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -758,6 +758,8 @@ public class ServiceManager {
             ShizukuUtils.runCommandAndGetOutput(new String[]{"settings", "put", "secure", "enabled_accessibility_services", "br.com.redesurftank.havalshisuku/.services.AccessibilityService"});
             ShizukuUtils.runCommandAndGetOutput(new String[]{"settings", "put", "secure", "accessibility_enabled", "1"});
             ShizukuUtils.runCommandAndGetOutput(new String[]{"pm", "grant", context.getPackageName(), "android.permission.WRITE_SECURE_SETTINGS"});
+            // Localização: usada pelo brilho automático por nascer/pôr do sol (getLastKnownLocation).
+            ShizukuUtils.runCommandAndGetOutput(new String[]{"pm", "grant", context.getPackageName(), "android.permission.ACCESS_FINE_LOCATION"});
             controlService.registerDataChangedListener(context.getPackageName(), listener);
             controlService.addListenerKey(App.getContext().getPackageName(), getCombinedKeys());
 

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -29,6 +29,11 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
     ENABLE_AUTO_BRIGHTNESS("enableAutoBrightness", "Habilitar ajuste automático de brilho"),
     AUTO_BRIGHTNESS_LEVEL_NIGHT("autoBrightnessLevelNight", "Nível de brilho automático à noite"),
     AUTO_BRIGHTNESS_LEVEL_DAY("autoBrightnessLevelDay", "Nível de brilho automático durante o dia"),
+    AUTO_BRIGHTNESS_USE_SUN("autoBrightnessUseSun", "Usar nascer/pôr do sol (transição suave) no brilho automático"),
+    AUTO_BRIGHTNESS_STEP_MIN("autoBrightnessStepMin", "Minutos por degrau de 1 nível na transição de brilho (nascer/pôr do sol)"),
+    AUTO_BRIGHTNESS_LAST_LAT("autoBrightnessLastLat", "Última latitude conhecida (cache p/ nascer/pôr do sol)"),
+    AUTO_BRIGHTNESS_LAST_LON("autoBrightnessLastLon", "Última longitude conhecida (cache p/ nascer/pôr do sol)"),
+    AUTO_BRIGHTNESS_CITY("autoBrightnessCity", "Cidade de referência (cache do GPS, p/ exibição)"),
     ENABLE_FRIDA_HOOKS("enableFridaHooks", "Habilitar hooks do Frida"),
     ENABLE_FRIDA_HOOK_SYSTEM_SERVER(
             "enableFridaHookSystemServer",

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -14,6 +14,9 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -2205,7 +2208,18 @@ fun BasicSettingsTab() {
                                                                                 initialValue = null,
                                                                                 autoBrightnessUseSun
                                                                         ) {
-                                                                                value = AutoBrightnessManager.getInstance().getSunInfoForDisplay()
+                                                                                // Fora da main; tenta de novo enquanto o GPS não tem fix
+                                                                                // ou a cidade ainda é coordenada (geocode em background).
+                                                                                var tries = 0
+                                                                                while (tries < 15) {
+                                                                                        val info = withContext(Dispatchers.IO) {
+                                                                                                AutoBrightnessManager.getInstance().getSunInfoForDisplay()
+                                                                                        }
+                                                                                        value = info
+                                                                                        if (info != null && info.cityResolved) break
+                                                                                        tries++
+                                                                                        delay(2000)
+                                                                                }
                                                                         }
                                                                         Column {
                                                                                 Text(

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -248,6 +248,11 @@ fun BasicSettingsTab() {
                         prefs.getBoolean(SharedPreferencesKeys.ENABLE_AUTO_BRIGHTNESS.key, false)
                 )
         }
+        var autoBrightnessUseSun by remember {
+                mutableStateOf(
+                        prefs.getBoolean(SharedPreferencesKeys.AUTO_BRIGHTNESS_USE_SUN.key, false)
+                )
+        }
         var nightStartHour by remember {
                 mutableIntStateOf(prefs.getInt(SharedPreferencesKeys.NIGHT_START_HOUR.key, 20))
         }
@@ -2162,6 +2167,63 @@ fun BasicSettingsTab() {
                                                                         thickness = 1.dp
                                                                 )
 
+                                                                // Toggle: transição por nascer/pôr do sol
+                                                                Row(
+                                                                        modifier = Modifier.fillMaxWidth(),
+                                                                        verticalAlignment = Alignment.CenterVertically
+                                                                ) {
+                                                                        Column(modifier = Modifier.weight(1f)) {
+                                                                                Text(
+                                                                                        "Transição por nascer/pôr do sol",
+                                                                                        color = Color.White,
+                                                                                        fontSize = 15.sp,
+                                                                                        fontWeight = FontWeight.Medium
+                                                                                )
+                                                                                Text(
+                                                                                        "Usa o GPS pra escurecer/clarear suave (1 nível a cada 5 min) no pôr/nascer do sol. Substitui os horários fixos.",
+                                                                                        color = Color(0xFFB0B8C4),
+                                                                                        fontSize = 12.sp
+                                                                                )
+                                                                        }
+                                                                        Switch(
+                                                                                checked = autoBrightnessUseSun,
+                                                                                onCheckedChange = { on ->
+                                                                                        autoBrightnessUseSun = on
+                                                                                        prefs.edit {
+                                                                                                putBoolean(
+                                                                                                        SharedPreferencesKeys.AUTO_BRIGHTNESS_USE_SUN.key,
+                                                                                                        on
+                                                                                                )
+                                                                                        }
+                                                                                        AutoBrightnessManager.getInstance().updateSchedule()
+                                                                                }
+                                                                        )
+                                                                }
+
+                                                                if (autoBrightnessUseSun) {
+                                                                        val sunInfo by produceState<AutoBrightnessManager.SunDisplayInfo?>(
+                                                                                initialValue = null,
+                                                                                autoBrightnessUseSun
+                                                                        ) {
+                                                                                value = AutoBrightnessManager.getInstance().getSunInfoForDisplay()
+                                                                        }
+                                                                        Column {
+                                                                                Text(
+                                                                                        "Referência (GPS): ${sunInfo?.city ?: "obtendo localização..."}",
+                                                                                        color = Color.White,
+                                                                                        fontSize = 14.sp
+                                                                                )
+                                                                                sunInfo?.let {
+                                                                                        Text(
+                                                                                                "Nascer ${it.sunrise}  ·  Pôr ${it.sunset}",
+                                                                                                color = Color(0xFFB0B8C4),
+                                                                                                fontSize = 13.sp
+                                                                                        )
+                                                                                }
+                                                                        }
+                                                                }
+
+                                                                if (!autoBrightnessUseSun)
                                                                 Row(
                                                                         modifier =
                                                                                 Modifier.fillMaxWidth(),

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/utils/BrightnessSchedule.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/utils/BrightnessSchedule.kt
@@ -1,0 +1,55 @@
+package br.com.redesurftank.havalshisuku.utils
+
+import kotlin.math.abs
+
+/**
+ * Rampa de brilho por nascer/pôr do sol (pura/testável). Transição CENTRADA no evento, dando
+ * UM DEGRAU DE 1 NÍVEL a cada `stepMs` (padrão 5 min). O total acompanha o gap:
+ * duração = |dia − noite| × stepMs (ex.: dia 10 / noite 1 = 9 passos = 45 min, 22,5 antes e 22,5
+ * depois do sol). Fora das rampas, mantém dia ou noite. O agendamento do próximo tick fica no
+ * manager (durante a rampa, re-tica a cada `stepMs`).
+ */
+object BrightnessSchedule {
+    const val DEFAULT_STEP_MIN = 5
+    const val MIN_STEP_MIN = 1
+    const val MAX_STEP_MIN = 30
+
+    data class Result(val level: Int, val inTransition: Boolean)
+
+    /** Duração total (ms) da transição pra este gap de níveis. */
+    fun totalMs(dayLevel: Int, nightLevel: Int, stepMs: Long): Long =
+        abs(dayLevel - nightLevel).toLong() * stepMs
+
+    fun levelFor(
+        nowMs: Long,
+        sunriseMs: Long,
+        sunsetMs: Long,
+        dayLevel: Int,
+        nightLevel: Int,
+        stepMs: Long
+    ): Result {
+        val gap = abs(dayLevel - nightLevel)
+        // Sem gap ou passo inválido: switch seco pela posição do sol (dia entre nascer e pôr).
+        if (gap == 0 || stepMs <= 0L) {
+            val isDay = nowMs in sunriseMs until sunsetMs
+            return Result(if (isDay) dayLevel else nightLevel, false)
+        }
+        val half = gap.toLong() * stepMs / 2
+        return when {
+            nowMs < sunriseMs - half -> Result(nightLevel, false)            // madrugada
+            nowMs < sunriseMs + half ->                                      // amanhecer: noite -> dia
+                Result(stepLevel(nightLevel, dayLevel, nowMs - (sunriseMs - half), stepMs, gap), true)
+            nowMs < sunsetMs - half -> Result(dayLevel, false)               // dia pleno
+            nowMs < sunsetMs + half ->                                       // entardecer: dia -> noite
+                Result(stepLevel(dayLevel, nightLevel, nowMs - (sunsetMs - half), stepMs, gap), true)
+            else -> Result(nightLevel, false)                               // noite (após o pôr)
+        }
+    }
+
+    // Anda `elapsed/stepMs` degraus de 1 nível de `from` rumo a `to` (limitado ao gap).
+    private fun stepLevel(from: Int, to: Int, elapsedMs: Long, stepMs: Long, gap: Int): Int {
+        val steps = (elapsedMs / stepMs).coerceIn(0L, gap.toLong()).toInt()
+        val dir = if (to >= from) 1 else -1
+        return from + dir * steps
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/utils/SolarCalculator.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/utils/SolarCalculator.kt
@@ -1,0 +1,56 @@
+package br.com.redesurftank.havalshisuku.utils
+
+import kotlin.math.acos
+import kotlin.math.asin
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Nascer e pôr do sol a partir de latitude/longitude/data — algoritmo NOAA (equação do nascer do
+ * sol), tudo em matemática local (SEM internet). Puro/estático pra ser testável na JVM.
+ *
+ * Referência: https://en.wikipedia.org/wiki/Sunrise_equation
+ * Longitude no padrão LESTE-positivo (ex.: Goiânia = -49.23). Retorna epoch millis UTC do nascer e
+ * do pôr do sol do dia que contém `dateMillis`, ou null em dia/noite polar (sol não nasce/põe).
+ */
+object SolarCalculator {
+    private const val DEG = Math.PI / 180.0
+    private const val JD_UNIX_EPOCH = 2440587.5 // Julian Date de 1970-01-01T00:00Z
+    private const val MS_PER_DAY = 86_400_000.0
+    private const val OBLIQUITY = 23.44 // obliquidade da eclíptica (graus)
+    // Ângulo do centro do sol no horizonte: -0.833° (raio do disco + refração atmosférica).
+    private const val SUN_ALTITUDE = -0.833
+
+    data class SunTimes(val sunriseUtcMs: Long, val sunsetUtcMs: Long)
+
+    fun calculate(latDeg: Double, lonEastDeg: Double, dateMillis: Long): SunTimes? {
+        // Número de dias desde 2000-01-01 (para o instante dado), arredondado ao dia.
+        val jd = dateMillis / MS_PER_DAY + JD_UNIX_EPOCH
+        val n = Math.round(jd - 2451545.0 + 0.0008).toDouble()
+
+        // Meio-dia solar médio. Longitude LESTE-positiva entra direto aqui: n - lonLeste/360 posiciona
+        // o trânsito no UTC certo (ex.: Goiânia lon=-49.23 -> trânsito ~15:17 UTC = 12:17 local solar).
+        val jStar = n - lonEastDeg / 360.0
+        val mDeg = (357.5291 + 0.98560028 * jStar) % 360.0 // anomalia média do sol
+        val m = mDeg * DEG
+        // Equação do centro (graus)
+        val cDeg = 1.9148 * sin(m) + 0.0200 * sin(2 * m) + 0.0003 * sin(3 * m)
+        val lambdaDeg = (mDeg + cDeg + 180.0 + 102.9372) % 360.0 // longitude eclíptica
+        val lambda = lambdaDeg * DEG
+        val jTransit = 2451545.0 + jStar + 0.0053 * sin(m) - 0.0069 * sin(2 * lambda) // trânsito solar
+
+        val declination = asin(sin(lambda) * sin(OBLIQUITY * DEG)) // declinação do sol
+        val lat = latDeg * DEG
+        val cosOmega =
+            (sin(SUN_ALTITUDE * DEG) - sin(lat) * sin(declination)) / (cos(lat) * cos(declination))
+        if (cosOmega < -1.0 || cosOmega > 1.0) return null // sol da meia-noite / noite polar
+        val omega = acos(cosOmega) / DEG // ângulo horário (graus)
+
+        val jRise = jTransit - omega / 360.0
+        val jSet = jTransit + omega / 360.0
+        return SunTimes(julianToMillis(jRise), julianToMillis(jSet))
+    }
+
+    private fun julianToMillis(jd: Double): Long =
+        Math.round((jd - JD_UNIX_EPOCH) * MS_PER_DAY)
+}

--- a/app/src/test/java/br/com/redesurftank/havalshisuku/utils/BrightnessScheduleTest.kt
+++ b/app/src/test/java/br/com/redesurftank/havalshisuku/utils/BrightnessScheduleTest.kt
@@ -1,0 +1,92 @@
+package br.com.redesurftank.havalshisuku.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BrightnessScheduleTest {
+
+    private val day = 10
+    private val night = 1
+    private val step = 5 * 60 * 1000L          // 5 min por degrau de 1 nível
+    private val gap = day - night              // 9
+    private val half = gap * step / 2          // 22,5 min
+    private val sunrise = 6 * 3_600_000L       // 06:00
+    private val sunset = 18 * 3_600_000L       // 18:00
+
+    private fun levelAt(ms: Long) =
+        BrightnessSchedule.levelFor(ms, sunrise, sunset, day, night, step)
+
+    @Test
+    fun `total acompanha o gap`() {
+        assertEquals(9L * step, BrightnessSchedule.totalMs(10, 1, step)) // 45 min
+        assertEquals(6L * step, BrightnessSchedule.totalMs(8, 2, step))  // 30 min
+    }
+
+    @Test
+    fun `madrugada dia e noite fora da transicao`() {
+        assertEquals(night, levelAt(2 * 3_600_000L).level)
+        assertFalse(levelAt(2 * 3_600_000L).inTransition)
+        assertEquals(day, levelAt(12 * 3_600_000L).level)
+        assertEquals(night, levelAt(22 * 3_600_000L).level)
+    }
+
+    @Test
+    fun `amanhecer sobe 1 nivel a cada passo`() {
+        val start = sunrise - half
+        for (s in 0..8) {
+            val r = levelAt(start + s * step)
+            assertEquals("passo $s", night + s, r.level) // 1,2,3,...,9
+            assertTrue(r.inTransition)
+        }
+        assertEquals(day, levelAt(sunrise + half).level) // fim exato: dia (10)
+    }
+
+    @Test
+    fun `entardecer desce 1 nivel a cada passo`() {
+        val start = sunset - half
+        for (s in 0..8) {
+            val r = levelAt(start + s * step)
+            assertEquals("passo $s", day - s, r.level)   // 10,9,8,...,2
+            assertTrue(r.inTransition)
+        }
+        assertEquals(night, levelAt(sunset + half).level) // fim exato: noite (1)
+    }
+
+    @Test
+    fun `no sol exato fica proximo do meio`() {
+        // elapsed = half = 22,5 min -> floor(22,5/5)=4 degraus
+        assertEquals(night + 4, levelAt(sunrise).level) // 5
+        assertEquals(day - 4, levelAt(sunset).level)    // 6
+    }
+
+    @Test
+    fun `amanhecer nunca cai e entardecer nunca sobe`() {
+        var prev = 0
+        var t = sunrise - half
+        while (t <= sunrise + half) { val l = levelAt(t).level; assertTrue(l >= prev); prev = l; t += 60_000L }
+        assertEquals(day, prev)
+        prev = 99; t = sunset - half
+        while (t <= sunset + half) { val l = levelAt(t).level; assertTrue(l <= prev); prev = l; t += 60_000L }
+        assertEquals(night, prev)
+    }
+
+    @Test
+    fun `passo nunca pula mais de 1 nivel`() {
+        var t = sunrise - half; var prev = levelAt(t).level
+        while (t <= sunrise + half) {
+            val l = levelAt(t).level
+            assertTrue("pulo de ${l - prev} em t=$t", kotlin.math.abs(l - prev) <= 1)
+            prev = l; t += 60_000L
+        }
+    }
+
+    @Test
+    fun `gap zero = switch seco pela posicao do sol`() {
+        val r1 = BrightnessSchedule.levelFor(12 * 3_600_000L, sunrise, sunset, 5, 5, step)
+        assertEquals(5, r1.level); assertFalse(r1.inTransition)
+        val r2 = BrightnessSchedule.levelFor(2 * 3_600_000L, sunrise, sunset, 5, 5, step)
+        assertEquals(5, r2.level)
+    }
+}

--- a/app/src/test/java/br/com/redesurftank/havalshisuku/utils/SolarCalculatorTest.kt
+++ b/app/src/test/java/br/com/redesurftank/havalshisuku/utils/SolarCalculatorTest.kt
@@ -1,0 +1,63 @@
+package br.com.redesurftank.havalshisuku.utils
+
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SolarCalculatorTest {
+
+    private fun utcMillis(y: Int, mo: Int, d: Int, h: Int = 12): Long =
+        LocalDate.of(y, mo, d).atTime(h, 0).toInstant(ZoneOffset.UTC).toEpochMilli()
+
+    private fun hourUtc(ms: Long): Double {
+        val z = ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(ms), ZoneOffset.UTC)
+        return z.hour + z.minute / 60.0
+    }
+
+    @Test
+    fun `equador no equinocio nasce ~6h e poe ~18h UTC`() {
+        // Equador (0,0) no equinócio de março: dia ~12h, nascer ~06:00, pôr ~18:00 UTC.
+        val t = SolarCalculator.calculate(0.0, 0.0, utcMillis(2026, 3, 20))!!
+        assertTrue(t.sunriseUtcMs < t.sunsetUtcMs)
+        val rise = hourUtc(t.sunriseUtcMs)
+        val set = hourUtc(t.sunsetUtcMs)
+        assertTrue("nascer=$rise", rise in 5.5..6.5)
+        assertTrue("por=$set", set in 17.5..18.5)
+        val dayLen = (t.sunsetUtcMs - t.sunriseUtcMs) / 3_600_000.0
+        assertTrue("dia=$dayLen", dayLen in 11.5..12.5)
+    }
+
+    @Test
+    fun `goiania em julho tem dia de inverno plausivel`() {
+        // Goiânia (-16.62, -49.23), UTC-3, inverno do sul: dia ~11h, nascer ~06:5x, pôr ~18:0x local.
+        val t = SolarCalculator.calculate(-16.622428, -49.233194, utcMillis(2026, 7, 21))!!
+        assertTrue(t.sunriseUtcMs < t.sunsetUtcMs)
+        val riseLocal = hourUtc(t.sunriseUtcMs) - 3 // BRT
+        val setLocal = hourUtc(t.sunsetUtcMs) - 3
+        assertTrue("nascer local=$riseLocal", riseLocal in 6.0..7.5)
+        assertTrue("por local=$setLocal", setLocal in 17.0..18.75)
+        val dayLen = (t.sunsetUtcMs - t.sunriseUtcMs) / 3_600_000.0
+        assertTrue("dia=$dayLen", dayLen in 10.0..12.5)
+    }
+
+    @Test
+    fun `goiania em janeiro tem dia mais longo que em julho`() {
+        val jul = SolarCalculator.calculate(-16.62, -49.23, utcMillis(2026, 7, 21))!!
+        val jan = SolarCalculator.calculate(-16.62, -49.23, utcMillis(2026, 1, 21))!!
+        val julLen = jul.sunsetUtcMs - jul.sunriseUtcMs
+        val janLen = jan.sunsetUtcMs - jan.sunriseUtcMs
+        assertTrue("verão do sul deve ter dia mais longo", janLen > julLen)
+    }
+
+    @Test
+    fun `noite polar retorna null`() {
+        // Ártico (lat 80) no solstício de dezembro: noite polar -> sol não nasce.
+        assertNull(SolarCalculator.calculate(80.0, 0.0, utcMillis(2026, 12, 21)))
+        // E verifica que em latitude normal NÃO é null.
+        assertNotNull(SolarCalculator.calculate(-16.62, -49.23, utcMillis(2026, 12, 21)))
+    }
+}


### PR DESCRIPTION
## O que é

Adiciona um modo de **brilho automático por nascer/pôr do sol** (opt-in) ao ajuste de brilho por horário que já existe. Em vez do corte seco em horários fixos, o brilho faz uma **transição suave** em torno do nascer/pôr do sol do local.

## Como funciona

- **Cálculo local, sem internet:** `SolarCalculator` (algoritmo NOAA) calcula nascer/pôr do sol do dia a partir de lat/lon + data. Retorna `null` em dia/noite polar.
- **Transição centrada, 1 nível por passo:** `BrightnessSchedule` interpola entre o brilho de dia e o de noite (os mesmos níveis 1–10 já configuráveis), dando **um degrau de 1 nível a cada N minutos** (padrão 5), centrado no evento. Ex.: dia 10 / noite 1 = 9 passos = 45 min (22,5 antes e 22,5 depois). Fora das rampas, mantém dia/noite.
- **Auto-corretivo:** o nível é função pura do horário atual — em todo boot/tick recalcula o valor certo pra "agora", então ligar o carro no meio da transição já aplica o degrau correto.
- **Localização:** `LocationManager` (gps/passive/network/fused) com **cache** do último lat/lon (funciona offline/garagem) e geocode da cidade em background (best-effort). Sem GPS nem cache, cai no modo horário fixo.
- **UI:** toggle "Transição por nascer/pôr do sol" dentro de "Ajustar brilho automaticamente"; ligado, esconde os horários fixos e mostra a cidade de referência + nascer/pôr do dia.

## Testes

12 testes JVM puros (`SolarCalculatorTest`, `BrightnessScheduleTest`): equador no equinócio (~6h/18h UTC), inverno/verão do hemisfério sul, noite polar → null; rampa de 1 nível por passo, monotônica, nunca pula mais de 1 nível.

**Testado em carro real: Haval H6 PHEV 34** — transição por nascer/pôr do sol funcionando (GPS detectando a cidade, nascer/pôr corretos e brilho subindo/descendo suave nos degraus).

## Notas

- `ACCESS_FINE_LOCATION` já declarado; o app concede a si mesmo via Shizuku no init.
- Mantém o modo horário fixo intacto como fallback.
