### PR TITLE
fix(carplay): stop media card cover flicker from transient blank now-playing frames

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/services/CarPlayNowPlayingMonitor.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/services/CarPlayNowPlayingMonitor.kt
@@ -38,6 +38,7 @@ class CarPlayNowPlayingMonitor(
     private var lastServiceBindAttemptAtMs = 0L
     private var lastSubscriptionAttemptAtMs = 0L
     private var lastUpdateAtMs = 0L
+    @Volatile private var lastValidNowPlayingAtMs = 0L
 
     private val connection =
             object : ServiceConnection {
@@ -319,7 +320,14 @@ class CarPlayNowPlayingMonitor(
                     } else {
                         lastUpdateAtMs = SystemClock.elapsedRealtime()
                         callbackRegistered = true
-                        publishClear("empty now playing update")
+                        // CarPlay interleaves EMPTY updates (readInt==0) with the real ones; treating
+                        // each as a clear made the media card flicker (cover <-> blank). Only clear if
+                        // the empty state persists beyond the grace window (= a real stop).
+                        if (System.currentTimeMillis() - lastValidNowPlayingAtMs >=
+                                        BLANK_NOW_PLAYING_GRACE_MS
+                        ) {
+                            publishClear("empty now playing update")
+                        }
                     }
                     true
                 }
@@ -370,9 +378,16 @@ class CarPlayNowPlayingMonitor(
             val artist = info.artist?.takeIf { it.isNotBlank() }
             val isPlaying = info.playbackStatus == PLAYBACK_STATE_PLAYING
             if (title == null && artist == null && artwork == null && !isPlaying) {
+                // CarPlay sends TRANSIENT blank frames between real ones; treating each as a "clear"
+                // made the media card flicker (cover <-> blank/icon). Only clear if the blank state
+                // persists beyond the grace window (= a real stop).
+                if (System.currentTimeMillis() - lastValidNowPlayingAtMs < BLANK_NOW_PLAYING_GRACE_MS) {
+                    return@launch
+                }
                 publishClear("blank stopped now playing update")
                 return@launch
             }
+            lastValidNowPlayingAtMs = System.currentTimeMillis()
             val update =
                     CarPlayNowPlayingUpdate(
                             title = title,
@@ -508,6 +523,8 @@ class CarPlayNowPlayingMonitor(
 
     companion object {
         private const val TAG = "CarPlayNowPlayingMonitor"
+        // Grace window to ignore CarPlay's transient blank now-playing frames.
+        private const val BLANK_NOW_PLAYING_GRACE_MS = 4_000L
         private const val CARPLAY_PACKAGE_NAME = "com.ts.carplay"
         private const val CARPLAY_SERVICE_CLASS_NAME = "com.ts.carplay.CarPlayService"
         private const val CARPLAY_SERVICE_ACTION = "com.ts.carplay.action.CarPlayService"


### PR DESCRIPTION
CarPlay interleaves **empty** now-playing updates (`readInt == 0`) and fully-**blank** frames (all fields null) in between the real ones. `CarPlayNowPlayingMonitor` treated each of these as a "clear", so the media card flickered between the album cover and the blank/icon state roughly once per second.

**Fix:** add a grace window (`BLANK_NOW_PLAYING_GRACE_MS = 4s`). A clear is only published once the empty/blank state has persisted beyond it (= a real stop), tracked via `lastValidNowPlayingAtMs`, which is refreshed on every valid update. Real track changes still apply immediately.

Scope: a single file (`CarPlayNowPlayingMonitor.kt`). Pre-existing bug, not introduced by any recent change. Verified on a real car.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
