### PR TITLE
feat(conectividade): HotRouter (roteamento do hotspot) + controle de dados móveis do carro

### DIFF
--- a/HANDOFF-BARRA-CONECTIVIDADE.md
+++ b/HANDOFF-BARRA-CONECTIVIDADE.md
@@ -1,0 +1,109 @@
+# Handoff — card de conectividade na barra estendida (companheiro deste PR)
+
+Um chip único na barra estendida que mostra, num relance, a situação de conectividade do carro:
+o **roteamento do hotspot** (do HotRouter) ou, quando o roteamento está off, **por onde a própria
+multimídia (tela) está navegando** + o estado do corte de 4G.
+
+Este PR **não inclui o card** porque a barra estendida é bem diferente entre as bases — este doc é o
+guia pra plugar na sua barra. **Nenhum dado novo é capturado:** o card só combina o que já está neste
+PR (`HotRouterManager` + `MobileDataManager` + `ServiceManager.isHotspotOnAir`).
+
+## De onde vêm os dados (tudo já neste PR)
+
+| fonte | o que dá |
+|---|---|
+| `HotRouterManager.getInstance().readStatusBlocking()` | `.mode` = OFF/STARTING/WLAN/4G/ERROR (já com o freshness: travado -> ERROR) |
+| `ServiceManager.getInstance().isHotspotOnAir()` | hotspot do carro REALMENTE no ar (carrier do sysfs; getWifiApState é -1 neste OEM) |
+| `MobileDataManager.isControlEnabled()` | controle de dados móveis ligado |
+| `MobileDataManager.blockReason(ctx)` | motivo do corte do 4G ("manual"/"consumo"/"WiFi"/"AA"/"CarPlay") ou `null` |
+| `MobileDataManager.isWifiConnected(ctx)` | a TELA está com internet ativa via WiFi |
+| `HotRouterManager.readRoutedWifiNameBlocking()` *(opcional, ver fim)* | SSID da rede (pro texto "· \<nome\>") |
+
+Tudo é **blocking/shell** → chamar **fora da main thread**.
+
+## Regra de apresentação (a mesma lógica pro chip)
+
+Função pura; devolve `(texto, nível, ícone)`. `texto == null` = esconder o card.
+
+```kotlin
+data class ConnChip(val text: String?, val level: String, val icon: String)
+
+fun buildConnChip(
+    mode: String,             // HotRouterManager.MODE_*
+    wifiName: String?,        // SSID (WLAN roteando OU tela no WiFi); null -> "WiFi"
+    controlEnabled: Boolean,  // MobileDataManager.isControlEnabled()
+    blockReason: String?,     // MobileDataManager.blockReason(ctx)
+    hotspotActive: Boolean,   // ServiceManager.getInstance().isHotspotOnAir()
+    headUnitOnWifi: Boolean   // MobileDataManager.isWifiConnected(ctx)
+): ConnChip {
+    val hotspotOn = mode == HotRouterManager.MODE_WLAN || hotspotActive
+    val blocked = blockReason != null
+    val ssid = wifiName?.takeIf { it.isNotBlank() }
+    return when {
+        // --- HotRouter roteando o hotspot: mostra o uplink do roteamento ---
+        hotspotOn && mode == HotRouterManager.MODE_WLAN     -> ConnChip("Roteando · " + (ssid ?: "WiFi"), "good", "satellite")
+        hotspotOn && mode == HotRouterManager.MODE_4G       -> ConnChip("Roteando · 4G", "warn", "cell")
+        hotspotOn && mode == HotRouterManager.MODE_STARTING -> ConnChip("Hotspot · conectando", "muted", "loader")
+        hotspotOn && mode == HotRouterManager.MODE_ERROR    -> ConnChip("Hotspot · erro", "bad", "alert")
+        // --- HotRouter off/parado: por onde a TELA navega + o corte do 4G ---
+        headUnitOnWifi            -> ConnChip("Tela · " + (ssid ?: "WiFi"), "good", "wifi")
+        controlEnabled && blocked -> ConnChip("4G off · $blockReason", "bad", "cell_off")
+        else                      -> ConnChip("Tela · 4G", "warn", "cell")
+    }
+}
+```
+
+**Por que o gate `isHotspotOnAir`:** o daemon do HotRouter reporta WLAN/4G mesmo com o hotspot do carro
+**desligado** (ele só checa o uplink). Sem o gate, o card diria "Roteando" à toa. Com o hotspot off e o
+HotRouter off, o card cai no ramo "Tela · …" e mostra a conexão real da multimídia.
+
+## Renderização
+
+- Poll **off-main** a cada ~1.5–2s **enquanto a barra está aberta** (nada em repouso).
+- Chip = ícone + texto, com cor de destaque pelo **nível**:
+  `good`=verde, `warn`=âmbar, `bad`=vermelho, `muted`=cinza.
+- Ícones sugeridos (mapear pros seus): `satellite` (roteando WLAN), `wifi` (tela no WiFi),
+  `cell` (4G), `cell_off` (4G cortado), `loader`/sync (conectando), `alert` (erro).
+
+Esboço:
+
+```kotlin
+val (text, level, icon) = withContext(Dispatchers.IO) {
+    val hr = HotRouterManager.getInstance()
+    val mode = hr.readStatusBlocking().mode
+    val onWifi = MobileDataManager.isWifiConnected(ctx)
+    val ssid = if (mode == HotRouterManager.MODE_WLAN || onWifi) hr.readRoutedWifiNameBlocking() else null
+    buildConnChip(
+        mode, ssid,
+        MobileDataManager.isControlEnabled(),
+        MobileDataManager.blockReason(ctx),
+        ServiceManager.getInstance().isHotspotOnAir(),
+        onWifi
+    ).let { Triple(it.text, it.level, it.icon) }
+}
+// desenhe `text` (se != null) com a cor de `level` e o ícone de `icon`
+```
+
+## SSID (opcional)
+
+Pro texto mostrar o nome da rede ("Roteando · Minha-Rede" / "Tela · Minha-Rede") em vez de "WiFi",
+adicione este método ao `HotRouterManager` (lê o SSID da `wlan0` via shell; neste head unit `iw`/
+`wpa_cli`/`iwconfig` voltam vazio, então o fallback confiável é o `dumpsys netstats`). Se não quiser,
+é só passar `null` como `wifiName` que o card usa "WiFi".
+
+```java
+/** SSID da Wi-Fi (wlan0) atual/roteada. null se não determinar. Chamar fora da main thread. */
+public String readRoutedWifiNameBlocking() {
+    final String IF = "wlan0"; // = WLAN_IF do hotrouter.sh
+    try {
+        String out = ShizukuUtils.runCommandAndGetOutput(new String[]{"sh","-c","iw dev "+IF+" link 2>/dev/null"});
+        for (String line : out.split("\n")) { int i = line.indexOf("SSID:"); if (i>=0){ String v=line.substring(i+5).trim(); if(!v.isEmpty()) return v; } }
+        out = ShizukuUtils.runCommandAndGetOutput(new String[]{"sh","-c","wpa_cli -i "+IF+" status 2>/dev/null"});
+        for (String line : out.split("\n")) { String t=line.trim(); if (t.startsWith("ssid=")){ String v=t.substring(5).trim(); if(!v.isEmpty()) return v; } }
+        // fallback confiável neste head unit: a rede WiFi ativa aparece no netstats como networkId="<nome>"
+        out = ShizukuUtils.runCommandAndGetOutput(new String[]{"sh","-c","dumpsys netstats 2>/dev/null | grep -m1 networkId"});
+        int n = out.indexOf("networkId=\""); if (n>=0){ int e=out.indexOf('"', n+11); if (e>n+11){ String v=out.substring(n+11,e).trim(); if(!v.isEmpty()) return v; } }
+    } catch (Exception ignored) {}
+    return null;
+}
+```

--- a/HANDOFF-BARRA-CONECTIVIDADE.md
+++ b/HANDOFF-BARRA-CONECTIVIDADE.md
@@ -36,7 +36,9 @@ fun buildConnChip(
     hotspotActive: Boolean,   // ServiceManager.getInstance().isHotspotOnAir()
     headUnitOnWifi: Boolean   // MobileDataManager.isWifiConnected(ctx)
 ): ConnChip {
-    val hotspotOn = mode == HotRouterManager.MODE_WLAN || hotspotActive
+    // CUIDADO: o daemon reporta WLAN/4G pelo UPLINK (pinga a wlan0), NÃO pelo AP -> mode==WLAN NÃO
+    // implica hotspot ligado. O gate do "Roteando" é SÓ o hotspot real (isHotspotOnAir).
+    val hotspotOn = hotspotActive
     val blocked = blockReason != null
     val ssid = wifiName?.takeIf { it.isNotBlank() }
     return when {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,9 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <!-- Contador de dados móveis do carro (NetworkStatsManager): concedidas via Shizuku no boot. -->
+    <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS" tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.READ_NETWORK_USAGE_HISTORY" tools:ignore="ProtectedPermissions" />
 
     <application
         android:name="br.com.redesurftank.App"

--- a/app/src/main/assets/hotrouter.sh
+++ b/app/src/main/assets/hotrouter.sh
@@ -1,0 +1,263 @@
+#!/system/bin/sh
+
+# hotrouter.sh
+#
+# Automatic router daemon for the multimedia hotspot.
+#
+# Goal:
+# - Prefer external WLAN (wlan0), e.g. Starlink, for hotspot clients.
+# - Fall back to OEM 4G route (vlan13) when WLAN is unavailable.
+#
+# Usage:
+#   sh hotrouter.sh start   # run the routing loop (default)
+#   sh hotrouter.sh stop    # kill the daemon and tear down all rules
+
+BASE="/data/local/tmp"
+NAME="hotrouter"
+LOG="$BASE/$NAME.log"
+PIDFILE="$BASE/$NAME.pid"
+STATEFILE="$BASE/$NAME.state"
+HOTSPOT_IF="wlan2"
+WLAN_IF="wlan0"
+WLAN_TABLE="wlan0"
+RULE_PRIO="17999"
+CHECK_HOSTS="8.8.8.8 1.1.1.1"
+INTERVAL_SEC=5
+MAX_LOG_LINES=400
+HEARTBEAT_EVERY=24
+
+log() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') [$1] $2" >> "$LOG"
+}
+
+write_state() {
+  echo "$1|$(date +%s)" > "$STATEFILE"
+}
+
+trim_log() {
+  [ -f "$LOG" ] || return
+  lines="$(wc -l < "$LOG" 2>/dev/null)"
+  [ "$lines" -gt "$MAX_LOG_LINES" ] || return
+  tail -n "$MAX_LOG_LINES" "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"
+}
+
+kill_old_hotrouters() {
+  self="$$"
+  # Kill the recorded daemon pid first. Toybox `ps` does not print script args, so a
+  # `ps | grep hotrouter.sh` sweep never matches the setsid'd daemon — the pidfile and a
+  # /proc/<pid>/cmdline scan are the only reliable ways to find it.
+  if [ -f "$PIDFILE" ]; then
+    oldpid="$(cat "$PIDFILE" 2>/dev/null)"
+    if [ -n "$oldpid" ] && [ "$oldpid" != "$self" ]; then
+      kill -9 "$oldpid" 2>/dev/null
+    fi
+  fi
+  for p in /proc/[0-9]*; do
+    pid="${p#/proc/}"
+    [ "$pid" = "$self" ] && continue
+    # Read via cat so a process exiting mid-scan (cmdline gone) is swallowed by 2>/dev/null
+    # instead of leaking a shell "can't open" error to stderr.
+    cmd="$(cat "$p/cmdline" 2>/dev/null | tr '\0' ' ')"
+    case "$cmd" in
+      *hotrouter.sh*start*) kill -9 "$pid" 2>/dev/null ;;
+    esac
+  done
+  rm -f "$PIDFILE"
+}
+
+cleanup_duplicate_rules() {
+  while ip rule | grep -q "iif $HOTSPOT_IF lookup $WLAN_TABLE"; do
+    ip rule del from all iif "$HOTSPOT_IF" lookup "$WLAN_TABLE" priority "$RULE_PRIO" 2>/dev/null || break
+  done
+}
+
+ensure_rule_once() {
+  cleanup_duplicate_rules
+  ip rule add from all iif "$HOTSPOT_IF" lookup "$WLAN_TABLE" priority "$RULE_PRIO" 2>/dev/null
+}
+
+chain_exists() {
+  iptables -nL "$1" >/dev/null 2>&1
+}
+
+nat_chain_exists() {
+  iptables -t nat -nL "$1" >/dev/null 2>&1
+}
+
+ensure_iptables() {
+  nat_chain_exists tetherctrl_nat_POSTROUTING || {
+    log ERROR "Missing NAT chain tetherctrl_nat_POSTROUTING"
+    return 1
+  }
+
+  chain_exists tetherctrl_FORWARD || {
+    log ERROR "Missing chain tetherctrl_FORWARD"
+    return 1
+  }
+
+  chain_exists tetherctrl_counters || {
+    log ERROR "Missing chain tetherctrl_counters"
+    return 1
+  }
+
+  iptables -t nat -C tetherctrl_nat_POSTROUTING -o "$WLAN_IF" -j MASQUERADE 2>/dev/null || \
+  iptables -t nat -I tetherctrl_nat_POSTROUTING 1 -o "$WLAN_IF" -j MASQUERADE
+
+  iptables -C tetherctrl_FORWARD -i "$WLAN_IF" -o "$HOTSPOT_IF" -m state --state RELATED,ESTABLISHED -g tetherctrl_counters 2>/dev/null || \
+  iptables -I tetherctrl_FORWARD 1 -i "$WLAN_IF" -o "$HOTSPOT_IF" -m state --state RELATED,ESTABLISHED -g tetherctrl_counters
+
+  iptables -C tetherctrl_FORWARD -i "$HOTSPOT_IF" -o "$WLAN_IF" -m state --state INVALID -j DROP 2>/dev/null || \
+  iptables -I tetherctrl_FORWARD 2 -i "$HOTSPOT_IF" -o "$WLAN_IF" -m state --state INVALID -j DROP
+
+  iptables -C tetherctrl_FORWARD -i "$HOTSPOT_IF" -o "$WLAN_IF" -g tetherctrl_counters 2>/dev/null || \
+  iptables -I tetherctrl_FORWARD 3 -i "$HOTSPOT_IF" -o "$WLAN_IF" -g tetherctrl_counters
+
+  iptables -C tetherctrl_counters -i "$HOTSPOT_IF" -o "$WLAN_IF" -j RETURN 2>/dev/null || \
+  iptables -I tetherctrl_counters 1 -i "$HOTSPOT_IF" -o "$WLAN_IF" -j RETURN
+
+  iptables -C tetherctrl_counters -i "$WLAN_IF" -o "$HOTSPOT_IF" -j RETURN 2>/dev/null || \
+  iptables -I tetherctrl_counters 2 -i "$WLAN_IF" -o "$HOTSPOT_IF" -j RETURN
+
+  return 0
+}
+
+teardown_iptables() {
+  while iptables -t nat -C tetherctrl_nat_POSTROUTING -o "$WLAN_IF" -j MASQUERADE 2>/dev/null; do
+    iptables -t nat -D tetherctrl_nat_POSTROUTING -o "$WLAN_IF" -j MASQUERADE 2>/dev/null || break
+  done
+
+  while iptables -C tetherctrl_FORWARD -i "$WLAN_IF" -o "$HOTSPOT_IF" -m state --state RELATED,ESTABLISHED -g tetherctrl_counters 2>/dev/null; do
+    iptables -D tetherctrl_FORWARD -i "$WLAN_IF" -o "$HOTSPOT_IF" -m state --state RELATED,ESTABLISHED -g tetherctrl_counters 2>/dev/null || break
+  done
+
+  while iptables -C tetherctrl_FORWARD -i "$HOTSPOT_IF" -o "$WLAN_IF" -m state --state INVALID -j DROP 2>/dev/null; do
+    iptables -D tetherctrl_FORWARD -i "$HOTSPOT_IF" -o "$WLAN_IF" -m state --state INVALID -j DROP 2>/dev/null || break
+  done
+
+  while iptables -C tetherctrl_FORWARD -i "$HOTSPOT_IF" -o "$WLAN_IF" -g tetherctrl_counters 2>/dev/null; do
+    iptables -D tetherctrl_FORWARD -i "$HOTSPOT_IF" -o "$WLAN_IF" -g tetherctrl_counters 2>/dev/null || break
+  done
+
+  while iptables -C tetherctrl_counters -i "$HOTSPOT_IF" -o "$WLAN_IF" -j RETURN 2>/dev/null; do
+    iptables -D tetherctrl_counters -i "$HOTSPOT_IF" -o "$WLAN_IF" -j RETURN 2>/dev/null || break
+  done
+
+  while iptables -C tetherctrl_counters -i "$WLAN_IF" -o "$HOTSPOT_IF" -j RETURN 2>/dev/null; do
+    iptables -D tetherctrl_counters -i "$WLAN_IF" -o "$HOTSPOT_IF" -j RETURN 2>/dev/null || break
+  done
+}
+
+starlink_has_ping() {
+  ip link show "$HOTSPOT_IF" >/dev/null 2>&1 || return 1
+  ip link show "$WLAN_IF" >/dev/null 2>&1 || return 1
+  ip route show table "$WLAN_TABLE" | grep -q "^default" || return 1
+
+  for host in $CHECK_HOSTS; do
+    ping -I "$WLAN_IF" -c 1 -W 2 "$host" >/dev/null 2>&1 && return 0
+  done
+
+  return 1
+}
+
+route_to_starlink() {
+  echo 1 > /proc/sys/net/ipv4/ip_forward
+  ensure_rule_once
+  ensure_iptables || return 1
+  ip route flush cache
+  return 0
+}
+
+route_to_4g() {
+  cleanup_duplicate_rules
+  ip route flush cache
+}
+
+do_stop() {
+  # kill_old_hotrouters kills the daemon via pidfile + /proc cmdline scan (toybox ps
+  # does not show script args, so a ps-based sweep can't find the setsid'd daemon).
+  kill_old_hotrouters
+  cleanup_duplicate_rules
+  teardown_iptables
+  ip route flush cache
+  write_state "OFF"
+  log INFO "Service stopped + teardown done"
+}
+
+CMD="${1:-start}"
+
+case "$CMD" in
+  stop)
+    do_stop
+    exit 0
+    ;;
+  start)
+    ;;
+  *)
+    echo "usage: $0 {start|stop}"
+    exit 1
+    ;;
+esac
+
+kill_old_hotrouters
+
+echo $$ > "$PIDFILE"
+
+trap 'rm -f "$PIDFILE"; write_state "OFF"; log INFO "Service stopped"; exit 0' INT TERM EXIT
+
+echo 1 > /proc/sys/net/ipv4/ip_forward
+
+last_mode="initial"
+tick=0
+
+log INFO "Service force-started"
+log INFO "Old hotrouter processes killed"
+log INFO "Hotspot=$HOTSPOT_IF | Starlink=$WLAN_IF | Table=$WLAN_TABLE | Ping=$CHECK_HOSTS"
+
+while true; do
+  trim_log
+
+  if starlink_has_ping; then
+    if route_to_starlink; then
+      mode="starlink"
+    else
+      # Could not apply the WLAN route (e.g. tetherctrl chains missing). Clean up
+      # any half-applied diversion rule so the hotspot genuinely falls back to 4G,
+      # keeping the reported "4G" state honest instead of leaving traffic broken.
+      route_to_4g
+      mode="broken"
+      log ERROR "Starlink has ping, but route_to_starlink failed; fell back to 4G"
+    fi
+  else
+    route_to_4g
+    mode="4g"
+  fi
+
+  case "$mode" in
+    starlink) write_state "WLAN" ;;
+    *)        write_state "4G" ;;
+  esac
+
+  if [ "$mode" != "$last_mode" ]; then
+    case "$mode" in
+      starlink)
+        log INFO "Route transition: $last_mode -> STARLINK. Hotspot forced through $WLAN_IF."
+        ;;
+      4g)
+        log WARN "Route transition: $last_mode -> 4G. Starlink ping unavailable."
+        ;;
+      broken)
+        log ERROR "Route transition: $last_mode -> BROKEN. Starlink ping OK but firewall/routing failed."
+        ;;
+    esac
+    last_mode="$mode"
+  fi
+
+  tick=$((tick + 1))
+
+  if [ "$tick" -ge "$HEARTBEAT_EVERY" ]; then
+    log INFO "Heartbeat: current_mode=$mode"
+    tick=0
+  fi
+
+  sleep "$INTERVAL_SEC"
+done

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/HotRouterManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/HotRouterManager.java
@@ -1,0 +1,245 @@
+package br.com.redesurftank.havalshisuku.managers;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.SystemClock;
+import android.util.Base64;
+import android.util.Log;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+import br.com.redesurftank.App;
+import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys;
+import br.com.redesurftank.havalshisuku.utils.ShizukuUtils;
+
+public class HotRouterManager {
+
+    private static final String TAG = "HotRouterManager";
+
+    private static final String BASE = "/data/local/tmp";
+    private static final String SCRIPT = BASE + "/hotrouter.sh";
+    private static final String PIDFILE = BASE + "/hotrouter.pid";
+    private static final String STATEFILE = BASE + "/hotrouter.state";
+    private static final String ASSET_NAME = "hotrouter.sh";
+
+    private static final String PID_ALIVE_CMD =
+            "kill -0 $(cat " + PIDFILE + " 2>/dev/null) 2>/dev/null && echo ALIVE || echo DEAD";
+
+    private static final long WATCHDOG_INTERVAL_MS = 60000L;
+    private static final long START_GRACE_MS = 20000L;
+
+    // UI-facing status modes
+    public static final String MODE_OFF = "OFF";
+    public static final String MODE_STARTING = "STARTING";
+    public static final String MODE_WLAN = "WLAN";
+    public static final String MODE_4G = "4G";
+    public static final String MODE_ERROR = "ERROR";
+    // Se o statefile não é reescrito há mais que isto, o daemon está vivo mas travado (loop pendurado):
+    // trata como ERRO em vez de mostrar o último modo congelado. O daemon reescreve a cada ~5s.
+    private static final long STALE_STATE_MAX_AGE_SEC = 30L;
+
+    public static class Status {
+        public final String mode;
+        public final long epochSeconds;
+
+        public Status(String mode, long epochSeconds) {
+            this.mode = mode;
+            this.epochSeconds = epochSeconds;
+        }
+    }
+
+    private static volatile HotRouterManager INSTANCE;
+
+    public static HotRouterManager getInstance() {
+        if (INSTANCE == null) {
+            synchronized (HotRouterManager.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = new HotRouterManager();
+                }
+            }
+        }
+        return INSTANCE;
+    }
+
+    private final SharedPreferences prefs;
+    private final Handler bgHandler;
+    private volatile boolean watchdogRunning = false;
+    private volatile long enableTimeMs = 0L;
+
+    private HotRouterManager() {
+        prefs = App.getDeviceProtectedContext().getSharedPreferences("haval_prefs", Context.MODE_PRIVATE);
+        HandlerThread thread = new HandlerThread("HotRouterThread");
+        thread.start();
+        bgHandler = new Handler(thread.getLooper());
+    }
+
+    private boolean isEnabled() {
+        return prefs.getBoolean(SharedPreferencesKeys.ENABLE_HOT_ROUTER.getKey(), false);
+    }
+
+    /** Called from the settings toggle. Persistence is done by the UI before this call. */
+    public void setEnabled(boolean enabled) {
+        if (enabled) {
+            enableTimeMs = SystemClock.elapsedRealtime();
+            bgHandler.post(() -> {
+                pushScript();
+                startDaemon();
+            });
+            startWatchdog();
+        } else {
+            bgHandler.post(this::stopDaemon);
+        }
+    }
+
+    /** Called by ForegroundService once Shizuku is ready (covers boot autostart). */
+    public void onServicesReady() {
+        if (isEnabled()) {
+            enableTimeMs = SystemClock.elapsedRealtime();
+            bgHandler.post(() -> {
+                pushScript();
+                String alive = ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c", PID_ALIVE_CMD});
+                if (!alive.contains("ALIVE")) {
+                    startDaemon();
+                }
+            });
+            startWatchdog();
+        }
+    }
+
+    private void pushScript() {
+        try {
+            String b64 = readAssetBase64();
+            if (b64.isEmpty()) {
+                Log.e(TAG, "Empty hotrouter.sh asset, aborting push");
+                return;
+            }
+            String cmd = "echo " + b64 + " | base64 -d > " + SCRIPT + " && chmod 755 " + SCRIPT;
+            ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c", cmd});
+            Log.w(TAG, "hotrouter.sh pushed to " + SCRIPT);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to push hotrouter.sh: " + e.getMessage(), e);
+        }
+    }
+
+    private String readAssetBase64() {
+        try (InputStream is = App.getContext().getAssets().open(ASSET_NAME)) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buf = new byte[4096];
+            int n;
+            while ((n = is.read(buf)) != -1) {
+                baos.write(buf, 0, n);
+            }
+            return Base64.encodeToString(baos.toByteArray(), Base64.NO_WRAP);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to read asset " + ASSET_NAME + ": " + e.getMessage(), e);
+            return "";
+        }
+    }
+
+    private void startDaemon() {
+        try {
+            // Detach with the project's proven idiom (see FridaUtils): setsid + redirect
+            // + `< /dev/null` so the daemon fully reparents and the Shizuku controlling
+            // process returns immediately (otherwise runCommandAndGetOutput's waitFor()
+            // could wedge the single HotRouterThread looper on the infinite-loop daemon).
+            String cmd = "setsid sh " + SCRIPT + " start >" + BASE + "/hotrouter.out 2>&1 < /dev/null &";
+            ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c", cmd});
+            Log.w(TAG, "hotrouter daemon start requested");
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to start hotrouter daemon: " + e.getMessage(), e);
+        }
+    }
+
+    private void stopDaemon() {
+        try {
+            ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c", "sh " + SCRIPT + " stop"});
+            Log.w(TAG, "hotrouter daemon stop requested");
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to stop hotrouter daemon: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Arms the watchdog. Posted to bgHandler so the watchdogRunning check-then-set runs
+     * on the single looper thread (no race between setEnabled and onServicesReady). The
+     * loop self-terminates the next time it finds the feature disabled.
+     */
+    private void startWatchdog() {
+        bgHandler.post(() -> {
+            if (watchdogRunning) {
+                return;
+            }
+            watchdogRunning = true;
+            bgHandler.postDelayed(watchdogRunnable, WATCHDOG_INTERVAL_MS);
+        });
+    }
+
+    private final Runnable watchdogRunnable = new Runnable() {
+        @Override
+        public void run() {
+            if (!isEnabled()) {
+                watchdogRunning = false;
+                return;
+            }
+            try {
+                String alive = ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c", PID_ALIVE_CMD});
+                if (!alive.contains("ALIVE")) {
+                    Log.w(TAG, "Watchdog: daemon dead while enabled, relaunching");
+                    enableTimeMs = SystemClock.elapsedRealtime();
+                    pushScript();
+                    startDaemon();
+                }
+            } catch (Exception e) {
+                Log.e(TAG, "Watchdog error: " + e.getMessage(), e);
+            }
+            bgHandler.postDelayed(this, WATCHDOG_INTERVAL_MS);
+        }
+    };
+
+    /**
+     * Blocking status read (runs shell via Shizuku). Call off the main thread.
+     */
+    public Status readStatusBlocking() {
+        if (!isEnabled()) {
+            return new Status(MODE_OFF, 0L);
+        }
+        String alive = ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c", PID_ALIVE_CMD});
+        if (alive.contains("ALIVE")) {
+            String raw = ShizukuUtils.runCommandAndGetOutput(
+                    new String[]{"sh", "-c", "cat " + STATEFILE + " 2>/dev/null"}).trim();
+            if (raw.isEmpty()) {
+                return new Status(MODE_STARTING, 0L);
+            }
+            String[] parts = raw.split("\\|");
+            String mode = parts[0].trim();
+            long epoch = 0L;
+            if (parts.length > 1) {
+                try {
+                    epoch = Long.parseLong(parts[1].trim());
+                } catch (NumberFormatException ignored) {
+                }
+            }
+            if (MODE_OFF.equals(mode)) {
+                return new Status(MODE_STARTING, epoch);
+            }
+            if (MODE_WLAN.equals(mode) || MODE_4G.equals(mode)) {
+                // Ligado != funcionando: se a última escrita do statefile é muito antiga, o daemon
+                // travou (vivo mas sem iterar) -> reporta ERRO em vez do modo congelado.
+                long ageSec = (System.currentTimeMillis() / 1000L) - epoch;
+                if (epoch > 0L && ageSec > STALE_STATE_MAX_AGE_SEC) {
+                    return new Status(MODE_ERROR, epoch);
+                }
+                return new Status(mode, epoch);
+            }
+            return new Status(MODE_STARTING, epoch);
+        }
+        long since = SystemClock.elapsedRealtime() - enableTimeMs;
+        if (since < START_GRACE_MS) {
+            return new Status(MODE_STARTING, 0L);
+        }
+        return new Status(MODE_ERROR, 0L);
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/MobileDataManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/MobileDataManager.kt
@@ -111,12 +111,17 @@ object MobileDataManager {
 
     @Synchronized
     private fun applyMobileData(block: Boolean) {
-        if (lastAppliedBlock == block) return
+        // BLOQUEADO: reaplica SEMPRE (não pula por memória própria). O hotspot/OEM religa o dado móvel
+        // por trás pra ter uplink; o guard antigo confiava no `lastAppliedBlock` (nossa memória), não no
+        // estado real -> o 4G vazava pro hotspot e nunca era re-cortado. `svc data disable` é idempotente
+        // no sistema, então re-emitir a cada tick (15s) / evento de tether fecha o vazamento.
+        // LIBERADO: aplica só na transição (não fica religando à toa).
+        if (!block && lastAppliedBlock == false) return
         try {
             ShizukuUtils.runCommandAndGetOutput(arrayOf("svc", "data", if (block) "disable" else "enable"))
+            val changed = lastAppliedBlock != block
             lastAppliedBlock = block
-            Log.w(TAG, "Dado movel do carro -> ${if (block) "BLOQUEADO" else "liberado"}")
-
+            if (changed) Log.w(TAG, "Dado movel do carro -> ${if (block) "BLOQUEADO" else "liberado"}")
         } catch (e: Exception) {
             Log.e(TAG, "Falha ao aplicar dado movel", e)
         }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/MobileDataManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/MobileDataManager.kt
@@ -1,0 +1,253 @@
+package br.com.redesurftank.havalshisuku.managers
+
+import android.app.usage.NetworkStatsManager
+import android.content.Context
+import android.content.SharedPreferences
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.net.TrafficStats
+import android.util.Log
+import br.com.redesurftank.App
+import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys
+import br.com.redesurftank.havalshisuku.utils.ShizukuUtils
+import java.util.Calendar
+
+/**
+ * Controle dos dados MÓVEIS (4G) do carro. O usuário roteia tudo por WiFi (Starlink/celular) e não
+ * quer que a multimídia gaste o pacote com apps em segundo plano.
+ *
+ * Modelo: um MASTER (isControlEnabled) liga/desliga todo o controle. Com ele ligado, um conjunto de
+ * REGRAS (OR) decide se o 4G da tela fica cortado — tudo converge no avaliador central
+ * [computeDesiredBlocked], que aplica `svc data disable/enable` UMA vez (só quando o estado muda):
+ *   a) manual (corta agora, independente do resto)
+ *   b) por consumo (>= teto no ciclo)
+ *   c) quando conectado ao WiFi
+ *   d) quando no Android Auto/CarPlay (projeção)
+ *
+ * Contador: uso móvel no ciclo (dia de renovação configurável) via NetworkStatsManager; fallback pra
+ * TrafficStats acumulado quando o NSM não estiver disponível. (A fatura inclui o TBOX, que a tela não
+ * mede — o contador é só a fatia da multimídia.)
+ */
+object MobileDataManager {
+    private const val TAG = "MobileDataManager"
+    private const val MB = 1024L * 1024L
+
+    private fun prefs(): SharedPreferences =
+            App.getDeviceProtectedContext().getSharedPreferences("haval_prefs", Context.MODE_PRIVATE)
+
+    // ================= Master + regras (toggles) =================
+    fun isControlEnabled(): Boolean =
+            prefs().getBoolean(SharedPreferencesKeys.MOBILE_DATA_CONTROL_ENABLED.key, false)
+    fun setControlEnabled(enabled: Boolean) = setRule(SharedPreferencesKeys.MOBILE_DATA_CONTROL_ENABLED.key, enabled)
+
+    /** (a) Bloqueio manual imediato. */
+    fun isManualBlock(): Boolean =
+            prefs().getBoolean(SharedPreferencesKeys.BLOCK_CAR_MOBILE_DATA.key, false)
+    fun setManualBlock(b: Boolean) = setRule(SharedPreferencesKeys.BLOCK_CAR_MOBILE_DATA.key, b)
+
+    /** (b) Bloqueio por consumo (>= teto no ciclo). */
+    fun isAutoblockEnabled(): Boolean =
+            prefs().getBoolean(SharedPreferencesKeys.MOBILE_DATA_AUTOBLOCK.key, false)
+    fun setAutoblockEnabled(b: Boolean) = setRule(SharedPreferencesKeys.MOBILE_DATA_AUTOBLOCK.key, b)
+
+    /** (c) Bloquear quando conectado ao WiFi. */
+    fun isBlockOnWifi(): Boolean =
+            prefs().getBoolean(SharedPreferencesKeys.MOBILE_DATA_BLOCK_ON_WIFI.key, false)
+    fun setBlockOnWifi(b: Boolean) = setRule(SharedPreferencesKeys.MOBILE_DATA_BLOCK_ON_WIFI.key, b)
+
+    /** (d) Bloquear quando no Android Auto/CarPlay. */
+    fun isBlockOnProjection(): Boolean =
+            prefs().getBoolean(SharedPreferencesKeys.MOBILE_DATA_BLOCK_ON_PROJECTION.key, false)
+    fun setBlockOnProjection(b: Boolean) = setRule(SharedPreferencesKeys.MOBILE_DATA_BLOCK_ON_PROJECTION.key, b)
+
+    private fun setRule(key: String, value: Boolean) {
+        prefs().edit().putBoolean(key, value).apply()
+        recomputeAndApply(App.getContext())
+    }
+
+    // ================= Estado de runtime (WiFi / projeção) =================
+    /** WiFi é a rede ativa (default)? No caso do carro, quando a Starlink/celular está no ar, ela é a default. */
+    fun isWifiConnected(context: Context): Boolean = try {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+        val net = cm?.activeNetwork
+        val caps = if (net != null) cm.getNetworkCapabilities(net) else null
+        caps?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+    } catch (t: Throwable) {
+        false
+    }
+
+    /** AA ou CarPlay projetando em qualquer display (main 0 ou cluster 3). */
+    fun isProjectionActive(): Boolean = try {
+        DisplayAppLauncher.isProjectionMirrorOnDisplay(0) || DisplayAppLauncher.isProjectionMirrorOnDisplay(3)
+    } catch (t: Throwable) {
+        false
+    }
+
+    // ================= Avaliador central =================
+    /** Regra que está cortando o 4G agora (pra UI), ou null se não está cortado. */
+    fun blockReason(context: Context): String? {
+        if (!isControlEnabled()) return null
+        if (isManualBlock()) return "manual"
+        if (isAutoblockEnabled() &&
+                getMobileUsedMbThisCycle(context, System.currentTimeMillis()) >= getAutoblockThresholdMb())
+            return "consumo"
+        if (isBlockOnWifi() && isWifiConnected(context)) return "WiFi"
+        if (isBlockOnProjection() && isProjectionActive()) return "AA/CarPlay"
+        return null
+    }
+
+    fun computeDesiredBlocked(context: Context): Boolean = blockReason(context) != null
+
+    @Volatile private var lastAppliedBlock: Boolean? = null
+
+    /** Reavalia todas as regras e aplica `svc data` (só se o estado desejado mudou). Boot / toggles / WiFi / periódico. */
+    fun recomputeAndApply(context: Context) {
+        try {
+            applyMobileData(computeDesiredBlocked(context))
+        } catch (e: Throwable) {
+            Log.w(TAG, "recomputeAndApply falhou: ${e.message}")
+        }
+    }
+
+    @Synchronized
+    private fun applyMobileData(block: Boolean) {
+        if (lastAppliedBlock == block) return
+        try {
+            ShizukuUtils.runCommandAndGetOutput(arrayOf("svc", "data", if (block) "disable" else "enable"))
+            lastAppliedBlock = block
+            Log.w(TAG, "Dado movel do carro -> ${if (block) "BLOQUEADO" else "liberado"}")
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Falha ao aplicar dado movel", e)
+        }
+    }
+
+    // ================= Telemetria OEM (DataTrack -> nuvem) =================
+    private const val DATATRACK_PKG = "com.beantechs.datatrackservice"
+
+    fun isDatatrackBlocked(): Boolean =
+            prefs().getBoolean(SharedPreferencesKeys.BLOCK_DATATRACK_TELEMETRY.key, false)
+
+    fun setDatatrackBlocked(blocked: Boolean) {
+        prefs().edit().putBoolean(SharedPreferencesKeys.BLOCK_DATATRACK_TELEMETRY.key, blocked).apply()
+        applyDatatrackState()
+    }
+
+    /**
+     * Congela/reativa o servico OEM de telemetria (com.beantechs.datatrackservice -> nuvem) via Shizuku.
+     * Reversivel (pm enable). NAO toca no remoto/OTA (operatorcenter/tbox). Reaplicado no boot.
+     */
+    fun applyDatatrackState() {
+        val block = isDatatrackBlocked()
+        try {
+            if (block) {
+                ShizukuUtils.runCommandAndGetOutput(arrayOf("am", "force-stop", DATATRACK_PKG))
+                ShizukuUtils.runCommandAndGetOutput(arrayOf("pm", "disable-user", "--user", "0", DATATRACK_PKG))
+            } else {
+                ShizukuUtils.runCommandAndGetOutput(arrayOf("pm", "enable", DATATRACK_PKG))
+            }
+            Log.w(TAG, "Telemetria DataTrack -> ${if (block) "CONGELADA" else "reativada"}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Falha ao aplicar estado do DataTrack", e)
+        }
+    }
+
+    // ================= Config (teto / ciclo) =================
+    fun getCycleDay(): Int =
+            prefs().getInt(SharedPreferencesKeys.MOBILE_DATA_CYCLE_DAY.key, 1).coerceIn(1, 31)
+    /** Teto absoluto (MB) da MULTIMÍDIA (esta tela) em que o auto-bloqueio dispara (default 2 GB). */
+    fun getAutoblockCapMb(): Int =
+            prefs().getInt(SharedPreferencesKeys.MOBILE_DATA_AUTOBLOCK_CAP_MB.key, 2048).coerceAtLeast(0)
+    /**
+     * Limiar do auto-bloqueio = teto absoluto da tela. NÃO é % da linha: o eSIM fica no TBOX e a
+     * multimídia é só um dos consumidores (via vlan13); a fatura inclui o TBOX, que a tela não mede.
+     */
+    fun getAutoblockThresholdMb(): Int = getAutoblockCapMb()
+
+    // ================= Ciclo (dia de renovação configurável) =================
+    /** Início do ciclo atual (dia de renovação, 00:00), em millis. */
+    fun getCycleStartMillis(nowMillis: Long): Long {
+        val day = getCycleDay()
+        val cal = Calendar.getInstance()
+        cal.timeInMillis = nowMillis
+        val today = cal.get(Calendar.DAY_OF_MONTH)
+        // se hoje ainda nao chegou no dia de renovacao, o ciclo comecou no mes passado
+        if (today < day) cal.add(Calendar.MONTH, -1)
+        val maxDay = cal.getActualMaximum(Calendar.DAY_OF_MONTH) // ex.: dia 31 em fev -> ultimo dia
+        cal.set(Calendar.DAY_OF_MONTH, minOf(day, maxDay))
+        cal.set(Calendar.HOUR_OF_DAY, 0)
+        cal.set(Calendar.MINUTE, 0)
+        cal.set(Calendar.SECOND, 0)
+        cal.set(Calendar.MILLISECOND, 0)
+        return cal.timeInMillis
+    }
+
+    /** Tag do ciclo (ex.: "2026-7"), pra saber quando resetar o acumulador do fallback. */
+    fun getCycleTag(nowMillis: Long): String {
+        val cal = Calendar.getInstance()
+        cal.timeInMillis = getCycleStartMillis(nowMillis)
+        return "${cal.get(Calendar.YEAR)}-${cal.get(Calendar.MONTH) + 1}"
+    }
+
+    // ================= Uso =================
+    /** Bytes moveis usados no ciclo. NetworkStatsManager (por range); fallback TrafficStats acumulado. */
+    fun getMobileUsedBytesThisCycle(context: Context, nowMillis: Long): Long {
+        val start = getCycleStartMillis(nowMillis)
+        try {
+            val nsm = context.getSystemService(Context.NETWORK_STATS_SERVICE) as? NetworkStatsManager
+            if (nsm != null) {
+                val bucket = nsm.querySummaryForDevice(
+                        ConnectivityManager.TYPE_MOBILE, null, start, nowMillis)
+                if (bucket != null) {
+                    val total = bucket.rxBytes + bucket.txBytes
+                    if (total >= 0) return total
+                }
+            }
+        } catch (e: Throwable) {
+            Log.w(TAG, "NetworkStatsManager indisponivel (${e.message}); fallback TrafficStats")
+        }
+        return getTrafficStatsAccumBytes(nowMillis)
+    }
+
+    fun getMobileUsedMbThisCycle(context: Context, nowMillis: Long): Long =
+            getMobileUsedBytesThisCycle(context, nowMillis) / MB
+
+    /** Acumula deltas do TrafficStats movel entre chamadas (robusto a reboot), resetando por ciclo. */
+    @Synchronized
+    fun getTrafficStatsAccumBytes(nowMillis: Long): Long {
+        val p = prefs()
+        val cycleTag = getCycleTag(nowMillis)
+        var accum = p.getLong(SharedPreferencesKeys.MOBILE_DATA_TRAFFIC_ACCUM_BYTES.key, 0L)
+        var last = p.getLong(SharedPreferencesKeys.MOBILE_DATA_TRAFFIC_LAST_READING.key, -1L)
+        if (p.getString(SharedPreferencesKeys.MOBILE_DATA_TRAFFIC_CYCLE_TAG.key, "") != cycleTag) {
+            accum = 0L
+            last = -1L
+        }
+        val rx = TrafficStats.getMobileRxBytes()
+        val tx = TrafficStats.getMobileTxBytes()
+        val current = if (rx < 0 || tx < 0) -1L else rx + tx // UNSUPPORTED em alguns aparelhos
+        if (current >= 0) {
+            if (last in 0..current) accum += (current - last) // delta normal
+            else if (last > current) accum += current // reboot (contador do SO zerou)
+            last = current
+        }
+        p.edit()
+                .putString(SharedPreferencesKeys.MOBILE_DATA_TRAFFIC_CYCLE_TAG.key, cycleTag)
+                .putLong(SharedPreferencesKeys.MOBILE_DATA_TRAFFIC_ACCUM_BYTES.key, accum)
+                .putLong(SharedPreferencesKeys.MOBILE_DATA_TRAFFIC_LAST_READING.key, last)
+                .apply()
+        return accum
+    }
+
+    /** Concede a permissao de uso de rede via Shizuku (pro NetworkStatsManager). Best-effort. */
+    fun ensureUsageStatsPermission(context: Context) {
+        try {
+            val pkg = context.packageName
+            ShizukuUtils.runCommandAndGetOutput(arrayOf("appops", "set", pkg, "GET_USAGE_STATS", "allow"))
+            ShizukuUtils.runCommandAndGetOutput(arrayOf("pm", "grant", pkg, "android.permission.PACKAGE_USAGE_STATS"))
+            ShizukuUtils.runCommandAndGetOutput(arrayOf("pm", "grant", pkg, "android.permission.READ_NETWORK_USAGE_HISTORY"))
+        } catch (e: Exception) {
+            Log.w(TAG, "ensureUsageStatsPermission: ${e.message}")
+        }
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -221,6 +221,7 @@ public class ServiceManager {
     private volatile Runnable mobileDataAutoblockRunnable;
     private static final long MOBILE_DATA_CHECK_MS = 15 * 1000L; // 15s: pega consumo/WiFi/projeção
     private android.net.ConnectivityManager.NetworkCallback mobileDataWifiCallback;
+    private BroadcastReceiver mobileDataTetherReceiver;
     // Monitor periódico do % do HEV Prioritário: reaplica o valor salvo mesmo se algum evento
     // (power-on/entrar no modo/carro resetar) tiver sido perdido — ex.: app subiu tarde no boot.
     private static final long HEV_SOC_MONITOR_INTERVAL_MS = 30000L;
@@ -2801,6 +2802,7 @@ public class ServiceManager {
             MobileDataManager.INSTANCE.recomputeAndApply(ctx); // aplica as regras salvas no boot
             MobileDataManager.INSTANCE.applyDatatrackState(); // reaplica o congelamento do datatrack salvo no boot
             registerMobileDataWifiCallback(ctx); // reavalia na hora quando o WiFi conecta/cai
+            registerMobileDataTetherReceiver(ctx); // reforça o bloqueio na hora que o hotspot liga/desliga
         } catch (Throwable t) {
             Log.w(TAG, "initMobileDataGuard: " + t.getMessage());
         }
@@ -2842,6 +2844,27 @@ public class ServiceManager {
             cm.registerNetworkCallback(req, mobileDataWifiCallback);
         } catch (Throwable t) {
             Log.w(TAG, "registerMobileDataWifiCallback: " + t.getMessage());
+        }
+    }
+
+    // Hotspot (tether) ligou/desligou -> reforça o bloqueio NA HORA. O hotspot religa o dado móvel pra
+    // ter uplink; sem este gatilho, o vazamento ficaria aberto até o próximo tick de 15s. O broadcast
+    // android.net.conn.TETHER_STATE_CHANGED não é protegido (qualquer app registra).
+    private void registerMobileDataTetherReceiver(android.content.Context ctx) {
+        try {
+            if (mobileDataTetherReceiver != null) return;
+            mobileDataTetherReceiver = new BroadcastReceiver() {
+                @Override public void onReceive(Context c, Intent i) {
+                    try {
+                        MobileDataManager.INSTANCE.recomputeAndApply(App.getContext());
+                    } catch (Throwable ignored) {
+                    }
+                }
+            };
+            ctx.registerReceiver(mobileDataTetherReceiver,
+                    new IntentFilter("android.net.conn.TETHER_STATE_CHANGED"));
+        } catch (Throwable t) {
+            Log.w(TAG, "registerMobileDataTetherReceiver: " + t.getMessage());
         }
     }
 }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -217,6 +217,10 @@ public class ServiceManager {
     private Boolean closeSunroofDueToeSpeed = false;
     private HandlerThread handlerThread;
     private Handler backgroundHandler;
+    // ===== Dados móveis do carro (controle: master + regras) =====
+    private volatile Runnable mobileDataAutoblockRunnable;
+    private static final long MOBILE_DATA_CHECK_MS = 15 * 1000L; // 15s: pega consumo/WiFi/projeção
+    private android.net.ConnectivityManager.NetworkCallback mobileDataWifiCallback;
     // Monitor periódico do % do HEV Prioritário: reaplica o valor salvo mesmo se algum evento
     // (power-on/entrar no modo/carro resetar) tiver sido perdido — ex.: app subiu tarde no boot.
     private static final long HEV_SOC_MONITOR_INTERVAL_MS = 30000L;
@@ -760,6 +764,7 @@ public class ServiceManager {
             ShizukuUtils.runCommandAndGetOutput(new String[]{"pm", "grant", context.getPackageName(), "android.permission.WRITE_SECURE_SETTINGS"});
             controlService.registerDataChangedListener(context.getPackageName(), listener);
             controlService.addListenerKey(App.getContext().getPackageName(), getCombinedKeys());
+            initMobileDataGuard();
 
             IBinder rawConnectivityBinder = getSystemService(Context.CONNECTIVITY_SERVICE);
             if (rawConnectivityBinder != null) {
@@ -2175,6 +2180,29 @@ public class ServiceManager {
         return wifiTetherEnabled;
     }
 
+    // Estado real "no ar" do SoftAP pelo sysfs (lido via Shizuku=shell, que consegue ler sysfs_net).
+    // "1"=no ar (beaconando), "0"=iface up mas sem BSS (quebrado/meio-ligado), ""=desconhecido/down.
+    private String softApCarrier() {
+        try {
+            String out = ShizukuUtils.runCommandAndGetOutput(new String[]{"sh", "-c",
+                    "i=$(getprop sys.wifi.softap_interface_name); [ -z \"$i\" ] && i=wlan2; cat /sys/class/net/$i/carrier 2>/dev/null"});
+            if (out != null) {
+                String v = out.trim();
+                if (v.equals("1") || v.equals("0")) return v;
+            }
+        } catch (Throwable ignored) {
+        }
+        return "";
+    }
+
+    // Hotspot (Wi-Fi AP) REALMENTE no ar? Prefere o carrier do sysfs (real, via wlan2); em OEMs onde o
+    // getWifiApState() retorna -1, cai pro cache do receiver WIFI_AP_STATE_CHANGED. Usado pelo status do
+    // HotRouter pra não mostrar "Ativo" com o hotspot desligado (o daemon reporta WLAN/4G de qualquer jeito).
+    public boolean isHotspotOnAir() {
+        String carrier = softApCarrier();
+        return "1".equals(carrier) || (carrier.isEmpty() && currentWifiTetherState());
+    }
+
     // Desliga o BT salvando que estava ligado (p/ religar no próximo power-on). Não sobrescreve um
     // "estava ligado" anterior com false (caso recolher-retrovisor + power-off no mesmo ciclo).
     private void shutdownBluetoothForRestore() {
@@ -2764,5 +2792,56 @@ public class ServiceManager {
 
     public SharedPreferences getSharedPreferences() {
         return sharedPreferences;
+    }
+
+    private void initMobileDataGuard() {
+        try {
+            android.content.Context ctx = App.getContext();
+            MobileDataManager.INSTANCE.ensureUsageStatsPermission(ctx); // pro NetworkStatsManager (best-effort)
+            MobileDataManager.INSTANCE.recomputeAndApply(ctx); // aplica as regras salvas no boot
+            MobileDataManager.INSTANCE.applyDatatrackState(); // reaplica o congelamento do datatrack salvo no boot
+            registerMobileDataWifiCallback(ctx); // reavalia na hora quando o WiFi conecta/cai
+        } catch (Throwable t) {
+            Log.w(TAG, "initMobileDataGuard: " + t.getMessage());
+        }
+        if (backgroundHandler == null || mobileDataAutoblockRunnable != null) return;
+        mobileDataAutoblockRunnable = new Runnable() {
+            @Override public void run() {
+                try {
+                    MobileDataManager.INSTANCE.recomputeAndApply(App.getContext());
+                } catch (Throwable ignored) {
+                } finally {
+                    if (backgroundHandler != null && mobileDataAutoblockRunnable == this) {
+                        backgroundHandler.postDelayed(this, MOBILE_DATA_CHECK_MS);
+                    }
+                }
+            }
+        };
+        backgroundHandler.postDelayed(mobileDataAutoblockRunnable, MOBILE_DATA_CHECK_MS);
+    }
+
+    // Callback de WiFi: quando conecta/cai, reavalia as regras na hora (a regra "bloquear no WiFi"
+    // precisa reagir rápido; o periódico de 15s é só a rede de segurança pra consumo/projeção).
+    private void registerMobileDataWifiCallback(android.content.Context ctx) {
+        try {
+            if (mobileDataWifiCallback != null) return;
+            android.net.ConnectivityManager cm =
+                    (android.net.ConnectivityManager) ctx.getSystemService(Context.CONNECTIVITY_SERVICE);
+            if (cm == null) return;
+            android.net.NetworkRequest req = new android.net.NetworkRequest.Builder()
+                    .addTransportType(android.net.NetworkCapabilities.TRANSPORT_WIFI)
+                    .build();
+            mobileDataWifiCallback = new android.net.ConnectivityManager.NetworkCallback() {
+                @Override public void onAvailable(android.net.Network network) {
+                    MobileDataManager.INSTANCE.recomputeAndApply(App.getContext());
+                }
+                @Override public void onLost(android.net.Network network) {
+                    MobileDataManager.INSTANCE.recomputeAndApply(App.getContext());
+                }
+            };
+            cm.registerNetworkCallback(req, mobileDataWifiCallback);
+        } catch (Throwable t) {
+            Log.w(TAG, "registerMobileDataWifiCallback: " + t.getMessage());
+        }
     }
 }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -328,5 +328,18 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
             "Reconectar automaticamente o Ambient Light"
     ),
     ENABLE_PERSIST_HEV_SOC_TARGET("enablePersistHevSocTarget", "Manter o % de bateria escolhido no HEV Prioritário"),
-    HEV_SOC_TARGET_VALUE("hevSocTargetValue", "% de bateria a manter no HEV Prioritário (20-80)")
+    HEV_SOC_TARGET_VALUE("hevSocTargetValue", "% de bateria a manter no HEV Prioritário (20-80)"),
+    ENABLE_HOT_ROUTER("enableHotRouter", "Roteia o hotspot pelo 4G ou WLAN (Starlink) quando disponível"),
+    // ===== Controle de dados móveis do carro =====
+    MOBILE_DATA_CONTROL_ENABLED("mobileDataControlEnabled", "Master: ativa o controle de dados móveis do carro"),
+    BLOCK_CAR_MOBILE_DATA("blockCarMobileData", "Bloquear dados móveis do carro (usar só WiFi/Starlink)"),
+    MOBILE_DATA_AUTOBLOCK("mobileDataAutoblock", "Bloquear dados móveis automaticamente perto do limite"),
+    MOBILE_DATA_AUTOBLOCK_CAP_MB("mobileDataAutoblockCapMb", "Teto de dados da multimídia p/ auto-bloqueio (MB)"),
+    MOBILE_DATA_BLOCK_ON_WIFI("mobileDataBlockOnWifi", "Bloquear dados móveis quando conectado ao WiFi"),
+    MOBILE_DATA_BLOCK_ON_PROJECTION("mobileDataBlockOnProjection", "Bloquear dados móveis quando no Android Auto/CarPlay"),
+    MOBILE_DATA_CYCLE_DAY("mobileDataCycleDay", "Dia de renovação do pacote de dados (1-31)"),
+    BLOCK_DATATRACK_TELEMETRY("blockDatatrackTelemetry", "Congelar telemetria OEM DataTrack (envio pra nuvem)"),
+    MOBILE_DATA_TRAFFIC_ACCUM_BYTES("mobileDataTrafficAccumBytes", "Acumulado de bytes móveis no ciclo (fallback TrafficStats)"),
+    MOBILE_DATA_TRAFFIC_LAST_READING("mobileDataTrafficLastReading", "Última leitura do TrafficStats móvel (controle interno)"),
+    MOBILE_DATA_TRAFFIC_CYCLE_TAG("mobileDataTrafficCycleTag", "Ciclo atual do acumulador de bytes (controle interno)")
 }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
@@ -40,6 +40,7 @@ import br.com.redesurftank.havalshisuku.managers.AndroidAutoPatchManager;
 import br.com.redesurftank.havalshisuku.managers.CarPlayPatchManager;
 import br.com.redesurftank.havalshisuku.managers.DisplayAppLauncher;
 import br.com.redesurftank.havalshisuku.managers.ServiceManager;
+import br.com.redesurftank.havalshisuku.managers.HotRouterManager;
 import br.com.redesurftank.havalshisuku.models.CommandListener;
 import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys;
 import br.com.redesurftank.havalshisuku.utils.IPTablesUtils;
@@ -679,6 +680,12 @@ public class ForegroundService extends Service implements Shizuku.OnBinderDeadLi
                 Log.e(TAG, "Projection patch auto-mount check failed: " + e.getMessage(), e);
             }
         });
+
+        try {
+            HotRouterManager.getInstance().onServicesReady();
+        } catch (Exception e) {
+            Log.e(TAG, "Error starting HotRouter: " + e.getMessage(), e);
+        }
 
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction("com.beantechs.intelligentvehiclecontrol.INIT_COMPLETED");

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -32,6 +32,18 @@ import br.com.redesurftank.havalshisuku.models.SteeringWheelCustomActionType
 import br.com.redesurftank.havalshisuku.ui.components.AppColors
 import br.com.redesurftank.havalshisuku.ui.components.SettingItem
 import br.com.redesurftank.havalshisuku.ui.components.TwoColumnSettingsLayout
+import br.com.redesurftank.havalshisuku.managers.HotRouterManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// HotRouter: formata o epoch do statefile em HH:mm:ss.
+private fun formatHms(epochSeconds: Long): String {
+        return SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(Date(epochSeconds * 1000L))
+}
 
 // Seletor reutilizavel de acao do volante (usado p/ toque curto / duplo / longo de cada botao).
 @OptIn(ExperimentalMaterial3Api::class)
@@ -691,8 +703,207 @@ fun BasicSettingsTab() {
                         prefs.getInt(SharedPreferencesKeys.HEV_SOC_TARGET_VALUE.key, 50)
                 )
         }
+        var enableHotRouter by remember {
+                mutableStateOf(prefs.getBoolean(SharedPreferencesKeys.ENABLE_HOT_ROUTER.key, false))
+        }
+        // ===== Controle de dados móveis do carro (master + regras) =====
+        val mdm = br.com.redesurftank.havalshisuku.managers.MobileDataManager
+        var mobileControlEnabled by remember { mutableStateOf(mdm.isControlEnabled()) }
+        var mobileManualBlock by remember { mutableStateOf(mdm.isManualBlock()) }
+        var mobileAutoblock by remember { mutableStateOf(mdm.isAutoblockEnabled()) }
+        var mobileBlockOnWifi by remember { mutableStateOf(mdm.isBlockOnWifi()) }
+        var mobileBlockOnProjection by remember { mutableStateOf(mdm.isBlockOnProjection()) }
+        var mobileDataCycleDay by remember {
+                mutableIntStateOf(prefs.getInt(SharedPreferencesKeys.MOBILE_DATA_CYCLE_DAY.key, 1).coerceIn(1, 31))
+        }
+        var mobileDataAutoblockCapMb by remember {
+                mutableIntStateOf(prefs.getInt(SharedPreferencesKeys.MOBILE_DATA_AUTOBLOCK_CAP_MB.key, 2048).coerceIn(512, 8192))
+        }
+        var blockDatatrack by remember { mutableStateOf(mdm.isDatatrackBlocked()) }
+        var mobileDataUsedMb by remember { mutableStateOf(0L) }
+        var mobileBlockReason by remember { mutableStateOf<String?>(null) }
+        LaunchedEffect(mobileControlEnabled, mobileDataCycleDay) {
+                while (true) {
+                        val ctx = br.com.redesurftank.App.getContext()
+                        mobileDataUsedMb = withContext(Dispatchers.IO) {
+                                mdm.getMobileUsedMbThisCycle(ctx, System.currentTimeMillis())
+                        }
+                        mobileBlockReason = withContext(Dispatchers.IO) { mdm.blockReason(ctx) }
+                        delay(10000)
+                }
+        }
 
         val settingsList = mutableListOf<SettingItem>()
+
+        // HotRouter: roteia o hotspot pela WLAN externa (Starlink) com fallback pro 4G.
+        settingsList.add(
+                SettingItem(
+                        title = "HotRouter",
+                        description = SharedPreferencesKeys.ENABLE_HOT_ROUTER.description,
+                        checked = enableHotRouter,
+                        onCheckedChange = {
+                                enableHotRouter = it
+                                prefs.edit {
+                                        putBoolean(SharedPreferencesKeys.ENABLE_HOT_ROUTER.key, it)
+                                }
+                                HotRouterManager.getInstance().setEnabled(it)
+                        },
+                        customContent =
+                                if (enableHotRouter) {
+                                        {
+                                                var statusMode by remember { mutableStateOf(HotRouterManager.MODE_STARTING) }
+                                                var statusEpoch by remember { mutableStateOf(0L) }
+                                                // Hotspot do carro REALMENTE no ar: o daemon reporta WLAN/4G mesmo com o
+                                                // hotspot desligado; sem isto o status mostrava "Ativo" à toa.
+                                                var hotspotOnAir by remember { mutableStateOf(true) }
+                                                LaunchedEffect(Unit) {
+                                                        while (true) {
+                                                                val s = withContext(Dispatchers.IO) {
+                                                                        HotRouterManager.getInstance().readStatusBlocking()
+                                                                }
+                                                                statusMode = s.mode
+                                                                statusEpoch = s.epochSeconds
+                                                                hotspotOnAir = withContext(Dispatchers.IO) {
+                                                                        try { ServiceManager.getInstance().isHotspotOnAir() } catch (t: Throwable) { true }
+                                                                }
+                                                                delay(3000)
+                                                        }
+                                                }
+                                                val label = when {
+                                                        statusMode == HotRouterManager.MODE_OFF -> "Desligado"
+                                                        statusMode == HotRouterManager.MODE_STARTING -> "Iniciando…"
+                                                        statusMode == HotRouterManager.MODE_ERROR -> "Erro"
+                                                        // Daemon rodando (WLAN/4G) mas hotspot fora do ar: não há o que rotear.
+                                                        !hotspotOnAir -> "Ligado (sem hotspot)"
+                                                        statusMode == HotRouterManager.MODE_WLAN -> "Ativo (WLAN)"
+                                                        statusMode == HotRouterManager.MODE_4G -> "Ativo (4G)"
+                                                        else -> "—"
+                                                }
+                                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                                        HorizontalDivider(color = Color(0xFF3A3F47), thickness = 1.dp)
+                                                        Text(text = "Status: $label", color = Color.White, fontSize = 16.sp)
+                                                        if (statusEpoch > 0L) {
+                                                                Text(text = "atualizado ${formatHms(statusEpoch)}", color = Color(0xFFB0B8C4), fontSize = 12.sp)
+                                                        }
+                                                }
+                                        }
+                                } else null
+                )
+        )
+
+        // Controle de dados móveis do carro (master + 4 regras). Roteia por WiFi/Starlink e corta o 4G.
+        settingsList.add(
+                SettingItem(
+                        title = "Controle de dados móveis",
+                        description =
+                                "Liga o gerenciamento do 4G da multimídia. Com ele ligado, escolha abaixo QUANDO cortar o 4G. Desligado = 4G livre (nada é bloqueado).",
+                        checked = mobileControlEnabled,
+                        onCheckedChange = {
+                                mobileControlEnabled = it
+                                mdm.setControlEnabled(it)
+                        },
+                        customContent = {
+                                Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+                                        val reason = mobileBlockReason
+                                        Text(
+                                                if (reason != null) "4G agora: BLOQUEADO ($reason)" else "4G agora: LIBERADO",
+                                                color = if (reason != null) Color(0xFFE53935) else Color(0xFF34C759),
+                                                fontSize = 15.sp
+                                        )
+                                        Text(
+                                                String.format("Multimídia (esta tela): %.2f GB neste ciclo", mobileDataUsedMb / 1024f),
+                                                color = AppColors.TextSecondary,
+                                                fontSize = 13.sp,
+                                                modifier = Modifier.padding(top = 4.dp)
+                                        )
+                                        Row(
+                                                modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                                                verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                                Text("Bloquear manualmente agora", color = AppColors.TextPrimary, fontSize = 14.sp, modifier = Modifier.weight(1f))
+                                                Switch(checked = mobileManualBlock, onCheckedChange = { mobileManualBlock = it; mdm.setManualBlock(it) })
+                                        }
+                                        Text("Corta o 4G na hora, independente do resto.", color = AppColors.TextSecondary, fontSize = 12.sp)
+                                        Row(
+                                                modifier = Modifier.fillMaxWidth().padding(top = 14.dp),
+                                                verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                                Text("Bloquear conforme o gasto", color = AppColors.TextPrimary, fontSize = 14.sp, modifier = Modifier.weight(1f))
+                                                Switch(checked = mobileAutoblock, onCheckedChange = { mobileAutoblock = it; mdm.setAutoblockEnabled(it) })
+                                        }
+                                        if (mobileAutoblock) {
+                                                val usedGb = mobileDataUsedMb / 1024f
+                                                val capGb = mobileDataAutoblockCapMb / 1024f
+                                                val remainingGb = (capGb - usedGb).coerceAtLeast(0f)
+                                                Text(
+                                                        String.format("Bloquear ao passar de %.1f GB — faltam %.2f GB", capGb, remainingGb),
+                                                        color = AppColors.TextSecondary, fontSize = 12.sp, modifier = Modifier.padding(top = 2.dp)
+                                                )
+                                                Slider(
+                                                        value = (mobileDataAutoblockCapMb / 1024f).coerceIn(0.5f, 8f),
+                                                        onValueChange = {
+                                                                val gb = Math.round(it * 2f) / 2f
+                                                                mobileDataAutoblockCapMb = (gb * 1024).toInt().coerceIn(512, 8192)
+                                                        },
+                                                        onValueChangeFinished = {
+                                                                prefs.edit { putInt(SharedPreferencesKeys.MOBILE_DATA_AUTOBLOCK_CAP_MB.key, mobileDataAutoblockCapMb) }
+                                                        },
+                                                        valueRange = 0.5f..8f,
+                                                        steps = 14
+                                                )
+                                                Text("Zera a contagem no dia $mobileDataCycleDay do mês", color = AppColors.TextSecondary, fontSize = 12.sp)
+                                                Slider(
+                                                        value = mobileDataCycleDay.toFloat(),
+                                                        onValueChange = { mobileDataCycleDay = it.toInt().coerceIn(1, 31) },
+                                                        onValueChangeFinished = {
+                                                                prefs.edit { putInt(SharedPreferencesKeys.MOBILE_DATA_CYCLE_DAY.key, mobileDataCycleDay) }
+                                                        },
+                                                        valueRange = 1f..31f,
+                                                        steps = 29
+                                                )
+                                        } else {
+                                                Text("Bloqueia sozinho só quando a tela atinge o teto (GB) no ciclo.", color = AppColors.TextSecondary, fontSize = 12.sp)
+                                        }
+                                        Row(
+                                                modifier = Modifier.fillMaxWidth().padding(top = 14.dp),
+                                                verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                                Text("Bloquear quando conectado ao WiFi", color = AppColors.TextPrimary, fontSize = 14.sp, modifier = Modifier.weight(1f))
+                                                Switch(checked = mobileBlockOnWifi, onCheckedChange = { mobileBlockOnWifi = it; mdm.setBlockOnWifi(it) })
+                                        }
+                                        Text("Com WiFi/Starlink no ar, desliga o 4G; volta quando o WiFi cai.", color = AppColors.TextSecondary, fontSize = 12.sp)
+                                        Row(
+                                                modifier = Modifier.fillMaxWidth().padding(top = 14.dp),
+                                                verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                                Text("Bloquear no Android Auto/CarPlay", color = AppColors.TextPrimary, fontSize = 14.sp, modifier = Modifier.weight(1f))
+                                                Switch(checked = mobileBlockOnProjection, onCheckedChange = { mobileBlockOnProjection = it; mdm.setBlockOnProjection(it) })
+                                        }
+                                        Text("Enquanto o celular estiver projetando, o 4G do carro fica desligado.", color = AppColors.TextSecondary, fontSize = 12.sp)
+                                        Text(
+                                                "A fatura da linha é maior: inclui o TBOX (não passa pela tela e não é medido aqui).",
+                                                color = AppColors.TextSecondary,
+                                                fontSize = 12.sp,
+                                                modifier = Modifier.padding(top = 12.dp)
+                                        )
+                                }
+                        }
+                )
+        )
+
+        // Congelar a telemetria OEM (DataTrack -> nuvem). Reversível; não afeta o comando remoto.
+        settingsList.add(
+                SettingItem(
+                        title = "Bloquear telemetria (DataTrack → nuvem)",
+                        description =
+                                "Congela o serviço OEM que manda telemetria pra nuvem (com.beantechs.datatrackservice). Reversível; não mexe no comando remoto.",
+                        checked = blockDatatrack,
+                        onCheckedChange = {
+                                blockDatatrack = it
+                                mdm.setDatatrackBlocked(it)
+                        }
+                )
+        )
 
         settingsList.add(
                 SettingItem(


### PR DESCRIPTION
Dois recursos de conectividade do carro, **opt-in (default OFF)** e controlados pela tela de **Configurações**.

## HotRouter (roteamento do hotspot) — re-propõe o #90
Roteia o hotspot do carro por uma **WLAN externa** (ex.: Starlink) e cai **automaticamente pro 4G** quando a WLAN some. Daemon em shell (`hotrouter.sh`) tocado via Shizuku; toggle com **status ao vivo** (WLAN / 4G / iniciando / erro).

*(O #90 foi fechado; aqui ele vem junto com o controle de dados móveis. Dá pra revisar/mergear em partes se preferir.)*

## Controle de dados móveis
Pra quem roteia tudo por WiFi/Starlink e não quer que a multimídia gaste o pacote (SIM própria, pacote pequeno) com apps em segundo plano. Um **master** liga/desliga; com ele ligado, **regras (OR)** decidem quando cortar o 4G da tela (`svc data disable`):
- **manual** — corta agora;
- **por consumo** — `>=` teto em GB no ciclo (contador via `NetworkStatsManager`, fallback `TrafficStats`; dia de renovação configurável);
- **no WiFi** — callback de rede, reage na hora;
- **no Android Auto/CarPlay** — projeção.

Avaliador central reaplica no boot + tick de 15s. Inclui um toggle pra **congelar a telemetria OEM** (`com.beantechs.datatrackservice`) via `pm disable-user` — reversível, não afeta o comando remoto.

## Notas
- Permissões concedidas via Shizuku no boot: `PACKAGE_USAGE_STATS` + `READ_NETWORK_USAGE_HISTORY`.
- Tudo default OFF; nada muda pra quem não ligar.
- `./gradlew :app:compileReleaseJavaWithJavac` — BUILD SUCCESSFUL. Rodando no meu carro.

8 arquivos, +1035 linhas.

---

## Atualização — refinamentos do status + card da barra (handoff)

Empurrei **dois refinamentos no status do HotRouter** (no commit da feature):
- **Freshness:** "Ativo (WLAN/4G)" só aparece se o daemon estiver de fato iterando — o statefile é reescrito a cada ~5s; parado por >30s (daemon vivo mas travado) vira **"Erro"** em vez de congelar no último modo.
- **Hotspot real:** o daemon reporta WLAN/4G mesmo com o hotspot do carro **desligado** (ele só checa o uplink). Agora o status confere se o AP está de fato no ar — `ServiceManager.isHotspotOnAir()` lê o *carrier* do sysfs do `wlan2` (o `getWifiApState()` retorna -1 neste OEM) — e mostra **"Ligado (sem hotspot)"** quando não há o que rotear.

E adicionei o doc **`HANDOFF-BARRA-CONECTIVIDADE.md`** (commit `docs:`): um guia pra, **opcionalmente**, plugar um **card único de conectividade na barra estendida** que combina esses mesmos dados (HotRouter + controle de dados móveis + hotspot real) num texto/cor/ícone só. O card em si **não entra no código do PR** porque a barra estendida difere bastante entre as bases — o doc já traz a função de apresentação pronta (`buildConnChip`) e o método opcional de SSID.
