### PR TITLE
fix(carplay): restaura ícones nativos após recarga do host

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/CarPlayPatchManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/CarPlayPatchManager.kt
@@ -1,8 +1,10 @@
 package br.com.redesurftank.havalshisuku.managers
 
 import android.content.Context
+import android.os.SystemClock
 import android.util.Log
 import br.com.redesurftank.App
+import br.com.redesurftank.havalshisuku.diagnostics.ClusterPersistentEventLogger
 import br.com.redesurftank.havalshisuku.utils.ShizukuUtils
 import java.io.File
 import java.io.FileOutputStream
@@ -21,6 +23,13 @@ object CarPlayPatchManager {
     const val SYSTEM_SERVICE_PATH = "/vendor/app/TsCarPlayService/TsCarPlayService.apk"
     private const val SYSTEM_APP_OAT = "/system/app/TsCarPlayApp/oat"
     private const val SYSTEM_SERVICE_OAT = "/vendor/app/TsCarPlayService/oat"
+    private const val SYSTEM_UI_PACKAGE = "com.android.systemui"
+    private const val APP_LIST_PACKAGE = "com.beantechs.applist"
+    private const val SYSTEM_UI_REFRESH_OVERLAY = "com.android.systemui.theme.dark"
+    private const val PROCESS_RELOAD_GRACE_MS = 500L
+    private const val PROCESS_RESTART_TIMEOUT_MS = 3_000L
+    private const val PROCESS_RESTART_POLL_MS = 100L
+    private const val OEM_CLIENT_REFRESH_SETTLE_MS = 1_000L
 
     private data class BundledPatchInstallResult(
         val success: Boolean,
@@ -296,11 +305,19 @@ object CarPlayPatchManager {
                 TAG,
                 "[$reason] CarPlay visual task is active; reloading visual and host so mounted HVAC focus patches are loaded"
             )
-            sh("am force-stop com.ts.carplay.app 2>/dev/null || true")
-            sh("am force-stop com.ts.carplay 2>/dev/null || true")
-            sh("sleep 0.3")
-            sh("am startservice -n com.ts.carplay/.CarPlayService 2>/dev/null || true")
-            sh("am startservice -n com.ts.carplay.app/.service.CarPlayRemoteService 2>/dev/null || true")
+            reloadBoundProcessWithoutForceStop(
+                packageName = "com.ts.carplay.app",
+                serviceComponent = "com.ts.carplay.app/.service.CarPlayRemoteService",
+                reason = reason
+            )
+            val hostReloaded = reloadBoundProcessWithoutForceStop(
+                packageName = "com.ts.carplay",
+                serviceComponent = "com.ts.carplay/.CarPlayService",
+                reason = reason
+            )
+            if (hostReloaded) {
+                refreshOemCarPlayClientsAfterHostReload(reason)
+            }
             if (visualTaskOnDisplay3) {
                 sh("am start --display 3 --windowingMode 5 --activity-multiple-task -f 0x18000000 -n com.ts.carplay.app/com.ts.carplay.app.ui.display.view.CarPlayDisplayActivity 2>/dev/null || true")
             } else if (visualTaskOnDisplay0) {
@@ -313,11 +330,238 @@ object CarPlayPatchManager {
             TAG,
             "[$reason] Reloading idle CarPlay processes so mounted HVAC focus patches are loaded in memory"
         )
-        sh("am force-stop com.ts.carplay.app 2>/dev/null || true")
-        sh("am force-stop com.ts.carplay 2>/dev/null || true")
-        sh("sleep 0.2")
-        sh("am startservice -n com.ts.carplay/.CarPlayService 2>/dev/null || true")
-        sh("am startservice -n com.ts.carplay.app/.service.CarPlayRemoteService 2>/dev/null || true")
+        reloadBoundProcessWithoutForceStop(
+            packageName = "com.ts.carplay.app",
+            serviceComponent = "com.ts.carplay.app/.service.CarPlayRemoteService",
+            reason = reason
+        )
+        val hostReloaded = reloadBoundProcessWithoutForceStop(
+            packageName = "com.ts.carplay",
+            serviceComponent = "com.ts.carplay/.CarPlayService",
+            reason = reason
+        )
+        if (hostReloaded) {
+            refreshOemCarPlayClientsAfterHostReload(reason)
+        }
+    }
+
+    /**
+     * Reloads patched code without putting the package in Android's force-stopped state.
+     *
+     * `am force-stop` permanently marks every existing service connection as DEAD until the
+     * client binds again. A direct process signal preserves ActivityManager's BIND_AUTO_CREATE
+     * records and reconnects clients to the replacement host. The OEM CarPlay SDK still caches
+     * its inner manager Binder, so the affected native clients are renewed separately after the
+     * host replacement.
+     */
+    private fun reloadBoundProcessWithoutForceStop(
+        packageName: String,
+        serviceComponent: String,
+        reason: String
+    ): Boolean {
+        val originalPids = readProcessIds(packageName)
+        ClusterPersistentEventLogger.log(
+            "carplay_patch_process_reload_started",
+            mapOf(
+                "reason" to reason,
+                "package" to packageName,
+                "originalPids" to originalPids.joinToString(","),
+                "strategy" to "signal_preserve_bind"
+            )
+        )
+
+        originalPids.forEach { pid ->
+            sh("kill -TERM $pid 2>/dev/null || true")
+        }
+
+        if (originalPids.isNotEmpty()) {
+            Thread.sleep(PROCESS_RELOAD_GRACE_MS)
+            readProcessIds(packageName)
+                .filter { it in originalPids }
+                .forEach { pid -> sh("kill -KILL $pid 2>/dev/null || true") }
+        }
+
+        var replacementPids =
+            if (originalPids.isEmpty()) emptySet()
+            else waitForReplacementProcess(packageName, originalPids)
+        var startFallbackUsed = false
+        if (replacementPids.isEmpty()) {
+            startFallbackUsed = true
+            sh("am startservice -n $serviceComponent 2>/dev/null || true")
+            replacementPids = waitForReplacementProcess(packageName, originalPids)
+        }
+
+        val replacementObserved = replacementPids.isNotEmpty()
+        Log.w(
+            TAG,
+            "[$reason] Bind-preserving CarPlay reload package=$packageName " +
+                "originalPids=$originalPids replacementPids=$replacementPids " +
+                "startFallbackUsed=$startFallbackUsed"
+        )
+        ClusterPersistentEventLogger.log(
+            "carplay_patch_process_reload_finished",
+            mapOf(
+                "reason" to reason,
+                "package" to packageName,
+                "originalPids" to originalPids.joinToString(","),
+                "replacementPids" to replacementPids.joinToString(","),
+                "replacementObserved" to replacementObserved,
+                "startFallbackUsed" to startFallbackUsed
+            )
+        )
+        return replacementObserved
+    }
+
+    /**
+     * Renews the two OEM clients that cache a CarPlayManager Binder across host replacement.
+     *
+     * SystemUI is not restarted. Toggling and immediately restoring its built-in resource
+     * overlay makes FragmentHostManager recreate only the navigation view, whose detach/attach
+     * lifecycle clears the stale manager. AppList is a separate process and can be renewed with
+     * a direct signal; if it was not active, its next normal launch creates a fresh manager.
+     */
+    private fun refreshOemCarPlayClientsAfterHostReload(reason: String) {
+        Thread.sleep(OEM_CLIENT_REFRESH_SETTLE_MS)
+        refreshSystemUiCarPlayView(reason)
+        refreshAppListCarPlayManager(reason)
+    }
+
+    private fun refreshSystemUiCarPlayView(reason: String) {
+        val systemUiPidsBefore = readProcessIds(SYSTEM_UI_PACKAGE)
+        val overlayListing = sh("cmd overlay list '$SYSTEM_UI_PACKAGE' 2>/dev/null || true")
+        val overlayInitiallyEnabled =
+            parseOverlayEnabled(overlayListing, SYSTEM_UI_REFRESH_OVERLAY)
+
+        if (overlayInitiallyEnabled == null) {
+            Log.e(TAG, "[$reason] SystemUI refresh overlay state unavailable; preserving native menu")
+            ClusterPersistentEventLogger.log(
+                "carplay_native_client_refresh_skipped",
+                mapOf(
+                    "reason" to reason,
+                    "client" to SYSTEM_UI_PACKAGE,
+                    "cause" to "overlay_state_unavailable"
+                )
+            )
+            return
+        }
+
+        val toggleAction = if (overlayInitiallyEnabled) "disable" else "enable"
+        val restoreAction = if (overlayInitiallyEnabled) "enable" else "disable"
+        try {
+            sh("cmd overlay $toggleAction --user 0 '$SYSTEM_UI_REFRESH_OVERLAY' 2>/dev/null || true")
+            Thread.sleep(OEM_CLIENT_REFRESH_SETTLE_MS)
+        } finally {
+            sh("cmd overlay $restoreAction --user 0 '$SYSTEM_UI_REFRESH_OVERLAY' 2>/dev/null || true")
+            Thread.sleep(OEM_CLIENT_REFRESH_SETTLE_MS)
+        }
+
+        val overlayRestored =
+            parseOverlayEnabled(
+                sh("cmd overlay list '$SYSTEM_UI_PACKAGE' 2>/dev/null || true"),
+                SYSTEM_UI_REFRESH_OVERLAY
+            ) == overlayInitiallyEnabled
+        val systemUiPidsAfter = readProcessIds(SYSTEM_UI_PACKAGE)
+        val systemUiPidPreserved =
+            systemUiPidsBefore.isNotEmpty() && systemUiPidsBefore == systemUiPidsAfter
+        val navigationBarPresent =
+            sh("dumpsys window windows 2>/dev/null | grep -F 'NavigationBar' | head -n 1")
+                .contains("NavigationBar")
+
+        Log.w(
+            TAG,
+            "[$reason] SystemUI CarPlay view refreshed; pidPreserved=$systemUiPidPreserved " +
+                "navigationBarPresent=$navigationBarPresent overlayRestored=$overlayRestored"
+        )
+        ClusterPersistentEventLogger.log(
+            "carplay_native_client_refreshed",
+            mapOf(
+                "reason" to reason,
+                "client" to SYSTEM_UI_PACKAGE,
+                "pidBefore" to systemUiPidsBefore.joinToString(","),
+                "pidAfter" to systemUiPidsAfter.joinToString(","),
+                "pidPreserved" to systemUiPidPreserved,
+                "navigationBarPresent" to navigationBarPresent,
+                "overlayRestored" to overlayRestored
+            )
+        )
+    }
+
+    private fun refreshAppListCarPlayManager(reason: String) {
+        val originalPids = readProcessIds(APP_LIST_PACKAGE)
+        if (originalPids.isEmpty()) {
+            ClusterPersistentEventLogger.log(
+                "carplay_native_client_refresh_skipped",
+                mapOf(
+                    "reason" to reason,
+                    "client" to APP_LIST_PACKAGE,
+                    "cause" to "process_not_running"
+                )
+            )
+            return
+        }
+
+        originalPids.forEach { pid -> sh("kill -TERM $pid 2>/dev/null || true") }
+        Thread.sleep(PROCESS_RELOAD_GRACE_MS)
+        readProcessIds(APP_LIST_PACKAGE)
+            .filter { it in originalPids }
+            .forEach { pid -> sh("kill -KILL $pid 2>/dev/null || true") }
+
+        val replacementPids = waitForReplacementProcess(APP_LIST_PACKAGE, originalPids)
+        Log.w(
+            TAG,
+            "[$reason] AppList CarPlay manager renewed; originalPids=$originalPids " +
+                "replacementPids=$replacementPids"
+        )
+        ClusterPersistentEventLogger.log(
+            "carplay_native_client_refreshed",
+            mapOf(
+                "reason" to reason,
+                "client" to APP_LIST_PACKAGE,
+                "pidBefore" to originalPids.joinToString(","),
+                "pidAfter" to replacementPids.joinToString(","),
+                "replacementObserved" to replacementPids.isNotEmpty()
+            )
+        )
+    }
+
+    private fun waitForReplacementProcess(packageName: String, originalPids: Set<Int>): Set<Int> {
+        val deadline = SystemClock.elapsedRealtime() + PROCESS_RESTART_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val currentPids = readProcessIds(packageName)
+            val replacements = replacementProcessIds(originalPids, currentPids)
+            if (replacements.isNotEmpty()) return replacements
+            Thread.sleep(PROCESS_RESTART_POLL_MS)
+        }
+        return replacementProcessIds(originalPids, readProcessIds(packageName))
+    }
+
+    private fun readProcessIds(packageName: String): Set<Int> {
+        return parseProcessIds(sh("pidof '$packageName' 2>/dev/null || true"))
+    }
+
+    internal fun parseProcessIds(output: String): Set<Int> {
+        return output
+            .trim()
+            .split(Regex("\\s+"))
+            .mapNotNull { token -> token.toIntOrNull()?.takeIf { it > 0 } }
+            .toSet()
+    }
+
+    internal fun replacementProcessIds(originalPids: Set<Int>, currentPids: Set<Int>): Set<Int> {
+        return currentPids - originalPids
+    }
+
+    internal fun parseOverlayEnabled(output: String, packageName: String): Boolean? {
+        val marker =
+            Regex("(?m)^\\[([x ])]\\s+${Regex.escape(packageName)}\\s*$")
+                .find(output)
+                ?.groupValues
+                ?.getOrNull(1)
+        return when (marker) {
+            "x" -> true
+            " " -> false
+            else -> null
+        }
     }
 
     fun getDiagnostics(): String {

--- a/app/src/test/java/br/com/redesurftank/havalshisuku/managers/CarPlayPatchManagerTest.kt
+++ b/app/src/test/java/br/com/redesurftank/havalshisuku/managers/CarPlayPatchManagerTest.kt
@@ -1,0 +1,72 @@
+package br.com.redesurftank.havalshisuku.managers
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CarPlayPatchManagerTest {
+
+    @Test
+    fun parseProcessIdsIgnoresShellNoiseAndInvalidTokens() {
+        assertEquals(
+            setOf(3620, 3916),
+            CarPlayPatchManager.parseProcessIds(" 3620  noise  -1  3916 ")
+        )
+    }
+
+    @Test
+    fun replacementProcessIdsRequiresANewGeneration() {
+        assertTrue(
+            CarPlayPatchManager.replacementProcessIds(
+                originalPids = setOf(3620),
+                currentPids = setOf(3620)
+            ).isEmpty()
+        )
+        assertEquals(
+            setOf(5812),
+            CarPlayPatchManager.replacementProcessIds(
+                originalPids = setOf(3620),
+                currentPids = setOf(5812)
+            )
+        )
+    }
+
+    @Test
+    fun processStartedFromAbsentStateCountsAsReplacement() {
+        assertEquals(
+            setOf(5841),
+            CarPlayPatchManager.replacementProcessIds(
+                originalPids = emptySet(),
+                currentPids = setOf(5841)
+            )
+        )
+    }
+
+    @Test
+    fun parseOverlayEnabledReadsEnabledAndDisabledStates() {
+        assertTrue(
+            CarPlayPatchManager.parseOverlayEnabled(
+                "[x] com.android.systemui.theme.dark",
+                "com.android.systemui.theme.dark"
+            ) == true
+        )
+        assertFalse(
+            CarPlayPatchManager.parseOverlayEnabled(
+                "[ ] com.android.systemui.theme.dark",
+                "com.android.systemui.theme.dark"
+            ) ?: true
+        )
+    }
+
+    @Test
+    fun parseOverlayEnabledDoesNotGuessWhenPackageIsMissing() {
+        assertNull(
+            CarPlayPatchManager.parseOverlayEnabled(
+                "[x] com.android.systemui.skin.B03G.v17",
+                "com.android.systemui.theme.dark"
+            )
+        )
+    }
+}

--- a/docs/architecture/projection-native-patch-strategy.md
+++ b/docs/architecture/projection-native-patch-strategy.md
@@ -781,3 +781,28 @@ Um novo patch CarPlay so deve ser considerado se:
 - `app/src/main/java/br/com/redesurftank/havalshisuku/projectors/InstrumentProjector2.kt`
 - `docs/carplay-cluster-regression-contract.md`
 - `tools/headunit-dev/diagnose-projection-focus-compare.sh`
+
+## Renovacao dos clientes OEM apos recarga do host CarPlay (2026-08-07)
+
+O bind externo e o manager interno sao duas camadas diferentes. A troca do processo
+`com.ts.carplay` por `SIGTERM` preserva os binds `BIND_AUTO_CREATE` registrados no
+ActivityManager, mas o SDK OEM `com.ts.carplay.manager.CarPlay` mantem os objetos em `mServiceMap`.
+No callback de desconexao, ele grava `mConnectionState=0` antes de chamar `disconnect()`; a chamada
+retorna imediatamente e nao executa `tearDownCarPlayManagers()`. Assim, SystemUI e AppList recebem
+o novo `onServiceConnected`, mas `getCarPlayManager()` devolve o manager que ainda aponta para o
+Binder morto.
+
+A estrategia da v310 e restrita ao momento em que `CarPlayPatchManager` confirma uma nova geracao
+do host:
+
+1. aguardar o host substituto estabilizar;
+2. renovar apenas o fragmento da NavigationBar por uma mudanca de recursos do SystemUI;
+3. restaurar o estado original do overlay OEM usado como gatilho;
+4. confirmar PID do SystemUI preservado e janela `NavigationBar` presente;
+5. renovar separadamente o processo do AppList por sinal direto, sem estado force-stopped.
+
+Essa sequencia nao toca no renderer CarPlay, Activity D0/D3, Surface, video focus, WebView,
+resolucao ou Android Auto. O teste manual no mesmo boot restaurou os dois icones. O cold boot
+seguinte da v310 tambem confirmou a automacao: SystemUI foi renovado e preservado antes da pinca;
+quando o AppList, ausente no boot, foi aberto normalmente, criou um manager novo e exibiu o segundo
+icone ativo.

--- a/docs/carplay-cluster-regression-contract.md
+++ b/docs/carplay-cluster-regression-contract.md
@@ -914,3 +914,41 @@ Contrato:
 - logs esperados:
   `Moving clean live CarPlay stack ... from D0 to D3 to preserve native Surface` e
   `CarPlay live stack moved to D3 as stack ...`.
+
+## Regra 43 - Recarga do host renova clientes OEM sem reiniciar SystemUI
+
+Em 2026-08-07, o cold boot da v309 comprovou que sinalizar diretamente o processo
+`com.ts.carplay` preserva os `ConnectionRecord` externos do ActivityManager, mas nao renova o
+`CarPlayManager` interno mantido pelo SDK OEM. O `CarPlay.java` zera `mConnectionState` antes de
+chamar `disconnect()` em `onServiceDisconnected`; por isso `tearDownCarPlayManagers()` retorna sem
+limpar `mServiceMap`. SystemUI e AppList reconectam ao novo host, mas continuam consultando o Binder
+interno do processo anterior. O servico novo estava com `linkStatus=2`, enquanto os dois icones
+permaneciam inativos.
+
+Contrato:
+
+- `com.android.systemui` nao pode ser encerrado ou reiniciado para atualizar o icone CarPlay;
+- depois de uma substituicao confirmada do host `com.ts.carplay`, a view nativa pode ser renovada
+  por uma mudanca de recursos direcionada ao SystemUI, usando o overlay OEM
+  `com.android.systemui.theme.dark` e restaurando obrigatoriamente seu estado original;
+- a recuperacao deve confirmar que o PID do SystemUI foi preservado e que a janela
+  `NavigationBar` continua presente;
+- se o estado inicial do overlay nao puder ser determinado, a renovacao deve ser ignorada e o menu
+  preservado;
+- o AppList pode ter apenas seu processo renovado por sinal direto, sem `am force-stop`; se ele nao
+  estiver ativo, o proximo inicio normal criara o manager novo;
+- a sequencia nao pode reiniciar CarPlay novamente, alterar Surface, foco, display D0/D3,
+  resolucao, WebView ou Android Auto.
+
+Validacao fisica manual em 2026-08-07:
+
+- SystemUI permaneceu no PID `1928`, host CarPlay permaneceu no PID `6792` e a NavigationBar ficou
+  presente;
+- o bind SystemUI foi renovado de `ConnectionRecord{3fdbd3d}` para
+  `ConnectionRecord{7716f94}` e o icone apareceu no menu lateral;
+- AppList foi renovado de PID `5808` para `17271`, criou
+  `ConnectionRecord{eb2cc4a}` e o usuario confirmou o icone ativo na area de trabalho;
+- cold boot automatico da v310 confirmado no `boot_id=e2376c73-a688-4bd8-b396-13247395a208`:
+  host `3913 -> 6152`, SystemUI PID `1993` preservado, `navigationBarPresent=true` e
+  `overlayRestored=true` antes de qualquer pinca; apos USB e abertura normal do AppList, PID
+  `14334` criou `ConnectionRecord{323f771}` e o usuario confirmou ambos os icones ativos.


### PR DESCRIPTION
## Contexto e relacao com o PR #117

O [PR #117](https://github.com/bobaoapae/haval-app-tool-multimidia/pull/117) introduz o contrato de temas v1.0 e permanece aberto contra `preview`.

Depois desse marco, a linha de desenvolvimento foi ampliada e validada com Theme Lab, compatibilidade dos temas Sport, simulacao de telemetria/projecao, navegacao pelo volante, hardening de performance e diagnosticos operacionais. Esse conjunto foi consolidado em `b8e2c4083` (`feat(cluster): harden Sport themes and add Theme Lab`).

> **Importante para a revisao:** o #117 ainda nao e ancestral de `preview`. Por seguranca, o diff efetivo deste PR #118 foi criado diretamente sobre a `preview` atual e contem somente a correcao CarPlay v310 descrita na secao **Escopo efetivo do #118**. O inventario abaixo registra toda a evolucao validada desde o #117, mas nao atribui ao diff de quatro arquivos alteracoes que ainda pertencem a linha de desenvolvimento pos-#117.

---

## Novidades validadas desde o #117

### Theme Lab unificado

- novo launcher local em `cluster-widgets` com `npm run dev`, servido em `http://localhost:1234/`;
- catalogo automatico dos temas em `source/v1.0`, `Themes/v1.0` e pacotes legados;
- seletor por pasta, versao, tipo de pacote e suporte ao teclado;
- canvas interno fixo em `1920x720`, com escala apenas na previa externa e sem scroll interno;
- paineis separados para Aparencia, AC/dados, Atalhos e Testes;
- adaptador de teclado para SportRed, SportRedLite, Basic, BasicLight e Default legado, sem editar os bundles publicados;
- checks automatizados para catalogo, camada frontal fixa, projecao, movimento dos instrumentos, acabamento Sport e telemetria.

### Simulacao realista de telemetria e projecao

- telemetria reutilizavel para velocidade, RPM, potencia/regeneracao, combustivel, bateria, autonomias, temperaturas e AC;
- simulacao CarPlay em full bleed, cobrindo `1920x720` atras dos instrumentos;
- gradiente lateral progressivo para preservar a leitura dos velocimetros e manter o centro da projecao claro;
- mapa/projecao sem o antigo recorte central pequeno;
- compatibilidade local mantida sem modificar o HTML OTA dos temas.

### Camada OEM fixa no contrato visual

- documentados como elementos nativos imutaveis: `READY`, placa de velocidade e indicador ESP;
- camada de simulacao unica acima de todos os sete temas atuais, com `z-index` maximo e sem capturar eventos;
- remocao visual dos mocks duplicados dos temas Sport, preservando apenas a camada na posicao OEM correta;
- zonas de exclusao registradas para que velocimetros e decoracoes nao sejam desenhados sob os indicadores nativos;
- nenhuma chave de telemetria, metodo de bridge ou versao de contrato foi alterada.

### Sport Colors e Sport Colors Leve

- acabamento das linhas dos velocimetros preservando o serrilhado caracteristico;
- velocidade e potencia/regeneracao alinhadas em `top: 380px`;
- cabecalho e rodape redesenhados com SVG vetorial, tracos brancos alinhados e sombra escura difusa atras dos dados;
- remocao das superficies decorativas grandes que quebravam o layout;
- layout full bleed da projecao com instrumentos preservados nas laterais;
- suavizacao responsiva dos ponteiros de velocidade e potencia/regeneracao, mantendo o teto de aproximadamente 30 fps;
- constante de resposta reduzida para `100 ms`, sem saltos artificiais em variacoes grandes;
- navegacao legada restaurada para `UP/DOWN/ENTER/BACK` por `LegacySportThemeNavigationPolicy`, sem mudar o contrato v1.0;
- os pacotes OTA Sport permaneceram byte a byte inalterados; as adequacoes sao aplicadas somente em memoria e com assinatura estrutural conhecida.

### Performance do MainMenu Sport

- renderer Normal pausado quando fica oculto no Analogico V2, evitando canvas, gradientes, arcos e `shadowBlur` fora da tela ativa;
- retomada imediata do renderer ao voltar para o modo Analogico;
- velocidade, RPM, fator/regeneracao, tensao e corrente coalescidos por `SportTelemetryBatchPolicy` em um unico lote a cada `33 ms`;
- politica de ultima amostra vencedora e apenas um calculo de kW por quadro;
- input, cards, AC, warnings e subscriptions continuam fora do lote e preservam o caminho prioritario;
- nenhuma nova thread, `setInterval`, observer ou animacao continua foi adicionada.

### Entrega de estado e compatibilidade no host Android

- `ClusterCardThemeDeliveryPolicy` mantem `onCardChanged` como canal canonico e controla fallback apenas onde necessario;
- `ProjectionDisplayHtmlPolicy` aplica as correcoes somente aos temas/assinaturas reconhecidos e falha fechado nos demais;
- diagnosticos dedicados para navegacao de cards, performance, CarPlay, Android Auto e captura visual do D3;
- documentacao de arquitetura ampliada para build, frontend, bridge, performance, navegacao nativa e contrato de temas;
- modo de display continua sendo uma escolha do usuario: CarPlay/mapa nao deve forcar automaticamente o tema Mapa.

---

## Escopo efetivo do PR #118

Este PR corrige o caso em que o CarPlay abre e funciona, mas os clientes nativos mantem um `CarPlayManager` ligado ao Binder da geracao anterior do host. O sintoma observado era assimetrico: o icone podia aparecer na Area de Trabalho e continuar ausente no menu lateral, ou ocorrer o inverso.

### Correcao CarPlay v310

- substitui `am force-stop` por recarga direta do processo CarPlay, preservando os binds administrados pelo ActivityManager;
- aguarda e confirma uma nova geracao do host antes de renovar os clientes nativos;
- renova somente a view da NavigationBar por mudanca de recursos e restaura exatamente o estado original do overlay OEM;
- **nao reinicia o SystemUI**, preservando a NavigationBar e evitando a regressao observada na v296;
- renova o AppList separadamente quando ele ja esta ativo e preserva seu proximo inicio normal quando esta fechado;
- adiciona eventos persistentes para inicio/fim da recarga, PID, geracao do processo, presenca da NavigationBar e restauracao do overlay;
- adiciona testes unitarios para parsing de PID, deteccao da geracao substituta e estado do overlay;
- documenta a causa no cache interno `mServiceMap` do SDK OEM e as travas de regressao.

### Arquivos do diff

- `app/src/main/java/br/com/redesurftank/havalshisuku/managers/CarPlayPatchManager.kt`;
- `app/src/test/java/br/com/redesurftank/havalshisuku/managers/CarPlayPatchManagerTest.kt`;
- `docs/architecture/projection-native-patch-strategy.md`;
- `docs/carplay-cluster-regression-contract.md`.

---

## Validacao

### Linha de desenvolvimento pos-#117

- `382` testes Android, sem falhas ou erros;
- `:app:assembleDebug` e `:app:lintDebug`: OK;
- `npm run check` e `npm run build` no Theme Lab: OK;
- validadores de catalogo, telemetria, projecao, camada fixa e temas Sport: OK;
- inspecao em navegador dos sete temas e do Sport Colors em `1920x720`: OK;
- bundles OTA Sport mantidos com os hashes anteriores.

### Branch limpa do #118

- `./gradlew :app:testDebugUnitTest :app:assembleDebug -PappVersionCode=310 -PappVersionName=1.0.0.310-preview-carplay-native-clients-refresh`: OK;
- `git diff --check`: OK;
- regression lock: todos os checks tocados passaram; o retorno global permanece limitado aos sete gaps preexistentes da baseline `preview`;
- teste fisico manual: icones do menu lateral e da Area de Trabalho restaurados sem reiniciar SystemUI;
- cold boot fisico v310: host `3913 -> 6152`, SystemUI PID `1993` preservado, `navigationBarPresent=true` e `overlayRestored=true`;
- AppList abriu naturalmente no PID `14334`, criou um bind novo e ambos os icones foram confirmados ativos pelo usuario.

## Limites preservados pelo #118

- mudanca funcional exclusiva de CarPlay;
- sem alteracao em Android Auto;
- sem alteracao de foco de video, Surface ou handoff D0/D3;
- sem alteracao de resolucao, bounds ou layout do cluster;
- sem alteracao de WebView, bridge ou contrato de temas;
- sem aplicacao automatica do tema Mapa.
