### PR TITLE
Cluster: corrige tela-preta/OOM e full-bleed do Android Auto, offset nos mapas + dashboard em tempo real

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/DisplayAppLauncher.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/DisplayAppLauncher.kt
@@ -34,6 +34,7 @@ import br.com.redesurftank.havalshisuku.services.BottomBarService
 import br.com.redesurftank.havalshisuku.services.AndroidAutoDcmRecovery
 import com.ts.androidauto.sdk.aidl.data.IfVehicleInfo
 import com.ts.androidauto.sdk.common.VehicleConst
+import java.io.File
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
@@ -4884,9 +4885,32 @@ object DisplayAppLauncher {
             .any { state -> state == "CONFIGURED" || state == "CONNECTED" }
     }
 
+    private const val PROJECTION_USB_STATE_PATH = "/sys/class/android_usb/android0/state"
+    private const val PROJECTION_USB_STATE_CACHE_MS = 500L
+
+    @Volatile private var cachedProjectionUsbConfigured: Boolean? = null
+    @Volatile private var cachedProjectionUsbConfiguredAtMs = 0L
+
     private fun isProjectionUsbConfigured(): Boolean {
-        val state = sh("cat /sys/class/android_usb/android0/state 2>/dev/null || true").trim()
-        return isProjectionUsbStateReady(state)
+        val cached = cachedProjectionUsbConfigured
+        if (cached != null &&
+            SystemClock.elapsedRealtime() - cachedProjectionUsbConfiguredAtMs < PROJECTION_USB_STATE_CACHE_MS
+        ) {
+            return cached
+        }
+        // Read the sysfs node directly (no shell spawn) — the same source BottomBarService uses.
+        // Fall back to a Shizuku shell read only if the direct read is blocked. This removes a very
+        // hot spawn: isProjectionUsbConfigured() is polled from many projection paths, and each
+        // sh("cat …") was a shell process routed through shizuku_server, starving its ~96MB heap
+        // → OutOfMemoryError → shizuku_server restart → cluster presentation dropped (the flicker).
+        val state = runCatching { File(PROJECTION_USB_STATE_PATH).readText() }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?: sh("cat $PROJECTION_USB_STATE_PATH 2>/dev/null || true")
+        val configured = isProjectionUsbStateReady(state.trim())
+        cachedProjectionUsbConfigured = configured
+        cachedProjectionUsbConfiguredAtMs = SystemClock.elapsedRealtime()
+        return configured
     }
 
     private suspend fun recreateMissingCarPlayVisualTaskOnCluster(reason: String): TaskInfo? {

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/DisplayAppLauncher.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/DisplayAppLauncher.kt
@@ -2652,16 +2652,26 @@ object DisplayAppLauncher {
 
     private fun getAndroidAutoDisplayBounds(displayId: Int): IntArray {
         val res = getDisplayResolution(displayId)
-        // Cluster (display 3): desloca a janela do AA pra direita (OPT-IN, começa desativado). Só
-        // aplica se ENABLE_AA_CLUSTER_OFFSET estiver ligado. Borda direita fixa (res.first), então
-        // aumentar o offset só estreita a esquerda, nunca corta a direita. Contorna o menu lateral do
-        // AA que o host do cluster corta.
-        if (displayId == 3 &&
-            getPrefs().getBoolean(SharedPreferencesKeys.ENABLE_AA_CLUSTER_OFFSET.key, false)) {
-            val offset = getPrefs()
-                .getInt(SharedPreferencesKeys.AA_CLUSTER_LEFT_OFFSET.key, 145)
-                .coerceIn(0, maxOf(0, res.first - 200))
-            return intArrayOf(offset, 0, res.first, res.second)
+        // Cluster (display 3): desloca a janela do AA pra direita. Borda direita fixa (res.first),
+        // então aumentar o offset só estreita a esquerda, nunca corta a direita. Contorna a coluna
+        // esquerda dos layouts de mapa do tema Sport.
+        //
+        // AUTOMÁTICO: nos 3 displays de MAPA do Sport (Mapa / Mapa Graduado / Mapa Limpo) o offset
+        // é aplicado sozinho; nos demais displays (Analógico V2, Normal, Digital) o AA fica em tela
+        // cheia. O toggle manual ENABLE_AA_CLUSTER_OFFSET continua funcionando como força-sempre.
+        if (displayId == 3) {
+            val display = getPrefs()
+                .getString(SharedPreferencesKeys.CURRENT_CLUSTER_DISPLAY.key, "").orEmpty()
+            val isMapDisplay =
+                display == "Mapa" || display == "Mapa Graduado" || display == "Mapa Limpo"
+            val manualForce =
+                getPrefs().getBoolean(SharedPreferencesKeys.ENABLE_AA_CLUSTER_OFFSET.key, false)
+            if (isMapDisplay || manualForce) {
+                val offset = getPrefs()
+                    .getInt(SharedPreferencesKeys.AA_CLUSTER_LEFT_OFFSET.key, 135)
+                    .coerceIn(0, maxOf(0, res.first - 200))
+                return intArrayOf(offset, 0, res.first, res.second)
+            }
         }
         return intArrayOf(0, 0, res.first, res.second)
     }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -175,7 +175,20 @@ public class ServiceManager {
             CarConstants.CAR_EV_INFO_INSTANT_ENERGY_CONSUMPTION,
             CarConstants.CAR_IPK_LIGHT_FUEL_LOW,
             CarConstants.CAR_MAP_TSR_NAV_SPEED_LIMIT,
-            CarConstants.CAR_MAP_TSR_NAV_SPEED_LIMIT_SIGN_STATUS
+            CarConstants.CAR_MAP_TSR_NAV_SPEED_LIMIT_SIGN_STATUS,
+            // Campos do dashboard que precisam atualizar EM TEMPO REAL (sem essas chaves observadas,
+            // o onDataChanged nunca dispara pra elas e o valor so re-le ao fechar/reabrir o dash).
+            CarConstants.CAR_EV_SETTING_POWER_RESERVE_CONFIG,
+            CarConstants.CAR_EV_SETTING_CHARGE_SOC_TARGET_CONFIG,
+            CarConstants.CAR_COMFORT_SETTING_DRIVER_SEAT_VENTILATION_LEVEL,
+            CarConstants.CAR_COMFORT_SETTING_PASSENGER_SEAT_VENTILATION_LEVEL,
+            CarConstants.CAR_COMFORT_SETTING_SEAT_VENTILATION_MAX_LEVEL,
+            CarConstants.CAR_EV_INFO_CAR_EV_INFO_SOC_OF_BATTERY,
+            CarConstants.CAR_EV_INFO_BATTERY_POWER_PERCENTAGE,
+            CarConstants.CAR_BASIC_REMAIN_ODOMETER,
+            CarConstants.CAR_BASIC_CUR_JOURNEY_AVG_FUEL_CONSUME,
+            CarConstants.CAR_EV_INFO_AVG_ENERGY_CONSUME_INFO_SINCE_STARTUP,
+            CarConstants.CAR_EV_INFO_POWER_BATTERY_CURRENT
     };
 
     private static final CarConstants[] KEYS_TO_SAVE = {

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/screens/DisplaySelectionScreen.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/screens/DisplaySelectionScreen.java
@@ -68,6 +68,13 @@ public class DisplaySelectionScreen implements Screen {
         serviceManager.dispatchServiceManagerEvent(
                 ServiceManagerEventType.DISPLAY_SCREEN_SELECTION,
                 "control('display', '" + display + "')");
+        // Re-aplica os bounds do AA no cluster: os 3 displays de mapa deslocam o AA 135px pra
+        // direita automaticamente; os demais voltam a tela cheia. No-op se o AA nao estiver no D3.
+        try {
+            br.com.redesurftank.havalshisuku.managers.DisplayAppLauncher.INSTANCE
+                    .reapplyAndroidAutoClusterBounds();
+        } catch (Throwable ignored) {
+        }
     }
 
     private void updateFocus() {

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/projectors/ProjectionDisplayHtmlPolicy.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/projectors/ProjectionDisplayHtmlPolicy.kt
@@ -39,18 +39,20 @@ internal object ProjectionDisplayHtmlPolicy {
 
     /**
      * Sport 0.16.44 uses a large black box-shadow to leave only a narrow map window between the
-     * Analogico V2 gauges. While CarPlay is on D3 its video Surface already fills 1920x720, so
-     * replace that opaque cutout with two static linear edge gradients. Each edge stays nearly
-     * opaque below its gauge and fades continuously toward the clear central navigation area.
-     * The theme's full-width top mask also becomes transparent while the independent center
-     * status capsule remains intact. These rules avoid filters/blur to keep the WebView compositor
-     * cost bounded. The `carplay-in-dash` selector deliberately keeps Android Auto outside this
-     * compatibility.
+     * Analogico V2 gauges. While CarPlay or Android Auto is projecting on D3 its video Surface
+     * already fills 1920x720, so replace that opaque cutout with two static linear edge gradients.
+     * Each edge stays nearly opaque below its gauge and fades continuously toward the clear central
+     * navigation area. The theme's full-width top mask also becomes transparent while the independent
+     * center status capsule remains intact. These rules avoid filters/blur to keep the WebView
+     * compositor cost bounded. Both in-dash projection classes get the same full-bleed treatment:
+     * CarPlay (`carplay-in-dash`) and Android Auto (`projection-mirror-in-dash`) — the latter was the
+     * missing case that left Android Auto in the narrow square crop.
      */
     private val projectionFullBleedMaskStyle =
         """
         <style $PROJECTION_FULL_BLEED_STYLE_MARKER="1">
-        .carplay-in-dash.display-analogico-v2 .cluster-mask-bg::after {
+        .carplay-in-dash.display-analogico-v2 .cluster-mask-bg::after,
+        .projection-mirror-in-dash.display-analogico-v2 .cluster-mask-bg::after {
           content: "" !important;
           display: block !important;
           position: absolute !important;
@@ -87,7 +89,8 @@ internal object ProjectionDisplayHtmlPolicy {
             ) !important;
           pointer-events: none !important;
         }
-        .carplay-in-dash.display-analogico-v2 .mask-top-bar {
+        .carplay-in-dash.display-analogico-v2 .mask-top-bar,
+        .projection-mirror-in-dash.display-analogico-v2 .mask-top-bar {
           background: transparent !important;
           background-image: none !important;
           box-shadow: none !important;

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/services/AndroidAutoDcmRecovery.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/services/AndroidAutoDcmRecovery.kt
@@ -32,11 +32,21 @@ object AndroidAutoDcmRecovery {
     private const val CAPABILITY_STATE_ACTIVATED = 4
     private const val DISCONNECT_REASON_SWITCH_PROJECTION = 2
     private const val ACTIVATE_SUCCESS = 0
+    private const val LOG_SNAPSHOT_CACHE_MS = 3_000L
+
+    @Volatile private var cachedLogSnapshots: List<DcmDeviceSnapshot> = emptyList()
+    @Volatile private var cachedLogSnapshotsAtMs: Long = 0L
 
     suspend fun readDeviceSnapshots(context: Context): List<DcmDeviceSnapshot> {
-        return withDcmBinder(context.applicationContext) { binder ->
+        val viaBinder = withDcmBinder(context.applicationContext) { binder ->
             readDevices(binder)
         } ?: emptyList()
+        if (viaBinder.isNotEmpty()) return viaBinder
+        // The OEM ConnDevice Parcelable isn't on our classpath, so the binder read always
+        // unmarshals to empty (ClassNotFound at Bundle.keySet). Fall back to parsing the
+        // OEM's own DcController "mergeDevices" log lines, which expose every field we need.
+        // Cached briefly so the (non-hot) callers don't re-scrape logcat and add Shizuku load.
+        return readDevicesFromLogs()
     }
 
     suspend fun recoverUsbProjection(context: Context, requestedDevId: String?): RecoveryResult {
@@ -269,6 +279,84 @@ object AndroidAutoDcmRecovery {
         return patterns.firstNotNullOfOrNull { pattern ->
             pattern.findAll(logs).lastOrNull()?.groupValues?.getOrNull(1)
         }
+    }
+
+    /**
+     * Reconstructs device snapshots from the OEM's own `DcController: mergeDevices ... Device{...}`
+     * log lines. Used when the binder read cannot unmarshal (ConnDevice class missing). The scrape
+     * is filtered to a single tag (few lines) and cached briefly, so it stays cheap.
+     */
+    private fun readDevicesFromLogs(): List<DcmDeviceSnapshot> {
+        val now = SystemClock.elapsedRealtime()
+        val cachedAt = cachedLogSnapshotsAtMs
+        if (cachedAt != 0L &&
+                (now - cachedAt) in 0..LOG_SNAPSHOT_CACHE_MS &&
+                cachedLogSnapshots.isNotEmpty()) {
+            return cachedLogSnapshots
+        }
+        val logs = runCatching {
+            ShizukuUtils.runCommandAndGetOutput(
+                arrayOf("logcat", "-d", "DcController:E", "*:S")
+            )
+        }.getOrNull().orEmpty()
+        if (logs.isBlank()) return cachedLogSnapshots
+        val byKey = LinkedHashMap<String, DcmDeviceSnapshot>()
+        logs.lineSequence().forEach { line ->
+            if (!line.contains("mergeDevices") || !line.contains("Device{")) return@forEach
+            val snap = parseDeviceLogLine(line) ?: return@forEach
+            byKey[snap.key] = snap
+        }
+        val result = byKey.values.toList()
+        if (result.isNotEmpty()) {
+            cachedLogSnapshots = result
+            cachedLogSnapshotsAtMs = now
+        }
+        return result
+    }
+
+    private fun parseDeviceLogLine(line: String): DcmDeviceSnapshot? {
+        fun str(name: String): String? =
+            Regex("$name='([^']*)'").find(line)?.groupValues?.getOrNull(1)?.takeIf {
+                it.isNotBlank() && it != "null"
+            }
+
+        fun int(name: String): Int? =
+            Regex("$name=(-?\\d+)").find(line)?.groupValues?.getOrNull(1)?.toIntOrNull()
+
+        val id = str("mId")
+        val bt = str("mBtAddr")
+        val key = bt ?: id ?: return null
+        val capa = parseCapaState(
+            Regex("mActiveCapaState=\\{([^}]*)\\}").find(line)?.groupValues?.getOrNull(1).orEmpty()
+        )
+        return DcmDeviceSnapshot(
+            key = key,
+            uuid = id,
+            friendlyName = str("mFriendlyName"),
+            usbSerial = str("mUsbSerialNumber"),
+            btAddr = bt,
+            availableCapability = int("mAvailableCapability"),
+            activeCapability = int("mActiveCapability"),
+            deviceConnectedState = int("mDeviceConnectedState"),
+            connectedTypeState =
+                Regex("mConnectedTypeState=\\{([^}]*)\\}").find(line)?.groupValues?.getOrNull(1),
+            activeUsbAndroidAutoState = capa[CAP_ANDROID_AUTO_USB],
+            activeWirelessAndroidAutoState = capa[CAP_ANDROID_AUTO_WIRELESS]
+        )
+    }
+
+    private fun parseCapaState(raw: String): Map<Int, Int> {
+        if (raw.isBlank()) return emptyMap()
+        val map = HashMap<Int, Int>()
+        raw.split(",").forEach { part ->
+            val kv = part.trim().split("=")
+            if (kv.size == 2) {
+                val k = kv[0].trim().toIntOrNull()
+                val v = kv[1].trim().toIntOrNull()
+                if (k != null && v != null) map[k] = v
+            }
+        }
+        return map
     }
 
     private fun transactDisconnectProjection(


### PR DESCRIPTION
## Resumo

Quatro correções de estabilidade/UX do **cluster** e do **dashboard**, feitas sobre a branch **`preview`** e validadas ao vivo no carro (Haval H6 PHEV) durante uma viagem de ~4h, numa build própria (`1.0.0.73.20`). Cada uma está num **commit separado e independente** — dá pra cherry-pickar/revisar individualmente.

| # | Commit | Área | Tipo |
|---|--------|------|------|
| 1 | `fix(cluster): tela preta na re-entrada do AA + flicker por OOM do Shizuku` | Android Auto no cluster | correção |
| 2 | `fix(cluster): full-bleed do AA no Analogico V2` | Android Auto no cluster | correção |
| 3 | `feat(cluster): offset automatico do AA nos displays de mapa do Sport` | Android Auto no cluster | recurso |
| 4 | `fix(dashboard): observar chaves de config em tempo real` | Dashboard | correção |

> As fixes **1** e **3** tocam ambas o `DisplayAppLauncher.kt`, mas em regiões distintas (aplicam limpo em sequência).

---

### 1. Tela preta na re-entrada do Android Auto + flicker por OOM do Shizuku
**Arquivos:** `DisplayAppLauncher.kt`, `AndroidAutoDcmRecovery.kt`

Dois problemas de estabilidade do cluster que apareciam juntos:

**(a) Tela preta ao re-entrar com o AA no cluster.**
Tirar o AA do cluster (D3), mexer na multimídia e devolver o AA pro cluster fazia ele voltar **totalmente preto** — só recuperava alternando manualmente de novo.
- **Causa raiz:** `AndroidAutoDcmRecovery.readDeviceSnapshots()` retornava **sempre vazio**. Ele lê o snapshot de dispositivos por binder do OEM, mas o `Bundle` devolvido referencia a classe `ts.car.dcm.common.data.ConnDevice`, que **não existe no APK** → o unparcel/`keySet()` dispara `ClassNotFoundException`. Com o snapshot vazio, os pontos do `DisplayAppLauncher` que decidem o hand-off do cluster ficam **cegos** e não re-afirmam a projeção → tela preta.
- **Correção:** *fallback* que, quando o binder falha, **parseia as próprias linhas de log do OEM** (`DcController: mergeDevices ...Device{mId=...,mAvailableCapability=...,mActiveCapaState={128=4}...}`) pra reconstruir o estado de conexão/capacidade, com **cache de 3s** pra não repetir o parse.

**(b) Flicker do cluster ("velocímetro") por OOM do processo do Shizuku.**
O cluster piscava/apagava por instantes, de tempos em tempos.
- **Causa raiz:** `isProjectionUsbConfigured()` fazia `sh("cat /sys/class/android_usb/android0/state")` **via Shizuku a cada chamada**, e é chamado de vários pontos. Isso enchia o heap (~96 MB) do `shizuku_server` → `OutOfMemoryError` → o Shizuku reiniciava → a `Presentation` do cluster perdia a *surface* → flicker. (Não era crash do nosso app — mesmo PID o tempo todo.)
- **Correção:** ler o sysfs **direto** (`File(...).readText()`), com *fallback* pra shell e **cache de 500 ms** — o mesmo padrão que o `BottomBarService` já usa pra esse arquivo.

**Validação:** reproduzido e confirmado curado no carro.

---

### 2. Full-bleed do Android Auto no display Analógico V2
**Arquivo:** `ProjectionDisplayHtmlPolicy.kt`

- **Sintoma:** no display **Analógico V2**, o Android Auto aparecia só num **recorte quadrado no centro** da tela, enquanto o CarPlay ocupava a tela inteira.
- **Causa raiz:** a máscara *full-bleed* (`projectionFullBleedMaskStyle`, que troca o recorte preto opaco central por gradientes de borda) estava escopada **apenas em `.carplay-in-dash`**. Quando é o AA que projeta, o `app.html` marca `.projection-mirror-in-dash` — classe que a máscara não cobria.
- **Correção:** estender os seletores da máscara pra também cobrir `.projection-mirror-in-dash` (variante `.display-analogico-v2`). Os *bounds* do AA e do CarPlay já são idênticos (tela cheia), então a correção é **100% CSS**.

---

### 3. Offset automático do AA nos displays de mapa do Sport
**Arquivos:** `DisplayAppLauncher.kt`, `DisplaySelectionScreen.java`

- **O quê:** nos 3 displays de mapa do tema Sport (**Mapa / Mapa Graduado / Mapa Limpo**), a projeção do AA passa a ser deslocada **135 px pra direita** automaticamente, pra alinhar com o layout de mapa do tema. Nos demais displays (Analógico V2 / Normal / Digital) segue **tela cheia**.
- **Como:** `getAndroidAutoDisplayBounds(3)` lê o pref `CURRENT_CLUSTER_DISPLAY` e aplica o offset só quando for um dos modos de mapa; o toggle `ENABLE_AA_CLUSTER_OFFSET` força-sempre. `DisplaySelectionScreen.persistAndDispatch()` chama `DisplayAppLauncher.reapplyAndroidAutoClusterBounds()` pra reaplicar na hora ao trocar de display (no-op se o AA não estiver no D3). Offset default (`AA_CLUSTER_LEFT_OFFSET`) = **135**.

---

### 4. Dashboard atualiza em tempo real (chaves faltando no `DEFAULT_KEYS`)
**Arquivo:** `ServiceManager.java`

- **Sintoma:** campos do dashboard não atualizavam ao vivo quando o valor mudava **por fora** (ex.: trocar HEV **Inteligente → Prioritário** pelo popup ou pela multimídia). Só refletia ao **fechar e reabrir** o dashboard.
- **Causa raiz:** o listener `IDataChanged` do dashboard já tinha ramo pra todos os campos, mas ~**11 dessas chaves CAN não estavam em `DEFAULT_KEYS`** (o conjunto que o `ServiceManager` observa). Sem observar, o `onDataChanged` nunca dispara pra elas → o valor só é relido num `getData` novo (ou seja, reabrindo).
- **Correção:** adicionar as 11 chaves ao `DEFAULT_KEYS`: modo/reserva HEV, SOC alvo, ventilação dos bancos (motorista/passageiro/máx), odômetro restante, consumos e corrente da bateria.

---

## Compatibilidade / risco
- Sem mudança de API pública nem de layout dos temas. Itens **1–3** são específicos da projeção no cluster (D3); item **4** só amplia o conjunto de chaves **observadas** (custo desprezível — as chaves já eram lidas, só não observadas).
- Item **1** usa um formato de log do OEM como *fallback*: se o formato mudar, o comportamento apenas degrada pro estado anterior (não piora).
- Cada commit é independente e cherry-pickável (1 e 3 tocam o `DisplayAppLauncher.kt` em trechos distintos).

## Testes
- Compila: `:app:compileReleaseKotlin` + `:app:compileReleaseJavaWithJavac`.
- Validado ao vivo no carro na versão `1.0.0.73.20-preview` durante viagem (itens 1, 2, 3); item 4 confirmado no fluxo de troca de submodo HEV.
