### PR TITLE
feat(nav): captura passiva da navegação do Android Auto (ETA, km, próxima manobra)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -9,6 +9,11 @@
 -keepclassmembers class com.autolink.** implements android.os.Parcelable {
     public static final android.os.Parcelable$Creator CREATOR;
 }
+# SDK vendorizado do host do Android Auto (com.ts.androidauto.sdk.aidl.data.*): mantém o CREATOR
+# dos Parcelables de navegação p/ o wire-format do LinkCallback bater com o do host.
+-keepclassmembers class com.ts.androidauto.** implements android.os.Parcelable {
+    public static final android.os.Parcelable$Creator CREATOR;
+}
 
 # Preview/release builds must not emit diagnostic logcat output. The debug and internalDebug
 # variants keep logs available for bench/central diagnostics.

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/bridge/AndroidAutoNavManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/bridge/AndroidAutoNavManager.kt
@@ -58,6 +58,9 @@ object AndroidAutoNavManager {
     private var stepTurnAngle = -1
     private var stepTurnNumber = -1
     private var stepLanes: JSONArray? = null
+    // diagnóstico: lista inteira de passos (com cueData) + palpite de destino derivado do último passo
+    private var stepsDump: JSONArray? = null
+    private var destinationGuess: String? = null
     // distância/tempo até a próxima manobra (de onNavigationCurrentPosition)
     private var nextMeters = 0
     private var nextValue: String? = null
@@ -80,6 +83,21 @@ object AndroidAutoNavManager {
                 .getBoolean(SharedPreferencesKeys.ENABLE_AA_NAV_CAPTURE.key, true)
         } catch (e: Exception) {
             true
+        }
+    }
+
+    /**
+     * Debug: incluir a lista inteira de passos (com cueData) no payload, sob a key `steps`.
+     * Default OFF — enriquece o diagnóstico (localizar o destino quando o host não popula
+     * navigationDestinations, ex. Waze). Ligue a pref pra inspecionar a rota inteira.
+     */
+    private fun isDebugStepsEnabled(): Boolean {
+        return try {
+            App.getDeviceProtectedContext()
+                .getSharedPreferences("haval_prefs", Context.MODE_PRIVATE)
+                .getBoolean(SharedPreferencesKeys.ENABLE_AA_NAV_DEBUG_STEPS.key, false)
+        } catch (e: Exception) {
+            false
         }
     }
 
@@ -113,6 +131,10 @@ object AndroidAutoNavManager {
                 stepTurnNumber = first.turnNumber
                 stepLanes = buildLanes(first)
             }
+            // diagnóstico + fallback do destino: o host NÃO popula navigationDestinations pro Waze,
+            // mas stepData vem completo — guarda a lista inteira (com cueData) e tenta o destino no último passo.
+            stepsDump = buildStepsDump(steps)
+            destinationGuess = guessDestination(steps)
             rebuild()
         }
     }
@@ -155,11 +177,43 @@ object AndroidAutoNavManager {
         return if (arr.length() > 0) arr else null
     }
 
+    /** Diagnóstico: lista inteira de passos com cueData (caça ao nome do destino no Waze). */
+    private fun buildStepsDump(steps: List<IfNavigationStepData?>?): JSONArray? {
+        if (steps.isNullOrEmpty()) return null
+        val arr = JSONArray()
+        steps.forEachIndexed { i, st ->
+            if (st == null) return@forEachIndexed
+            val o = JSONObject()
+            o.put("i", i)
+            o.put("event", st.event)
+            o.put("icon", maneuverIcon(st.event))
+            st.road?.let { if (it.isNotEmpty()) o.put("road", it) }
+            if (st.turnNumber > 0) o.put("turnNumber", st.turnNumber)
+            if (st.turnAngle >= 0) o.put("turnAngle", st.turnAngle)
+            val cues = st.navigationCue
+            if (!cues.isNullOrEmpty()) o.put("cues", JSONArray(cues))
+            arr.put(o)
+        }
+        return if (arr.length() > 0) arr else null
+    }
+
+    /**
+     * Fallback do destino: eventos 39..42 = "destination". Se o último passo for um deles, o road
+     * (ou o 1º cue) costuma trazer o nome do destino — usado quando navigationDestinations vem vazio (Waze).
+     */
+    private fun guessDestination(steps: List<IfNavigationStepData?>?): String? {
+        val last = steps?.lastOrNull { it != null } ?: return null
+        if (last.event !in 39..42) return null
+        last.road?.let { if (it.isNotEmpty()) return it }
+        return last.navigationCue?.firstOrNull { !it.isNullOrEmpty() }
+    }
+
     private fun clear() {
         synchronized(lock) {
             active = false
             destinations = null; currentRoad = null
             stepEvent = -1; stepRoad = null; stepTurnAngle = -1; stepTurnNumber = -1; stepLanes = null
+            stepsDump = null; destinationGuess = null
             nextMeters = 0; nextValue = null; nextUnit = 0; nextTimeSeconds = 0L
             destMeters = 0; destValue = null; destUnit = 0; destEta = null; destTimeSeconds = 0L
             directionsJson = EMPTY
@@ -177,6 +231,10 @@ object AndroidAutoNavManager {
                     o.put("destination", list[0] ?: "")
                     o.put("destinations", JSONArray(list))
                 }
+            }
+            // fallback Waze: host não popula navigationDestinations → destino derivado do último passo (evento 39..42)
+            if (!o.has("destination")) destinationGuess?.let {
+                if (it.isNotEmpty()) { o.put("destination", it); o.put("destinationSource", "lastStep") }
             }
             currentRoad?.let { if (it.isNotEmpty()) o.put("currentRoad", it) }
             // destino: ETA + distância/tempo restante
@@ -202,6 +260,8 @@ object AndroidAutoNavManager {
                 stepLanes?.let { n.put("lanes", it) }
                 o.put("next", n)
             }
+            // diagnóstico (gated, default OFF): lista inteira de passos c/ cueData p/ localizar o destino
+            if (isDebugStepsEnabled()) stepsDump?.let { o.put("steps", it) }
             directionsJson = o.toString()
         } catch (e: Exception) {
             Log.e(TAG, "rebuild failed", e)

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/bridge/AndroidAutoNavManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/bridge/AndroidAutoNavManager.kt
@@ -1,0 +1,283 @@
+package br.com.redesurftank.havalshisuku.bridge
+
+import android.content.Context
+import android.os.Binder
+import android.os.IBinder
+import android.os.IInterface
+import android.os.Parcel
+import android.util.Log
+import br.com.redesurftank.App
+import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys
+import com.ts.androidauto.sdk.aidl.data.IfNavigationDestDistanceData
+import com.ts.androidauto.sdk.aidl.data.IfNavigationPositionData
+import com.ts.androidauto.sdk.aidl.data.IfNavigationStateData
+import com.ts.androidauto.sdk.aidl.data.IfNavigationStepData
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Captura PASSIVA dos dados de navegação (Waze / Google Maps / etc.) projetados via Android Auto.
+ *
+ * O host do AA (`com.ts.androidauto.projectionservice`) entrega os dados ESTRUTURADOS de navegação
+ * por callbacks de um `LinkCallback` (AIDL `com.ts.androidauto.sdk.aidl.LinkCallback`). Registramos
+ * o nosso callback via `LinkCommand.addLinkCallback` (transação 1) reaproveitando o binder que o
+ * [br.com.redesurftank.havalshisuku.managers.DisplayAppLauncher] já mantém vivo. Recebemos:
+ *   - onNavigationCurrentPosition (txn 11): distância/tempo até a PRÓXIMA manobra + a lista
+ *     [IfNavigationDestDistanceData] com ETA + distância/tempo até o DESTINO.
+ *   - onNavigationState (txn 10): passos (próxima manobra: tipo, via, ângulo, faixas) + destino.
+ *   - onNotifyNavigationState (txn 7): 1 = navegando; qualquer outro = parou (limpa).
+ *
+ * O snapshot é exposto como JSON via [getDirectionsJson] em
+ * [VirtualTelemetryManager] -> canal `app.navigation.directions`, consumido pelo tema/dashboard.
+ *
+ * É SÓ LEITURA e não interfere no cluster: o host itera uma lista de callbacks, então o nosso
+ * callback convive com o do próprio cluster (que continua recebendo os mesmos eventos).
+ */
+object AndroidAutoNavManager {
+    private const val TAG = "AANavCapture"
+
+    /** Descriptor do LinkCallback — precisa bater exatamente com o do host. */
+    const val LINK_CALLBACK_DESCRIPTOR = "com.ts.androidauto.sdk.aidl.LinkCallback"
+
+    // Códigos de transação que o host chama NO nosso callback (LinkCallback.Stub).
+    private const val TXN_ON_NOTIFY_NAV_STATE = 7
+    private const val TXN_ON_NAV_STATE = 10
+    private const val TXN_ON_NAV_POSITION = 11
+
+    private const val EMPTY = "{}"
+
+    private val lock = Any()
+
+    // ---- estado retido (mesclado dos dois callbacks) ----
+    @Volatile private var active = false
+    private var destinations: List<String>? = null
+    private var currentRoad: String? = null
+    // próxima manobra (de onNavigationState.stepData[0])
+    private var stepEvent = -1
+    private var stepRoad: String? = null
+    private var stepTurnAngle = -1
+    private var stepTurnNumber = -1
+    private var stepLanes: JSONArray? = null
+    // distância/tempo até a próxima manobra (de onNavigationCurrentPosition)
+    private var nextMeters = 0
+    private var nextValue: String? = null
+    private var nextUnit = 0
+    private var nextTimeSeconds = 0L
+    // distância/tempo/ETA até o destino (de onNavigationCurrentPosition.destDistance[0])
+    private var destMeters = 0
+    private var destValue: String? = null
+    private var destUnit = 0
+    private var destEta: String? = null
+    private var destTimeSeconds = 0L
+
+    @Volatile private var directionsJson: String = EMPTY
+
+    /** Toggle (default ON — captura passiva e aditiva). */
+    fun isEnabled(): Boolean {
+        return try {
+            App.getDeviceProtectedContext()
+                .getSharedPreferences("haval_prefs", Context.MODE_PRIVATE)
+                .getBoolean(SharedPreferencesKeys.ENABLE_AA_NAV_CAPTURE.key, true)
+        } catch (e: Exception) {
+            true
+        }
+    }
+
+    /** JSON snapshot consumido pelo sink `app.navigation.directions`. */
+    fun getDirectionsJson(): String = if (isEnabled()) directionsJson else EMPTY
+
+    /** Binder que registramos no host via `LinkCommand.addLinkCallback`. */
+    val callbackBinder: IBinder by lazy { NavLinkCallback() }
+
+    // ---- handlers dos callbacks ----
+
+    private fun handleNotifyNavState(status: Int) {
+        if (status == 1) {
+            synchronized(lock) { active = true; rebuild() }
+        } else {
+            clear()
+        }
+    }
+
+    private fun handleNavState(s: IfNavigationStateData?) {
+        if (s == null) { clear(); return }
+        synchronized(lock) {
+            active = true
+            destinations = s.navigationDestinations
+            val steps = s.stepData
+            val first: IfNavigationStepData? = if (!steps.isNullOrEmpty()) steps[0] else null
+            if (first != null) {
+                stepEvent = first.event
+                stepRoad = first.road
+                stepTurnAngle = first.turnAngle
+                stepTurnNumber = first.turnNumber
+                stepLanes = buildLanes(first)
+            }
+            rebuild()
+        }
+    }
+
+    private fun handleNavPosition(p: IfNavigationPositionData?) {
+        if (p == null) { clear(); return }
+        synchronized(lock) {
+            active = true
+            nextMeters = p.meters
+            nextValue = p.displayValue
+            nextUnit = p.displayUnits
+            nextTimeSeconds = p.timeSeconds
+            currentRoad = p.currentRoad
+            val dests = p.ifNavigationDestDistanceData
+            val d: IfNavigationDestDistanceData? = if (!dests.isNullOrEmpty()) dests[0] else null
+            if (d != null) {
+                destMeters = d.meters
+                destValue = d.displayValue
+                destUnit = d.displayUnits
+                destEta = d.estimatedTime
+                destTimeSeconds = d.timeSeconds
+            }
+            rebuild()
+        }
+    }
+
+    private fun buildLanes(step: IfNavigationStepData): JSONArray? {
+        val lanes = step.laneData ?: return null
+        val arr = JSONArray()
+        for (lane in lanes) {
+            val dirs = lane?.ifNavigationDirectionData ?: continue
+            for (dir in dirs) {
+                if (dir == null) continue
+                arr.put(JSONObject().apply {
+                    put("shape", dir.shape)
+                    put("highlighted", dir.highlighted)
+                })
+            }
+        }
+        return if (arr.length() > 0) arr else null
+    }
+
+    private fun clear() {
+        synchronized(lock) {
+            active = false
+            destinations = null; currentRoad = null
+            stepEvent = -1; stepRoad = null; stepTurnAngle = -1; stepTurnNumber = -1; stepLanes = null
+            nextMeters = 0; nextValue = null; nextUnit = 0; nextTimeSeconds = 0L
+            destMeters = 0; destValue = null; destUnit = 0; destEta = null; destTimeSeconds = 0L
+            directionsJson = EMPTY
+        }
+    }
+
+    /** Recompõe o JSON a partir do estado retido. Deve ser chamado sob [lock]. */
+    private fun rebuild() {
+        if (!active) { directionsJson = EMPTY; return }
+        try {
+            val o = JSONObject()
+            o.put("active", true)
+            destinations?.let { list ->
+                if (list.isNotEmpty()) {
+                    o.put("destination", list[0] ?: "")
+                    o.put("destinations", JSONArray(list))
+                }
+            }
+            currentRoad?.let { if (it.isNotEmpty()) o.put("currentRoad", it) }
+            // destino: ETA + distância/tempo restante
+            destEta?.let { if (it.isNotEmpty()) o.put("eta", it) }
+            if (destTimeSeconds > 0L) o.put("remainingSeconds", destTimeSeconds)
+            if (destMeters > 0) o.put("remainingMeters", destMeters)
+            destValue?.let { if (it.isNotEmpty()) o.put("remainingText", it) }
+            if (destUnit != 0) o.put("remainingUnit", unitLabel(destUnit))
+            // próxima manobra
+            if (stepEvent >= 0 || nextMeters > 0) {
+                val n = JSONObject()
+                if (stepEvent >= 0) {
+                    n.put("event", stepEvent)
+                    n.put("icon", maneuverIcon(stepEvent))
+                }
+                stepRoad?.let { if (it.isNotEmpty()) n.put("road", it) }
+                if (stepTurnAngle >= 0) n.put("turnAngle", stepTurnAngle)
+                if (stepTurnNumber > 0) n.put("turnNumber", stepTurnNumber)
+                if (nextMeters > 0) n.put("distanceMeters", nextMeters)
+                nextValue?.let { if (it.isNotEmpty()) n.put("distanceText", it) }
+                if (nextUnit != 0) n.put("distanceUnit", unitLabel(nextUnit))
+                if (nextTimeSeconds > 0L) n.put("timeSeconds", nextTimeSeconds)
+                stepLanes?.let { n.put("lanes", it) }
+                o.put("next", n)
+            }
+            directionsJson = o.toString()
+        } catch (e: Exception) {
+            Log.e(TAG, "rebuild failed", e)
+        }
+    }
+
+    private fun unitLabel(u: Int): String = when (u) {
+        1 -> "m"
+        2, 3 -> "km"
+        4, 5 -> "mi"
+        6 -> "ft"
+        7 -> "yd"
+        else -> ""
+    }
+
+    /**
+     * Mapa do tipo de manobra (`mEvent`) -> rótulo de ícone, portado da tabela do host
+     * (NavigationProxy.initWhiteBitMap). 32-35 = rotatória (o ângulo detalha o setor).
+     */
+    private fun maneuverIcon(event: Int): String = MANEUVER_ICONS[event] ?: when (event) {
+        32, 33, 34, 35 -> "roundabout"
+        else -> "unknown"
+    }
+
+    private val MANEUVER_ICONS: Map<Int, String> = mapOf(
+        1 to "depart", 2 to "name_change", 3 to "keep_l", 4 to "keep_r",
+        5 to "slight_turn_l", 6 to "slight_turn_r", 7 to "turn_l", 8 to "turn_r",
+        9 to "sharp_turn_l", 10 to "sharp_turn_r", 11 to "u_turn_l", 12 to "u_turn_r",
+        13 to "slight_turn_l", 14 to "slight_turn_r", 15 to "turn_l", 16 to "turn_r",
+        17 to "sharp_turn_l", 18 to "sharp_turn_r", 19 to "u_turn_l", 20 to "u_turn_r",
+        21 to "slight_turn_l", 22 to "slight_turn_r", 23 to "turn_l", 24 to "turn_r",
+        25 to "fork_l", 26 to "fork_r", 27 to "merge", 28 to "merge", 29 to "merge",
+        36 to "name_change", 37 to "ferry_boat", 39 to "destination", 40 to "destination",
+        41 to "destination", 42 to "destination", 43 to "roundabout_enter_l",
+        44 to "roundabout_exit_l", 45 to "roundabout_enter_r", 46 to "roundabout_exit_r",
+        47 to "ferry_boat", 48 to "ferry_boat"
+    )
+
+    /**
+     * Binder local registrado no host como um `LinkCallback`. Implementa [IInterface] só pra
+     * `attachInterface`/`queryLocalInterface` (espelha o Stub gerado). Só tratamos os callbacks de
+     * navegação; o resto cai no super. Callbacks do host são ONEWAY, então não escrevemos reply.
+     */
+    private class NavLinkCallback : Binder(), IInterface {
+        init { attachInterface(this, LINK_CALLBACK_DESCRIPTOR) }
+
+        override fun asBinder(): IBinder = this
+
+        override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean {
+            return try {
+                when (code) {
+                    TXN_ON_NOTIFY_NAV_STATE -> {
+                        data.enforceInterface(LINK_CALLBACK_DESCRIPTOR)
+                        handleNotifyNavState(data.readInt())
+                        true
+                    }
+                    TXN_ON_NAV_STATE -> {
+                        data.enforceInterface(LINK_CALLBACK_DESCRIPTOR)
+                        val s = if (data.readInt() != 0)
+                            IfNavigationStateData.CREATOR.createFromParcel(data) else null
+                        handleNavState(s)
+                        true
+                    }
+                    TXN_ON_NAV_POSITION -> {
+                        data.enforceInterface(LINK_CALLBACK_DESCRIPTOR)
+                        val p = if (data.readInt() != 0)
+                            IfNavigationPositionData.CREATOR.createFromParcel(data) else null
+                        handleNavPosition(p)
+                        true
+                    }
+                    else -> super.onTransact(code, data, reply, flags)
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "onTransact code=$code failed", e)
+                true
+            }
+        }
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/bridge/VirtualTelemetryManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/bridge/VirtualTelemetryManager.kt
@@ -91,10 +91,7 @@ object VirtualTelemetryManager {
             "app.display.3.active_app_label" -> getActiveAppLabel(context, 3)
             "app.display.3.active_app_icon" -> getActiveAppIconBase64(context, 3)
             "app.launcher.apps" -> getLauncherAppsJson(context)
-            "app.navigation.directions" -> {
-                // Return generic / empty placeholder if not wired yet, satisfying additive principle
-                "{}"
-            }
+            "app.navigation.directions" -> AndroidAutoNavManager.getDirectionsJson()
             else -> ""
         }
     }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/DisplayAppLauncher.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/DisplayAppLauncher.kt
@@ -138,6 +138,7 @@ object DisplayAppLauncher {
         Pattern.compile("\\bstate\\s*[:=]\\s*started\\b", Pattern.CASE_INSENSITIVE)
     private const val ANDROID_AUTO_LINK_COMMAND_INTERFACE = "com.ts.androidauto.sdk.aidl.LinkCommand"
     private const val ANDROID_AUTO_LINK_COMMAND_CONNECT_TRANSACTION = 0x07
+    private const val ANDROID_AUTO_LINK_COMMAND_ADD_CALLBACK_TRANSACTION = 0x01
     private const val ANDROID_AUTO_LINK_COMMAND_SEND_KEY_EVENT_TRANSACTION = 0x0a
     private const val ANDROID_AUTO_LINK_COMMAND_SEND_VEHICLE_INFO_TRANSACTION = 0x0c
     private const val ANDROID_AUTO_LINK_COMMAND_GET_DEVICE_LIST_TRANSACTION = 0x0d
@@ -433,6 +434,7 @@ object DisplayAppLauncher {
     @Volatile private var androidAutoLinkCommandBindingStarted = false
     @Volatile private var androidAutoLinkCommandBindRequestedAtMs = 0L
     @Volatile private var lastAndroidAutoLinkCommandReconnectAtMs = 0L
+    @Volatile private var androidAutoNavCallbackRegistered = false
     private val carPlayServiceLock = Any()
     @Volatile private var carPlayServiceBinder: IBinder? = null
     @Volatile private var carPlayServiceBindingStarted = false
@@ -447,6 +449,7 @@ object DisplayAppLauncher {
             Log.w(TAG, "[ANDROID_AUTO_LINK_COMMAND_BIND] Connected to $name")
             scope.launch {
                 subscribeAndroidAutoHmiKeys("ANDROID_AUTO_LINK_COMMAND_BIND")
+                registerAndroidAutoNavCallbackIfEnabled("ANDROID_AUTO_LINK_COMMAND_BIND")
             }
         }
 
@@ -455,6 +458,7 @@ object DisplayAppLauncher {
                 androidAutoLinkCommandBinder = null
                 androidAutoLinkCommandBindingStarted = false
                 androidAutoLinkCommandBindRequestedAtMs = 0L
+                androidAutoNavCallbackRegistered = false
             }
             Log.w(TAG, "[ANDROID_AUTO_LINK_COMMAND_BIND] Disconnected from $name")
         }
@@ -1882,6 +1886,33 @@ object DisplayAppLauncher {
         } finally {
             reply.recycle()
             data.recycle()
+        }
+    }
+
+    /**
+     * Registra o nosso LinkCallback PASSIVO no host do AA (LinkCommand.addLinkCallback, txn 1) pra
+     * receber os eventos de navegação (ETA/km/próxima manobra). Reaproveita o binder do LinkCommand
+     * que já mantemos vivo. Idempotente por conexão (re-registra a cada onServiceConnected; o flag
+     * zera no onServiceDisconnected). Só leitura — o host itera uma lista de callbacks, então não
+     * atrapalha o callback do próprio cluster.
+     */
+    private fun registerAndroidAutoNavCallbackIfEnabled(reason: String) {
+        if (!br.com.redesurftank.havalshisuku.bridge.AndroidAutoNavManager.isEnabled()) return
+        if (androidAutoNavCallbackRegistered) return
+        val ok =
+            transactAndroidAutoLinkCommandSync(
+                ANDROID_AUTO_LINK_COMMAND_ADD_CALLBACK_TRANSACTION,
+                "${reason}_NAV_CALLBACK"
+            ) { data ->
+                data.writeStrongBinder(
+                    br.com.redesurftank.havalshisuku.bridge.AndroidAutoNavManager.callbackBinder
+                )
+            }
+        if (ok) {
+            androidAutoNavCallbackRegistered = true
+            Log.w(TAG, "[$reason] Android Auto nav callback registrado")
+        } else {
+            Log.w(TAG, "[$reason] Falha ao registrar nav callback do Android Auto (retenta no próximo bind)")
         }
     }
 

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -404,5 +404,10 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
     DATATRACK_DISABLED_BY_APP("datatrackDisabledByApp", "Controle interno: DataTrack desabilitado por este app"),
     MOBILE_DATA_TRAFFIC_ACCUM_BYTES("mobileDataTrafficAccumBytes", "Acumulado de bytes móveis no ciclo (fallback TrafficStats)"),
     MOBILE_DATA_TRAFFIC_LAST_READING("mobileDataTrafficLastReading", "Última leitura do TrafficStats móvel (controle interno)"),
-    MOBILE_DATA_TRAFFIC_CYCLE_TAG("mobileDataTrafficCycleTag", "Ciclo atual do acumulador de bytes (controle interno)")
+    MOBILE_DATA_TRAFFIC_CYCLE_TAG("mobileDataTrafficCycleTag", "Ciclo atual do acumulador de bytes (controle interno)"),
+    // ===== Captura de navegação do Android Auto (ETA/km/manobra) para o painel =====
+    ENABLE_AA_NAV_CAPTURE(
+            "enableAaNavCapture",
+            "Capturar navegação (ETA, km, próxima manobra) do Android Auto para o painel"
+    )
 }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -409,5 +409,10 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
     ENABLE_AA_NAV_CAPTURE(
             "enableAaNavCapture",
             "Capturar navegação (ETA, km, próxima manobra) do Android Auto para o painel"
+    ),
+    // Diagnóstico: expõe a lista inteira de passos (com cueData) no canal de nav — caça ao nome do destino no Waze
+    ENABLE_AA_NAV_DEBUG_STEPS(
+            "enableAaNavDebugSteps",
+            "Diagnóstico: incluir a lista inteira de passos (steps + cues) no canal de navegação"
     )
 }

--- a/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationData.java
+++ b/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationData.java
@@ -1,0 +1,117 @@
+package com.ts.androidauto.sdk.aidl.data;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/* JADX INFO: loaded from: classes.dex */
+public final class IfNavigationData implements Parcelable {
+    public static final Parcelable.Creator<IfNavigationData> CREATOR = new Parcelable.Creator<IfNavigationData>() { // from class: com.ts.androidauto.sdk.aidl.data.IfNavigationData.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationData createFromParcel(Parcel in) {
+            return new IfNavigationData(in);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationData[] newArray(int size) {
+            return new IfNavigationData[size];
+        }
+    };
+    private int mEvent;
+    private byte[] mImage;
+    private String mRoad;
+    private int mTurnAngle;
+    private int mTurnNumber;
+    private int mTurnSide;
+
+    public IfNavigationData() {
+    }
+
+    public byte[] getImage() {
+        return this.mImage;
+    }
+
+    public int getEvent() {
+        return this.mEvent;
+    }
+
+    public int getTurnAngle() {
+        return this.mTurnAngle;
+    }
+
+    public int getTurnNumber() {
+        return this.mTurnNumber;
+    }
+
+    public int getTurnSide() {
+        return this.mTurnSide;
+    }
+
+    public String getRoad() {
+        return this.mRoad;
+    }
+
+    public void setEvent(int event) {
+        this.mEvent = event;
+    }
+
+    public void setImage(byte[] image) {
+        this.mImage = image;
+    }
+
+    public void setRoad(String road) {
+        this.mRoad = road;
+    }
+
+    public void setTurnAngle(int turnAngle) {
+        this.mTurnAngle = turnAngle;
+    }
+
+    public void setTurnNumber(int turnNumber) {
+        this.mTurnNumber = turnNumber;
+    }
+
+    public void setTurnSide(int turnSide) {
+        this.mTurnSide = turnSide;
+    }
+
+    public IfNavigationData(Parcel in) {
+        this.mRoad = in.readString();
+        this.mTurnSide = in.readInt();
+        this.mEvent = in.readInt();
+        int len = in.readInt();
+        if (len <= 0) {
+            this.mImage = null;
+        } else {
+            this.mImage = new byte[len];
+            in.readByteArray(this.mImage);
+        }
+        this.mTurnAngle = in.readInt();
+        this.mTurnNumber = in.readInt();
+    }
+
+    public String toString() {
+        return this.mRoad + " " + this.mTurnSide + " " + this.mEvent + " " + this.mImage + " " + this.mTurnAngle + " " + this.mTurnNumber;
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(this.mRoad);
+        parcel.writeInt(this.mTurnSide);
+        parcel.writeInt(this.mEvent);
+        if (this.mImage != null && this.mImage.length > 0) {
+            parcel.writeInt(this.mImage.length);
+            parcel.writeByteArray(this.mImage);
+        } else {
+            parcel.writeInt(0);
+        }
+        parcel.writeInt(this.mTurnAngle);
+        parcel.writeInt(this.mTurnNumber);
+    }
+}

--- a/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationDestDistanceData.java
+++ b/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationDestDistanceData.java
@@ -1,0 +1,95 @@
+package com.ts.androidauto.sdk.aidl.data;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/* JADX INFO: loaded from: classes.dex */
+public final class IfNavigationDestDistanceData implements Parcelable {
+    public static final Parcelable.Creator<IfNavigationDestDistanceData> CREATOR = new Parcelable.Creator<IfNavigationDestDistanceData>() { // from class: com.ts.androidauto.sdk.aidl.data.IfNavigationDestDistanceData.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationDestDistanceData createFromParcel(Parcel in) {
+            return new IfNavigationDestDistanceData(in);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationDestDistanceData[] newArray(int size) {
+            return new IfNavigationDestDistanceData[size];
+        }
+    };
+    private int mDisplayUnits;
+    private String mDisplayValue;
+    private String mEstimatedTime;
+    private int mMeters;
+    private long mTimeSeconds;
+
+    public String getDisplayValue() {
+        return this.mDisplayValue;
+    }
+
+    public void setDisplayValue(String displayValue) {
+        this.mDisplayValue = displayValue;
+    }
+
+    public int getMeters() {
+        return this.mMeters;
+    }
+
+    public void setMeters(int meters) {
+        this.mMeters = meters;
+    }
+
+    public int getDisplayUnits() {
+        return this.mDisplayUnits;
+    }
+
+    public void setDisplayUnits(int displayUnits) {
+        this.mDisplayUnits = displayUnits;
+    }
+
+    public String getEstimatedTime() {
+        return this.mEstimatedTime;
+    }
+
+    public void setEstimatedTime(String estimatedTime) {
+        this.mEstimatedTime = estimatedTime;
+    }
+
+    public long getTimeSeconds() {
+        return this.mTimeSeconds;
+    }
+
+    public void setTimeSeconds(long timeSeconds) {
+        this.mTimeSeconds = timeSeconds;
+    }
+
+    public IfNavigationDestDistanceData() {
+    }
+
+    public IfNavigationDestDistanceData(Parcel in) {
+        this.mDisplayValue = in.readString();
+        this.mMeters = in.readInt();
+        this.mDisplayUnits = in.readInt();
+        this.mEstimatedTime = in.readString();
+        this.mTimeSeconds = in.readLong();
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(this.mDisplayValue);
+        parcel.writeInt(this.mMeters);
+        parcel.writeInt(this.mDisplayUnits);
+        parcel.writeString(this.mEstimatedTime);
+        parcel.writeLong(this.mTimeSeconds);
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    public String toString() {
+        return "IfNavigationDestDistanceData{mDisplayValue='" + this.mDisplayValue + "', mMeters=" + this.mMeters + ", mDisplayUnits=" + this.mDisplayUnits + ", mEstimatedTime='" + this.mEstimatedTime + "', mTimeSeconds=" + this.mTimeSeconds + '}';
+    }
+}

--- a/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationDirectionData.java
+++ b/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationDirectionData.java
@@ -1,0 +1,62 @@
+package com.ts.androidauto.sdk.aidl.data;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/* JADX INFO: loaded from: classes.dex */
+public final class IfNavigationDirectionData implements Parcelable {
+    public static final Parcelable.Creator<IfNavigationDirectionData> CREATOR = new Parcelable.Creator<IfNavigationDirectionData>() { // from class: com.ts.androidauto.sdk.aidl.data.IfNavigationDirectionData.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationDirectionData createFromParcel(Parcel in) {
+            return new IfNavigationDirectionData(in);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationDirectionData[] newArray(int size) {
+            return new IfNavigationDirectionData[size];
+        }
+    };
+    private int mIsHighlighted;
+    private int mShape;
+
+    public IfNavigationDirectionData() {
+    }
+
+    public IfNavigationDirectionData(Parcel in) {
+        this.mShape = in.readInt();
+        this.mIsHighlighted = in.readInt();
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeInt(this.mShape);
+        parcel.writeInt(this.mIsHighlighted);
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    public int getShape() {
+        return this.mShape;
+    }
+
+    public void setShape(int shape) {
+        this.mShape = shape;
+    }
+
+    public int getHighlighted() {
+        return this.mIsHighlighted;
+    }
+
+    public void setHighlighted(int highlighted) {
+        this.mIsHighlighted = highlighted;
+    }
+
+    public String toString() {
+        return "IfNavigationDirectionData{mShape=" + this.mShape + ", mIsHighlighted=" + this.mIsHighlighted + '}';
+    }
+}

--- a/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationLaneData.java
+++ b/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationLaneData.java
@@ -1,0 +1,62 @@
+package com.ts.androidauto.sdk.aidl.data;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import java.util.List;
+
+/* JADX INFO: loaded from: classes.dex */
+public final class IfNavigationLaneData implements Parcelable {
+    public static final Parcelable.Creator<IfNavigationLaneData> CREATOR = new Parcelable.Creator<IfNavigationLaneData>() { // from class: com.ts.androidauto.sdk.aidl.data.IfNavigationLaneData.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationLaneData createFromParcel(Parcel in) {
+            return new IfNavigationLaneData(in);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationLaneData[] newArray(int size) {
+            return new IfNavigationLaneData[size];
+        }
+    };
+    private List<IfNavigationDirectionData> mIfNavigationDirectionData;
+
+    public IfNavigationLaneData() {
+    }
+
+    public IfNavigationLaneData(Parcel in) {
+        int sizeDirection = in.readInt();
+        if (sizeDirection <= 0) {
+            this.mIfNavigationDirectionData = null;
+        } else {
+            this.mIfNavigationDirectionData = in.createTypedArrayList(IfNavigationDirectionData.CREATOR);
+        }
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        if (this.mIfNavigationDirectionData != null && this.mIfNavigationDirectionData.size() > 0) {
+            parcel.writeInt(this.mIfNavigationDirectionData.size());
+            parcel.writeTypedList(this.mIfNavigationDirectionData);
+        } else {
+            parcel.writeInt(0);
+        }
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    public List<IfNavigationDirectionData> getIfNavigationDirectionData() {
+        return this.mIfNavigationDirectionData;
+    }
+
+    public void setIfNavigationDirectionData(List<IfNavigationDirectionData> ifNavigationDirectionData) {
+        this.mIfNavigationDirectionData = ifNavigationDirectionData;
+    }
+
+    public String toString() {
+        return "IfNavigationLaneData{mIfNavigationDirectionData=" + this.mIfNavigationDirectionData + '}';
+    }
+}

--- a/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationPositionData.java
+++ b/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationPositionData.java
@@ -1,0 +1,117 @@
+package com.ts.androidauto.sdk.aidl.data;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import java.util.List;
+
+/* JADX INFO: loaded from: classes.dex */
+public final class IfNavigationPositionData implements Parcelable {
+    public static final Parcelable.Creator<IfNavigationPositionData> CREATOR = new Parcelable.Creator<IfNavigationPositionData>() { // from class: com.ts.androidauto.sdk.aidl.data.IfNavigationPositionData.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationPositionData createFromParcel(Parcel in) {
+            return new IfNavigationPositionData(in);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationPositionData[] newArray(int size) {
+            return new IfNavigationPositionData[size];
+        }
+    };
+    private String mCurrentRoad;
+    private int mDisplayUnits;
+    private String mDisplayValue;
+    private List<IfNavigationDestDistanceData> mIfNavigationDestDistanceData;
+    private int mMeters;
+    private long mTimeSeconds;
+
+    public String getDisplayValue() {
+        return this.mDisplayValue;
+    }
+
+    public void setDisplayValue(String displayValue) {
+        this.mDisplayValue = displayValue;
+    }
+
+    public int getMeters() {
+        return this.mMeters;
+    }
+
+    public void setMeters(int meters) {
+        this.mMeters = meters;
+    }
+
+    public int getDisplayUnits() {
+        return this.mDisplayUnits;
+    }
+
+    public void setDisplayUnits(int displayUnits) {
+        this.mDisplayUnits = displayUnits;
+    }
+
+    public long getTimeSeconds() {
+        return this.mTimeSeconds;
+    }
+
+    public void setTimeSeconds(long timeSeconds) {
+        this.mTimeSeconds = timeSeconds;
+    }
+
+    public String getCurrentRoad() {
+        return this.mCurrentRoad;
+    }
+
+    public void setCurrentRoad(String currentRoad) {
+        this.mCurrentRoad = currentRoad;
+    }
+
+    public List<IfNavigationDestDistanceData> getIfNavigationDestDistanceData() {
+        return this.mIfNavigationDestDistanceData;
+    }
+
+    public void setIfNavigationDestDistanceData(List<IfNavigationDestDistanceData> navigationDestDistanceData) {
+        this.mIfNavigationDestDistanceData = navigationDestDistanceData;
+    }
+
+    public IfNavigationPositionData() {
+    }
+
+    public IfNavigationPositionData(Parcel in) {
+        this.mDisplayValue = in.readString();
+        this.mMeters = in.readInt();
+        this.mDisplayUnits = in.readInt();
+        this.mTimeSeconds = in.readLong();
+        this.mCurrentRoad = in.readString();
+        int sizeDestDistance = in.readInt();
+        if (sizeDestDistance <= 0) {
+            this.mIfNavigationDestDistanceData = null;
+        } else {
+            this.mIfNavigationDestDistanceData = in.createTypedArrayList(IfNavigationDestDistanceData.CREATOR);
+        }
+    }
+
+    public String toString() {
+        return "IfNavigationPositionData{mDisplayValue='" + this.mDisplayValue + "', mMeters=" + this.mMeters + ", mDisplayUnits=" + this.mDisplayUnits + ", mTimeSeconds=" + this.mTimeSeconds + ", mCurrentRoad=" + this.mCurrentRoad + ", mIfNavigationDestDistanceData=" + this.mIfNavigationDestDistanceData + '}';
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(this.mDisplayValue);
+        parcel.writeInt(this.mMeters);
+        parcel.writeInt(this.mDisplayUnits);
+        parcel.writeLong(this.mTimeSeconds);
+        parcel.writeString(this.mCurrentRoad);
+        if (this.mIfNavigationDestDistanceData != null && this.mIfNavigationDestDistanceData.size() > 0) {
+            parcel.writeInt(this.mIfNavigationDestDistanceData.size());
+            parcel.writeTypedList(this.mIfNavigationDestDistanceData);
+        } else {
+            parcel.writeInt(0);
+        }
+    }
+}

--- a/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationStateData.java
+++ b/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationStateData.java
@@ -1,0 +1,83 @@
+package com.ts.androidauto.sdk.aidl.data;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import java.util.List;
+
+/* JADX INFO: loaded from: classes.dex */
+public final class IfNavigationStateData implements Parcelable {
+    public static final Parcelable.Creator<IfNavigationStateData> CREATOR = new Parcelable.Creator<IfNavigationStateData>() { // from class: com.ts.androidauto.sdk.aidl.data.IfNavigationStateData.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationStateData createFromParcel(Parcel in) {
+            return new IfNavigationStateData(in);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationStateData[] newArray(int size) {
+            return new IfNavigationStateData[size];
+        }
+    };
+    private List<String> mDestinationData;
+    private List<IfNavigationStepData> mStepData;
+
+    public IfNavigationStateData() {
+    }
+
+    public List<IfNavigationStepData> getStepData() {
+        return this.mStepData;
+    }
+
+    public void setStepData(List<IfNavigationStepData> stepData) {
+        this.mStepData = stepData;
+    }
+
+    public List<String> getNavigationDestinations() {
+        return this.mDestinationData;
+    }
+
+    public void setNavigationDestinations(List<String> navigationDestinations) {
+        this.mDestinationData = navigationDestinations;
+    }
+
+    public IfNavigationStateData(Parcel in) {
+        int sizeDest = in.readInt();
+        if (sizeDest <= 0) {
+            this.mDestinationData = null;
+        } else {
+            this.mDestinationData = in.createStringArrayList();
+        }
+        int sizeStep = in.readInt();
+        if (sizeStep <= 0) {
+            this.mStepData = null;
+        } else {
+            this.mStepData = in.createTypedArrayList(IfNavigationStepData.CREATOR);
+        }
+    }
+
+    public String toString() {
+        return "IfNavigationStateData{mStepData=" + this.mStepData + ", mDestinationData=" + this.mDestinationData + '}';
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        if (this.mDestinationData != null && this.mDestinationData.size() > 0) {
+            parcel.writeInt(this.mDestinationData.size());
+            parcel.writeStringList(this.mDestinationData);
+        } else {
+            parcel.writeInt(0);
+        }
+        if (this.mStepData != null && this.mStepData.size() > 0) {
+            parcel.writeInt(this.mStepData.size());
+            parcel.writeTypedList(this.mStepData);
+        } else {
+            parcel.writeInt(0);
+        }
+    }
+}

--- a/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationStepData.java
+++ b/app/src/main/java/com/ts/androidauto/sdk/aidl/data/IfNavigationStepData.java
@@ -1,0 +1,127 @@
+package com.ts.androidauto.sdk.aidl.data;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import java.util.List;
+
+/* JADX INFO: loaded from: classes.dex */
+public final class IfNavigationStepData implements Parcelable {
+    public static final Parcelable.Creator<IfNavigationStepData> CREATOR = new Parcelable.Creator<IfNavigationStepData>() { // from class: com.ts.androidauto.sdk.aidl.data.IfNavigationStepData.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationStepData createFromParcel(Parcel in) {
+            return new IfNavigationStepData(in);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public IfNavigationStepData[] newArray(int size) {
+            return new IfNavigationStepData[size];
+        }
+    };
+    private List<String> mCueData;
+    private int mEvent;
+    private List<IfNavigationLaneData> mLaneData;
+    private String mRoad;
+    private int mTurnAngle;
+    private int mTurnNumber;
+
+    public IfNavigationStepData() {
+    }
+
+    public List<IfNavigationLaneData> getLaneData() {
+        return this.mLaneData;
+    }
+
+    public void setLaneData(List<IfNavigationLaneData> laneData) {
+        this.mLaneData = laneData;
+    }
+
+    public List<String> getNavigationCue() {
+        return this.mCueData;
+    }
+
+    public void setNavigationCue(List<String> navigationCue) {
+        this.mCueData = navigationCue;
+    }
+
+    public int getEvent() {
+        return this.mEvent;
+    }
+
+    public int getTurnAngle() {
+        return this.mTurnAngle;
+    }
+
+    public int getTurnNumber() {
+        return this.mTurnNumber;
+    }
+
+    public String getRoad() {
+        return this.mRoad;
+    }
+
+    public void setEvent(int event) {
+        this.mEvent = event;
+    }
+
+    public void setRoad(String road) {
+        this.mRoad = road;
+    }
+
+    public void setTurnAngle(int turnAngle) {
+        this.mTurnAngle = turnAngle;
+    }
+
+    public void setTurnNumber(int turnNumber) {
+        this.mTurnNumber = turnNumber;
+    }
+
+    public IfNavigationStepData(Parcel in) {
+        this.mRoad = in.readString();
+        this.mEvent = in.readInt();
+        this.mTurnAngle = in.readInt();
+        this.mTurnNumber = in.readInt();
+        int sizeCue = in.readInt();
+        if (sizeCue <= 0) {
+            this.mCueData = null;
+        } else {
+            this.mCueData = in.createStringArrayList();
+        }
+        int sizeLane = in.readInt();
+        if (sizeLane <= 0) {
+            this.mLaneData = null;
+        } else {
+            this.mLaneData = in.createTypedArrayList(IfNavigationLaneData.CREATOR);
+        }
+    }
+
+    public String toString() {
+        return "IfNavigationStepData{mRoad='" + this.mRoad + "', mEvent=" + this.mEvent + ", mTurnAngle=" + this.mTurnAngle + ", mTurnNumber=" + this.mTurnNumber + ", mLaneData=" + this.mLaneData + ", mCueData=" + this.mCueData + '}';
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(this.mRoad);
+        parcel.writeInt(this.mEvent);
+        parcel.writeInt(this.mTurnAngle);
+        parcel.writeInt(this.mTurnNumber);
+        if (this.mCueData != null && this.mCueData.size() > 0) {
+            parcel.writeInt(this.mCueData.size());
+            parcel.writeStringList(this.mCueData);
+        } else {
+            parcel.writeInt(0);
+        }
+        if (this.mLaneData != null && this.mLaneData.size() > 0) {
+            parcel.writeInt(this.mLaneData.size());
+            parcel.writeTypedList(this.mLaneData);
+        } else {
+            parcel.writeInt(0);
+        }
+    }
+}


### PR DESCRIPTION
## O que é

Captura **passiva** dos dados de navegação (Waze / Google Maps / qualquer app de nav projetado) que o **Android Auto** entrega pro cluster, e publica no canal de telemetria `app.navigation.directions` — que hoje é um placeholder que devolve `{}`. Assim o tema/dashboard ganha acesso a **ETA, distância ao destino e próxima manobra** pra renderizar como quiser.

> ⚠️ **Somente Android Auto** (ver seção _Escopo_). A **renderização na tela não faz parte deste PR** — fica a cargo do tema/dashboard. Aqui é só a **fonte de dado** no canal.

## Como funciona

O host do AA (`com.ts.androidauto.projectionservice`, interface `com.ts.androidauto.sdk.aidl.LinkCommand`) já entrega os dados **estruturados** de navegação via callbacks de um `LinkCallback` — é o que o cluster nativo consome pra desenhar a seta de manobra no HUD. A engenharia reversa de `AndroidAutoApp.apk` / `AndroidAutoService.apk` mostrou o caminho exato:

1. **Registro** — `LinkCommand.addLinkCallback(cb)` (transação **1**), **reaproveitando o binder do LinkCommand que o `DisplayAppLauncher` já mantém vivo** (não abre bind novo). O `addLinkCallback` do host **itera uma lista** de callbacks, então a nossa assinatura **convive** com a do cluster: é 100% passiva, não interfere na projeção nem no HUD nativo.
2. **Callbacks recebidos** (o host chama no nosso `LinkCallback`):
   - `onNavigationCurrentPosition(IfNavigationPositionData)` — txn **11** → distância/tempo até a **próxima manobra** + lista `IfNavigationDestDistanceData` com **ETA (`getEstimatedTime`)** + distância/tempo até o **destino**.
   - `onNavigationState(IfNavigationStateData)` — txn **10** → passos (próxima manobra: `event`/tipo, via, ângulo, faixas, cues) + destino.
   - `onNotifyNavigationState(int)` — txn **7** → `1` = navegando; outro = parou (limpa o snapshot).
3. **Publicação** — monta um JSON e devolve em `VirtualTelemetryManager.getVirtualValue("app.navigation.directions")`.

### JSON publicado
```json
{
  "active": true,
  "destination": "...",
  "currentRoad": "...",
  "eta": "18:36",
  "remainingSeconds": 1500,
  "remainingMeters": 272000,
  "remainingText": "272",
  "remainingUnit": "km",
  "next": {
    "event": 8,
    "icon": "turn_r",
    "road": "070",
    "turnAngle": 0,
    "distanceMeters": 130000,
    "distanceText": "130",
    "distanceUnit": "km",
    "lanes": [ { "shape": 3, "highlighted": 1 } ]
  }
}
```
_(exemplo real capturado no carro navegando.)_

O mapa `event` → ícone (`turn_l`, `turn_r`, `roundabout`, `destination`, …) e a tabela de unidades foram portados do `NavigationProxy` do host.

## Escopo: **somente Android Auto**

Esta captura assina o `LinkCallback` do host do **Android Auto** (`com.ts.androidauto.projectionservice`). O **CarPlay** tem um pipeline **separado** — um `NavigationProxy` próprio em `com.ts.carplay.app` (via o mesmo SDK multidisplay da beantechs) — que **não** é tocado aqui. Portar pro CarPlay seria uma implementação-irmã (assinar o callback equivalente do serviço do CarPlay); fica pra um PR futuro.

## O que NÃO dá pra capturar (e o que foi tentado)

**Radares, alertas da comunidade e objetos na pista do Waze** (câmera de velocidade, polícia, buraco, veículo parado, etc.): **não são capturáveis por este caminho.** Motivo: esses avisos são **desenhados como pixels no próprio vídeo projetado** pelo app do celular — **não trafegam como dado estruturado** pelo canal do AA. Tentativas feitas:

- Varredura de **todas** as data-classes do SDK de nav (`IfNavigationStateData`, `IfNavigationStepData`, `IfNavigationPositionData`, `IfNavigationDestDistanceData`, `IfNavigationLaneData`, `IfNavigationDirectionData`, `IfNavigationData`) e da interface `LinkCallback` inteira: só existem campos de **manobra, distâncias, tempo/ETA, via, faixas e destino** — **nenhum** campo de hazard/radar/POI.
- Captura de `logcat` ao vivo do host durante navegação: nenhum evento estruturado de hazard/radar.
- Conclusão: o único caminho seria **visão computacional** sobre o frame projetado — fora de escopo e frágil.

Correlatos que **dão** por **outros** caminhos (não por este PR):
- **Limite de velocidade**: CAN (`CAR_MAP_TSR_NAV_SPEED_LIMIT`).
- **ADAS** (FCW/AEB, objetos detectados pelo carro): CAN (`CAR_IPK_INFO_FCW_WARNING` / `AEB_*`).
- **Lat/long atual**: GPS do próprio head unit (`LocationManager`). O canal do AA **não** carrega coordenadas — confirmado em todas as data-classes.

## Validação

Testado no carro (Haval H6 GT PHEV) com Waze navegando via AA: o canal passou a devolver ETA + km ao destino + próxima manobra corretos (ex.: `eta 18:36`, `272 km` ao destino, próxima manobra `turn_r` na via `070`). Como o host só emite em **mudança** (início de rota / troca de manobra / movimento), iniciar uma rota nova gera o "burst" que preenche o snapshot; parado, os valores ficam estáveis; **andando**, o ETA/km atualiza continuamente.

## Implementação

- **Novo** `bridge/AndroidAutoNavManager.kt` — o `LinkCallback` passivo (`Binder` + `IInterface`, descriptor `com.ts.androidauto.sdk.aidl.LinkCallback`), parse dos callbacks e montagem do JSON. Thread-safe (lock) e tolerante a erro (try/catch — nunca derruba a captura).
- **Vendorizados** os 7 Parcelables de nav do SDK do host em `com/ts/androidauto/sdk/aidl/data/` (mesmo diretório onde o `IfVehicleInfo` já vive), pro wire-format do `Parcel` bater exatamente com o do host.
- `managers/DisplayAppLauncher.kt` — const `ANDROID_AUTO_LINK_COMMAND_ADD_CALLBACK_TRANSACTION = 1`; registro **idempotente por conexão** no `onServiceConnected` do LinkCommand (flag zera no `onServiceDisconnected`).
- `bridge/VirtualTelemetryManager.kt` — o placeholder de `app.navigation.directions` agora devolve `AndroidAutoNavManager.getDirectionsJson()`.
- Toggle `ENABLE_AA_NAV_CAPTURE` (`enableAaNavCapture`, **default ON**) + keep de `CREATOR` no proguard pros Parcelables `com.ts.androidauto.**`.

## Nota

Nada destrutivo ou intrusivo: é **uma assinatura a mais** na lista de callbacks do host do AA, e o preenchimento de um canal de telemetria que antes era vazio. O tema consome `app.navigation.directions` do mesmo jeito que os outros canais `app.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
