### PR TITLE
Modo Concessionária, cortina automática, painel lateral e aviso de atualização

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -156,6 +156,20 @@
                 <action android:name="br.com.redesurftank.havalshisuku.FRIDA_START" />
             </intent-filter>
         </receiver>
+        <!-- Porta de serviço do Modo Concessionária: reverte por telnet/adb quando o ícone
+             do launcher está escondido e a sequência do volante não estiver disponível.
+             O broadcast PRECISA ser explícito (-n); implícito não chega em receiver de
+             manifest no Android 8+ (testado no carro):
+             am broadcast -n br.com.redesurftank.havalshisuku/.broadcastReceivers.StealthExitReceiver
+                 -a br.com.redesurftank.havalshisuku.STEALTH_EXIT -->
+        <receiver
+            android:name=".broadcastReceivers.StealthExitReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="br.com.redesurftank.havalshisuku.STEALTH_EXIT" />
+            </intent-filter>
+        </receiver>
         <receiver
             android:name=".broadcastReceivers.DispatchAllDatasReceiver"
             android:enabled="true"

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/MainActivity.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/MainActivity.kt
@@ -14,13 +14,21 @@ import br.com.redesurftank.havalshisuku.ui.theme.HavalShisukuTheme
 const val TAG = "HavalShisuku"
 
 class MainActivity : ComponentActivity() {
+
+    companion object {
+        /** Título da aba em que o app deve abrir. Usado pelo chip de atualização do dashboard. */
+        const val EXTRA_SCREEN = "br.com.redesurftank.havalshisuku.EXTRA_SCREEN"
+    }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             HavalShisukuTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    MainScreen(modifier = Modifier.padding(innerPadding))
+                    MainScreen(
+                            modifier = Modifier.padding(innerPadding),
+                            initialScreen = intent?.getStringExtra(EXTRA_SCREEN)
+                    )
                 }
             }
         }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/broadcastReceivers/StealthExitReceiver.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/broadcastReceivers/StealthExitReceiver.java
@@ -1,0 +1,38 @@
+package br.com.redesurftank.havalshisuku.broadcastReceivers;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import br.com.redesurftank.havalshisuku.managers.StealthModeManager;
+
+/**
+ * Porta de serviço do Modo Concessionária (rede de segurança).
+ *
+ * Com o modo ativo o ícone do launcher some, então a saída normal é a sequência do volante
+ * (3 toques CURTOS no botão 1, em até 8s). Se o volante falhar, este receiver reverte por
+ * telnet/adb.
+ *
+ * ATENÇÃO — O BROADCAST TEM QUE SER EXPLÍCITO. Testado no carro: só com `-n <componente>`
+ * funciona. A partir do Android 8 receivers declarados no manifest não recebem broadcasts
+ * implícitos, então mandar só a action NÃO chega aqui (o comando "funciona" e nada acontece):
+ *
+ * <pre>
+ * am broadcast -n br.com.redesurftank.havalshisuku/.broadcastReceivers.StealthExitReceiver \
+ *     -a br.com.redesurftank.havalshisuku.STEALTH_EXIT
+ * </pre>
+ *
+ * A action continua sendo conferida abaixo, então ela não pode ser omitida do comando.
+ */
+public class StealthExitReceiver extends BroadcastReceiver {
+    private static final String ACTION = "br.com.redesurftank.havalshisuku.STEALTH_EXIT";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Log.w("StealthExitReceiver", "Received intent: " + (intent == null ? "null" : intent.getAction()));
+        if (intent != null && ACTION.equals(intent.getAction())) {
+            StealthModeManager.exit(context, "BROADCAST");
+        }
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ProjectorManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ProjectorManager.java
@@ -32,6 +32,18 @@ public class ProjectorManager {
     private InstrumentProjector2 instrumentProjector2;
     private boolean initialized = false;
 
+    /**
+     * O listener de dados do carro e registrado UMA vez so. Antes ele vinha carona na criacao das
+     * Presentations, e como initialize() saia cedo sempre que algum projector ja existia, nunca
+     * duplicava. Agora que os projetores dependem das preferencias, initialize() pode rodar
+     * inteiro varias vezes sem criar nada (as duas prefs desligadas) — sem esta trava, cada
+     * chamada empilharia mais um listener sobre o mesmo evento de ignicao.
+     */
+    private boolean dataChangedListenerRegistered = false;
+
+    private final int maskDisplayId;
+    private final int hudDisplayId;
+
     private final Map<Integer, BiConsumer<android.content.Context, Display>> projectorCreators = new HashMap<>();
 
     public static synchronized ProjectorManager getInstance() {
@@ -44,9 +56,14 @@ public class ProjectorManager {
     private ProjectorManager() {
         sharedPreferences = App.getDeviceProtectedContext().getSharedPreferences("haval_prefs", Context.MODE_PRIVATE);
 
-        int maskDisplayId = br.com.redesurftank.havalshisuku.BuildConfig.SIMULATOR_MODE ? 0 : 3;
-        int hudDisplayId = br.com.redesurftank.havalshisuku.BuildConfig.SIMULATOR_MODE ? -1 : 1;
+        maskDisplayId = br.com.redesurftank.havalshisuku.BuildConfig.SIMULATOR_MODE ? 0 : 3;
+        hudDisplayId = br.com.redesurftank.havalshisuku.BuildConfig.SIMULATOR_MODE ? -1 : 1;
 
+        populateCreators();
+    }
+
+    /** Receita de como criar cada projector. Usada pelo construtor e pelo refresh(). */
+    private void populateCreators() {
         projectorCreators.put(maskDisplayId, (ctx, disp) -> {
             instrumentProjector2 = new InstrumentProjector2(ctx, disp);
             instrumentProjector2.show();
@@ -60,9 +77,81 @@ public class ProjectorManager {
         });
     }
 
+    /**
+     * A preferencia que decide se o projector daquele display deve EXISTIR.
+     *
+     * PORQUE AQUI E NAO LA DENTRO: uma Presentation viva nao e "so o desenho". Ela e uma JANELA
+     * NOSSA ocupando o display do painel — enquanto existir, o painel e do app, mesmo que o
+     * conteudo pintado dentro dela esteja vazio. Ate agora estas duas prefs so controlavam o que
+     * era pintado; a janela era criada de qualquer jeito. Resultado: desligar o Virtual Cluster
+     * nao devolvia o painel ao nativo.
+     *
+     * E POR QUE NAO DERRUBAR DEPOIS: derrubar (stopProjectors) e fragil por construcao — basta um
+     * caminho chamar initialize()/refresh() de novo, ou o processo reiniciar, para a Presentation
+     * voltar. Sempre escapa um caminho. A decisao tem que estar na origem, na criacao.
+     *
+     * Os defaults sao os MESMOS que o resto do app ja usa ao ler estas chaves
+     * (ENABLE_VIRTUAL_CLUSTER: true, como em DisplayAppLauncher e InstrumentProjector2;
+     * ENABLE_INSTRUMENT_PROJECTOR: false, como em ServiceManager e shouldShowProjector),
+     * para que quem nunca mexeu nessas preferencias nao veja mudanca nenhuma.
+     */
+    private boolean isProjectorEnabled(int displayId) {
+        try {
+            if (displayId == maskDisplayId) {
+                return sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_VIRTUAL_CLUSTER.getKey(), true);
+            }
+            if (displayId == hudDisplayId) {
+                // O HUD fica de fora desta regra no uso normal, de proposito. A pref tem default
+                // `false`, entao aplicar a checagem aqui deixaria de criar o projector do display 1
+                // para TODO mundo — e ele existia (mesmo sem pintar) desde sempre. Nao ha ganho em
+                // arriscar essa mudanca no dia a dia so para atender o Modo Concessionaria, que ja
+                // e atendido pelo cluster. No modo, ai sim, ele nao sobe.
+                return !StealthModeManager.isActive();
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to read projector preference for display " + displayId + "; assuming enabled", e);
+        }
+        return true;
+    }
+
+    /**
+     * A pref caiu com a janela ja no ar: derruba agora, senao ela fica por cima do painel ate o
+     * proximo boot. Presentation.dismiss() exige a UI thread — os dois pontos que chamam
+     * initialize()/refresh() ja postam no main looper.
+     */
+    private void dismissProjectorForDisplay(int displayId, String reason) {
+        if (displayId == maskDisplayId && instrumentProjector2 != null) {
+            Log.w(TAG, "Dismissing InstrumentProjector2 (Mask): " + reason);
+            try {
+                instrumentProjector2.dismiss();
+            } catch (Exception e) {
+                Log.e(TAG, "Error dismissing instrumentProjector2", e);
+            }
+            instrumentProjector2 = null;
+        }
+        if (displayId == hudDisplayId && instrumentProjector != null) {
+            Log.w(TAG, "Dismissing InstrumentProjector (HUD): " + reason);
+            try {
+                instrumentProjector.dismiss();
+            } catch (Exception e) {
+                Log.e(TAG, "Error dismissing instrumentProjector", e);
+            }
+            instrumentProjector = null;
+        }
+    }
+
     public void initialize() {
         Log.w(TAG, "Initializing ProjectorManager");
         try {
+            // Preferencia desligada = a janela nao pode existir. Se sobrou uma viva de antes
+            // (a pref caiu com o app rodando), derruba antes de qualquer outra coisa.
+            if (!isProjectorEnabled(maskDisplayId)) {
+                dismissProjectorForDisplay(maskDisplayId, "ENABLE_VIRTUAL_CLUSTER desligado");
+            }
+            if (!isProjectorEnabled(hudDisplayId)) {
+                dismissProjectorForDisplay(hudDisplayId, "ENABLE_INSTRUMENT_PROJECTOR desligado");
+            }
+
             if (initialized && (instrumentProjector != null || instrumentProjector2 != null)) {
                 Log.w(TAG, "ProjectorManager already initialized; skipping duplicate presentations");
                 return;
@@ -74,13 +163,20 @@ public class ProjectorManager {
                 Log.w(TAG, "Display found: " + display.getName() + " (ID: " + display.getDisplayId() + ")");
             }
 
-            Set<Integer> pending = new HashSet<>(projectorCreators.keySet());
+            Set<Integer> pending = new HashSet<>();
 
             for (Integer id : projectorCreators.keySet()) {
+                // A pref e consultada ANTES de criar: o que esta desligado simplesmente nao nasce,
+                // e nem entra na fila de espera do display (senao voltaria pelo listener).
+                if (!isProjectorEnabled(id)) {
+                    Log.w(TAG, "Projector for display " + id + " is disabled by preference; not creating it");
+                    continue;
+                }
                 Display display = getDisplayById(id);
                 if (display != null) {
                     projectorCreators.get(id).accept(App.getContext(), display);
-                    pending.remove(id);
+                } else {
+                    pending.add(id);
                 }
             }
 
@@ -89,6 +185,11 @@ public class ProjectorManager {
             }
 
             initialized = true;
+
+            if (dataChangedListenerRegistered) {
+                return;
+            }
+            dataChangedListenerRegistered = true;
 
             ServiceManager.getInstance().addDataChangedListener((key, value) -> {
                 if (key.equals(CarConstants.CAR_BASIC_ENGINE_STATE.getValue())) {
@@ -155,22 +256,10 @@ public class ProjectorManager {
     public void refresh() {
         Log.w(TAG, "Refreshing ProjectorManager");
         stopProjectors();
-        
-        // Re-read preferences and re-populate creators
-        int maskDisplayId = br.com.redesurftank.havalshisuku.BuildConfig.SIMULATOR_MODE ? 0 : 3;
-        int hudDisplayId = br.com.redesurftank.havalshisuku.BuildConfig.SIMULATOR_MODE ? -1 : 1;
 
-        projectorCreators.put(maskDisplayId, (ctx, disp) -> {
-            instrumentProjector2 = new InstrumentProjector2(ctx, disp);
-            instrumentProjector2.show();
-            Log.w(TAG, "InstrumentProjector2 (Mask) refreshed on Display " + disp.getDisplayId());
-        });
-
-        projectorCreators.put(hudDisplayId, (ctx, disp) -> {
-            instrumentProjector = new InstrumentProjector(ctx, disp);
-            instrumentProjector.show();
-            Log.w(TAG, "InstrumentProjector (HUD) refreshed on Display " + disp.getDisplayId());
-        });
+        // Repopula as receitas; quem decide o que de fato nasce e o initialize(), consultando as
+        // preferencias (ver isProjectorEnabled).
+        populateCreators();
 
         initialize();
     }
@@ -190,9 +279,20 @@ public class ProjectorManager {
             public void onDisplayAdded(int displayId) {
                 Log.w(TAG, "Display added: " + displayId);
                 if (pending.contains(displayId)) {
+                    // O display pode aparecer muito depois; a pref pode ter caido nesse meio tempo.
+                    // Sem esta checagem, a janela voltaria por aqui mesmo com a feature desligada.
+                    BiConsumer<android.content.Context, Display> creator = projectorCreators.get(displayId);
+                    if (creator == null || !isProjectorEnabled(displayId)) {
+                        Log.w(TAG, "Display " + displayId + " appeared, but its projector is disabled/unknown; ignoring");
+                        pending.remove(displayId);
+                        if (pending.isEmpty()) {
+                            displayManager.unregisterDisplayListener(this);
+                        }
+                        return;
+                    }
                     Display display = displayManager.getDisplay(displayId);
                     if (display != null) {
-                        projectorCreators.get(displayId).accept(App.getContext(), display);
+                        creator.accept(App.getContext(), display);
                         pending.remove(displayId);
                         if (pending.isEmpty()) {
                             displayManager.unregisterDisplayListener(this);

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -355,6 +355,32 @@ public class ServiceManager {
     private static final long STEERING_WHEEL_PROJECTION_TOGGLE_DEDUP_WINDOW_MS = 800L;
     private static final long STEERING_WHEEL_DASHBOARD_TOGGLE_DEDUP_WINDOW_MS = 800L;
     private static final long STEERING_WHEEL_CLIMATE_COMMAND_DEDUP_WINDOW_MS = 800L;
+    // ===== Modo Concessionária: sequência de saída pelo volante =====
+    // Com o modo ativo o ícone do launcher some, então esta é a ÚNICA porta de volta pela tela do
+    // carro: 3 toques CURTOS no botão 1, com até 8s entre eles. Roda MESMO com
+    // ENABLE_STEERING_WHEEL_CUSTOM_BUTTONS desligado (que é justamente o estado do modo). Fora do
+    // modo é inerte — não interfere no uso normal do botão.
+    // ===== Saída do Modo Concessionária pelas SETAS: esquerda, direita, esquerda, direita =====
+    // Escolhido no lugar do volante porque não depende de NADA que o modo desliga: as setas são
+    // do carro, sempre funcionam, e não deixam vestígio de app instalado. A contagem avança na
+    // TROCA de lado, não por tempo — então tanto faz dar um toque ou travar a alavanca, e a seta
+    // piscando não conta várias vezes.
+    private static final String[] STEALTH_EXIT_TURN_SEQUENCE = {"L", "R", "L", "R"};
+    private static final long STEALTH_EXIT_TURN_WINDOW_MS = 20000L; // folga entre um lado e outro
+    private int stealthExitTurnIndex = 0;
+    private String stealthExitLastTurnSide = null;
+    private long stealthExitLastTurnAtMs = 0L;
+
+    private static final int STEALTH_EXIT_BUTTON_1_KEY = 517;      // botão 1, toque curto
+    private static final int STEALTH_EXIT_PRESSES = 3;
+    private static final long STEALTH_EXIT_WINDOW_MS = 8000L;      // janela máxima ENTRE toques
+    // O input service deste head unit reporta o toque como evento de RELEASE (ver
+    // ClusterCardNavigationPolicy.shouldHandleInputAction). Não filtramos por action — se o
+    // firmware mandar DOWN+UP, este debounce colapsa o par em um toque só. Ele também é a defesa
+    // contra auto-repeat: repetição de firmware chega bem mais rápido que 300ms.
+    private static final long STEALTH_EXIT_DEBOUNCE_MS = 300L;
+    private int stealthExitPressCount = 0;
+    private long stealthExitLastPressAtMs = 0L;
     private int lastDashboardToggleButton = -1;
     private long lastDashboardToggleAtMs = 0L;
     private static final int[] INPUT_LISTENER_KEY_CODES = new int[] {
@@ -863,6 +889,14 @@ public class ServiceManager {
                 public void dispatchKeyEvent(KeyEvent keyEvent) {
                     final long dispatchStartedAt = SystemClock.uptimeMillis();
                     final int dispatchKeyCode = keyEvent.getKeyCode();
+                    // PRIMEIRA coisa do dispatch, antes de qualquer handler que possa dar return:
+                    // é a única porta de volta do Modo Concessionária e não pode depender de
+                    // nenhuma preferência nem de nenhum outro caminho ter deixado passar.
+                    try {
+                        handleStealthExitSequence(keyEvent);
+                    } catch (Exception e) {
+                        Log.e(TAG, "Error in stealth exit sequence detection", e);
+                    }
                     try {
                     Log.w(
                             TAG,
@@ -886,7 +920,13 @@ public class ServiceManager {
                         Log.w(TAG, "Android Auto handled steering media key: " + keyEvent.getKeyCode());
                         return;
                     }
-                    if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_STEERING_WHEEL_CUSTOM_BUTTONS.getKey(), false)) {
+                    // As ações CUSTOM do volante ficam suspensas no Modo Concessionária: senão os
+                    // 3 toques curtos da sequência de saída disparariam a ação de toque curto
+                    // configurada pelo usuário (e a de toque DUPLO, que a janela de 350ms detecta no
+                    // meio da sequência). A pref já está desligada no modo, então isto é rede de
+                    // segurança. A detecção da sequência já rodou lá em cima, antes de tudo.
+                    if (!StealthModeManager.isActive()
+                            && sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_STEERING_WHEEL_CUSTOM_BUTTONS.getKey(), false)) {
                         switch (keyEvent.getKeyCode()) {
                             case 517: onSteeringCustomShortPress(1); break;   // botao 1 curto
                             case 1031: onSteeringCustomShortPress(2); break;  // botao 2 curto
@@ -1189,6 +1229,18 @@ public class ServiceManager {
     }
 
     public void ensureSteeringWheelButtonIntegration() {
+        // Modo Concessionária: as preferências do usuário estão desligadas (inclusive a dos botões
+        // custom), então o caminho normal aqui embaixo devolveria os botões à função NATIVA do head
+        // unit — e os toques nunca mais chegariam ao dispatchKeyEvent. Como este método roda a cada
+        // boot (initialize()), sem esta guarda o primeiro ciclo de ignição mataria a sequência de
+        // saída e trancaria o app por dentro. É a mesma razão do force_steering_integration do
+        // enter(); a saída limpa a flag ANTES de chamar este método, então o estado do usuário volta
+        // normalmente.
+        if (StealthModeManager.isActive()) {
+            Log.w(TAG, "Modo Concessionária ativo; mantendo o botão 1 do volante integrado (porta de saída)");
+            enableSteeringWheelButton1Integration();
+            return;
+        }
         if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_STEERING_WHEEL_CUSTOM_BUTTONS.getKey(), false)) {
             // habilita o botao se QUALQUER toque (curto/duplo/longo) tiver acao configurada
             boolean button1Used = steeringActionConfigured(1, "SHORT") || steeringActionConfigured(1, "DOUBLE") || steeringActionConfigured(1, "LONG");
@@ -1249,6 +1301,148 @@ public class ServiceManager {
         return k != null
                 && !k.equals(SteeringWheelCustomActionType.DEFAULT.getKey())
                 && !k.equals(SteeringWheelCustomActionType.DEFAULT.name());
+    }
+
+    /**
+     * Modo Concessionária — detecção da sequência de saída: 3 toques CURTOS no botão 1 do volante,
+     * com até 8s entre eles. Chamada no TOPO de dispatchKeyEvent, antes de qualquer outro handler,
+     * porque com o modo ativo o ícone do app some e esta é a única porta de volta pela tela do
+     * carro.
+     *
+     * Deliberadamente NÃO consulta preferência nenhuma: no modo, ENABLE_STEERING_WHEEL_CUSTOM_BUTTONS
+     * está desligado de propósito, e a volta não pode depender de nada que o modo desliga. Quando o
+     * modo NÃO está ativo a sequência é inerte — só zera o contador e sai, sem consumir o evento nem
+     * alterar o comportamento normal do botão (o handler custom logo abaixo continua recebendo a
+     * tecla).
+     *
+     * O que garante que a tecla CHEGUE aqui é a integração custom do botão estar habilitada no head
+     * unit — por isso enter() a força e ensureSteeringWheelButtonIntegration() a mantém enquanto o
+     * modo está ativo.
+     */
+    /**
+     * Sequência de saída do Modo Concessionária pelas setas: esquerda, direita, esquerda, direita.
+     *
+     * Avança na TROCA de lado, não por tempo nem por número de piscadas — a seta ligada emite o
+     * sinal repetidamente, e contar cada emissão faria um único acionamento valer por vários.
+     * Fora do modo é inerte: só zera o progresso e sai.
+     */
+    private void handleStealthExitTurnSignal(String key, String value) {
+        if (key == null) return;
+        // A LUZ da seta, não o switch da alavanca: este carro responde
+        // "is not support for dataId car.basic.left_turn_switch_status" e nunca emite nada por lá.
+        // Estas três chaves já estavam em DEFAULT_KEYS, então chegam sem configuração extra.
+        boolean isLeft = CarConstants.CAR_BASIC_LEFT_TURN_LIGHT_STATUS.getValue().equals(key);
+        boolean isRight = CarConstants.CAR_BASIC_RIGHT_TURN_LIGHT_STATUS.getValue().equals(key);
+        if (!isLeft && !isRight) return;
+
+        // O mesmo detector serve a dois momentos: o ENSAIO (o dono prova que sabe sair, antes de
+        // ativar) e a SAÍDA de verdade. Fora dos dois, é inerte.
+        boolean rehearsing = StealthModeManager.isAwaitingConfirmation();
+        if (!StealthModeManager.isActive() && !rehearsing) {
+            stealthExitTurnIndex = 0;
+            stealthExitLastTurnSide = null;
+            stealthExitLastTurnAtMs = 0L;
+            return;
+        }
+
+        boolean on = "1".equals(value == null ? "" : value.trim());
+        if (!on) return; // apagar a luz não conta; só o acendimento
+
+        // Pisca-alerta acende os dois lados alternando: sozinho ele completaria a sequência e
+        // tiraria o carro do modo sem ninguém pedir. Enquanto estiver ligado, nada conta.
+        try {
+            String hazard = getData(CarConstants.CAR_BASIC_HAZARD_LIGHT_STATUS.getValue());
+            if (hazard != null && "1".equals(hazard.trim())) {
+                stealthExitTurnIndex = 0;
+                stealthExitLastTurnSide = null;
+                return;
+            }
+        } catch (Exception ignored) {
+        }
+
+        // Só com o carro PARADO. Manobrar para estacionar produz esquerda-direita-esquerda-direita
+        // sem nenhuma intenção de sair do modo; parado, a alternância só acontece de propósito.
+        // Velocidade ilegível conta como "em movimento": é o lado seguro (no pior caso o dono
+        // repete o gesto), e sair sozinho na garagem de terceiros seria bem pior.
+        try {
+            String rawSpeed = getData(CarConstants.CAR_BASIC_VEHICLE_SPEED.getValue());
+            float speed = rawSpeed == null || rawSpeed.trim().isEmpty()
+                    ? Float.MAX_VALUE
+                    : Float.parseFloat(rawSpeed.trim());
+            if (speed > 0.5f) {
+                stealthExitTurnIndex = 0;
+                stealthExitLastTurnSide = null;
+                return;
+            }
+        } catch (Exception e) {
+            stealthExitTurnIndex = 0;
+            stealthExitLastTurnSide = null;
+            return;
+        }
+
+        String side = isLeft ? "L" : "R";
+        if (side.equals(stealthExitLastTurnSide)) return; // mesma seta piscando: não avança
+
+        long now = SystemClock.uptimeMillis();
+        if (stealthExitLastTurnAtMs != 0L && now - stealthExitLastTurnAtMs > STEALTH_EXIT_TURN_WINDOW_MS) {
+            stealthExitTurnIndex = 0; // demorou demais entre os lados -> recomeça
+        }
+        stealthExitLastTurnSide = side;
+        stealthExitLastTurnAtMs = now;
+
+        if (!STEALTH_EXIT_TURN_SEQUENCE[stealthExitTurnIndex].equals(side)) {
+            // Lado fora de ordem: recomeça, mas já aproveita este acionamento se ele serve de 1º.
+            stealthExitTurnIndex = STEALTH_EXIT_TURN_SEQUENCE[0].equals(side) ? 1 : 0;
+            Log.w(TAG, "Stealth exit (setas): fora de ordem, recomeçando em " + stealthExitTurnIndex);
+            return;
+        }
+
+        stealthExitTurnIndex++;
+        Log.w(TAG, "Stealth exit (setas): " + stealthExitTurnIndex + "/" + STEALTH_EXIT_TURN_SEQUENCE.length);
+        if (stealthExitTurnIndex < STEALTH_EXIT_TURN_SEQUENCE.length) {
+            if (rehearsing) StealthModeManager.onConfirmationStep(stealthExitTurnIndex, false);
+            return;
+        }
+
+        stealthExitTurnIndex = 0;
+        stealthExitLastTurnSide = null;
+        stealthExitLastTurnAtMs = 0L;
+        if (rehearsing) {
+            Log.w(TAG, "Ensaio da saída concluído");
+            StealthModeManager.onConfirmationStep(STEALTH_EXIT_TURN_SEQUENCE.length, true);
+            return;
+        }
+        Log.w(TAG, "Stealth exit (setas) completo; saindo do Modo Concessionária");
+        StealthModeManager.exit(App.getContext(), "TURN_SIGNAL_SEQUENCE");
+    }
+
+    private void handleStealthExitSequence(KeyEvent keyEvent) {
+        if (keyEvent == null) return;
+        if (keyEvent.getKeyCode() != STEALTH_EXIT_BUTTON_1_KEY) return;
+
+        if (!StealthModeManager.isActive()) {
+            stealthExitPressCount = 0;
+            stealthExitLastPressAtMs = 0L;
+            return;
+        }
+
+        long now = SystemClock.uptimeMillis();
+        if (stealthExitLastPressAtMs != 0L && now - stealthExitLastPressAtMs < STEALTH_EXIT_DEBOUNCE_MS) {
+            return; // repique do mesmo toque
+        }
+        if (stealthExitLastPressAtMs != 0L && now - stealthExitLastPressAtMs > STEALTH_EXIT_WINDOW_MS) {
+            stealthExitPressCount = 0; // demorou demais entre toques -> recomeça
+        }
+        stealthExitLastPressAtMs = now;
+
+        stealthExitPressCount++;
+        Log.w(TAG, "Stealth exit sequence: toque " + stealthExitPressCount + "/" + STEALTH_EXIT_PRESSES);
+        if (stealthExitPressCount < STEALTH_EXIT_PRESSES) return;
+
+        stealthExitPressCount = 0;
+        stealthExitLastPressAtMs = 0L;
+        Log.w(TAG, "Stealth exit sequence complete; leaving Modo Concessionária");
+        StealthModeManager.exit(App.getContext(), "STEERING_SEQUENCE");
     }
 
     // Toque curto. Se houver acao de DUPLO configurada, espera ~350ms pra ver se vem um 2o toque
@@ -2291,7 +2485,25 @@ public class ServiceManager {
             Log.w(TAG, "[DOOR_DEBUG] key=" + key + " value=" + value);
         }
         dispatchTelemetryOnly(key, value);
+        // Antes de qualquer gate: com o Modo Concessionária ativo esta é a porta de saída, e ela
+        // não pode depender de nada que o modo tenha desligado.
+        try {
+            handleStealthExitTurnSignal(key, value);
+        } catch (Exception e) {
+            Log.e(TAG, "Error in stealth exit turn-signal detection", e);
+        }
         if (!servicesInitialized) {
+            return;
+        }
+        // ===== GATE do Modo Concessionária =====
+        // Com o modo ativo NENHUMA automação de CAN age (cortina, ventilação, brilho, BT/hotspot,
+        // AVM, HEV, janelas/teto...). A telemetria acima continua rodando de propósito: ela só
+        // alimenta a UI/tema/listeners internos, não escreve nada no carro.
+        //
+        // ISENÇÃO DAS TECLAS DO VOLANTE: elas NÃO passam por aqui. Chegam pelo callback separado
+        // IInputListener.dispatchKeyEvent (com.beantechs.inputservice), onde a sequência de saída
+        // é avaliada como primeiríssima etapa. Por isso este gate não pode trancar o app fora.
+        if (StealthModeManager.isActive()) {
             return;
         }
         try {

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -265,6 +265,19 @@ public class ServiceManager {
     private IClusterCallback.Stub clusterCallback;
     private boolean servicesInitialized = false;
     private boolean hasRunStartupCurtainAutomation = false;
+    // Cortina automática por horário — guarda "uma vez por ENTRADA na janela". Reseta ao SAIR
+    // da janela (respeita ajuste manual e permite disparar de novo na próxima entrada).
+    private boolean curtainOpenActedThisWindow = false;
+    private boolean curtainCloseActedThisWindow = false;
+    // Reavaliação event-driven: em vez de pollar (CPU à toa), reagenda p/ o PRÓXIMO boundary de
+    // janela — dorme quando longe; teto de 15min só por segurança (mudança de relógio). Um
+    // listener de prefs reagenda na hora quando a config muda.
+    private static final long CURTAIN_RESCHEDULE_CAP_MS = 15 * 60_000L;
+    private android.content.SharedPreferences.OnSharedPreferenceChangeListener curtainPrefsListener;
+    private final Runnable curtainScheduleRunnable = () -> {
+        evaluateCurtainSchedule("TIMER");
+        rescheduleCurtainEvaluation();
+    };
     private boolean isFridaInitialized = false;
     private final List<Runnable> pendingTasks = new ArrayList<>();
     private static long timeBootReceived;
@@ -1152,9 +1165,12 @@ public class ServiceManager {
         Log.w(TAG, "Services initialized successfully");
         boolean curtainOnStartEnabled = sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_OPEN_SUNROOF_CURTAIN_ON_START.getKey(), false);
         traceCurtain("sunroof_curtain_init", "enabled", curtainOnStartEnabled, "hasRun", hasRunStartupCurtainAutomation);
-        if (curtainOnStartEnabled && !hasRunStartupCurtainAutomation) {
+        if (!hasRunStartupCurtainAutomation) {
             hasRunStartupCurtainAutomation = true;
-            autoOpenSunroofCurtain(0);
+            // Avalia agora (caso ligue já dentro da janela) e passa a se auto-reagendar p/ o
+            // próximo boundary. O listener cobre habilitar/mudar a config depois, sem polling.
+            registerCurtainPrefsListener();
+            backgroundHandler.post(curtainScheduleRunnable);
         }
         scheduleStartupReportReconciliations();
         // HEV Prioritário: no boot o carro costuma resetar o % (ex.: 45->80) e o app pode subir
@@ -2654,6 +2670,131 @@ public class ServiceManager {
             traceCurtain("sunroof_curtain_temp_read", "raw", raw, "result", "unparseable");
             return null;
         }
+    }
+
+    /**
+     * Cortina automática do teto por horário (feature unificada "Conforto & conveniência").
+     * Event-driven: roda no boot e é reagendada p/ o PRÓXIMO boundary de janela
+     * (rescheduleCurtainEvaluation — sem polling), então pega a virada do horário mesmo com o
+     * carro ligado parado. Abrir e Fechar têm janelas próprias. Cada ação dispara UMA vez por
+     * ENTRADA na janela e rearma ao sair — respeita ajuste manual e não refaz a cada disparo.
+     * Fechar tem precedência se as janelas casarem. Temperatura condiciona SOMENTE a abertura.
+     */
+    private void evaluateCurtainSchedule(String trigger) {
+        boolean openEnabled = sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_OPEN_SUNROOF_CURTAIN_ON_START.getKey(), false);
+        boolean closeEnabled = sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_CLOSE_SUNROOF_CURTAIN_ON_TIME.getKey(), false);
+        if (!openEnabled && !closeEnabled) return;
+
+        Calendar now = Calendar.getInstance();
+        int t = now.get(Calendar.HOUR_OF_DAY) * 60 + now.get(Calendar.MINUTE);
+
+        boolean inOpen = openEnabled && isTimeInRange(t,
+                sharedPreferences.getInt(SharedPreferencesKeys.OPEN_SUNROOF_CURTAIN_START_HOUR.getKey(), 18),
+                sharedPreferences.getInt(SharedPreferencesKeys.OPEN_SUNROOF_CURTAIN_START_MINUTE.getKey(), 0),
+                sharedPreferences.getInt(SharedPreferencesKeys.OPEN_SUNROOF_CURTAIN_END_HOUR.getKey(), 9),
+                sharedPreferences.getInt(SharedPreferencesKeys.OPEN_SUNROOF_CURTAIN_END_MINUTE.getKey(), 0));
+        boolean inClose = closeEnabled && isTimeInRange(t,
+                sharedPreferences.getInt(SharedPreferencesKeys.CLOSE_SUNROOF_CURTAIN_START_HOUR.getKey(), 9),
+                sharedPreferences.getInt(SharedPreferencesKeys.CLOSE_SUNROOF_CURTAIN_START_MINUTE.getKey(), 0),
+                sharedPreferences.getInt(SharedPreferencesKeys.CLOSE_SUNROOF_CURTAIN_END_HOUR.getKey(), 17),
+                sharedPreferences.getInt(SharedPreferencesKeys.CLOSE_SUNROOF_CURTAIN_END_MINUTE.getKey(), 0));
+
+        // Rearma ao SAIR da janela (permite disparar de novo na próxima entrada).
+        if (!inOpen) curtainOpenActedThisWindow = false;
+        if (!inClose) curtainCloseActedThisWindow = false;
+
+        // Fechar tem precedência se (config equivocada) as janelas casarem — nunca abrir+fechar juntos.
+        if (inClose && !curtainCloseActedThisWindow) {
+            curtainCloseActedThisWindow = true;
+            traceCurtain("curtain_schedule_act", "trigger", trigger, "action", "close", "nowMin", t);
+            autoCloseSunroofCurtain();
+            return;
+        }
+        if (inOpen && !curtainOpenActedThisWindow) {
+            curtainOpenActedThisWindow = true;
+            traceCurtain("curtain_schedule_act", "trigger", trigger, "action", "open", "nowMin", t);
+            autoOpenSunroofCurtain(0);
+        }
+    }
+
+    /** Fecha a cortina do teto (janela já validada em evaluateCurtainSchedule). Idempotente. */
+    private void autoCloseSunroofCurtain() {
+        Log.w(TAG, "Auto-closing sunroof curtain (schedule)");
+        // Pequeno atraso p/ garantir serviços prontos no boot (igual à abertura).
+        backgroundHandler.postDelayed(this::closeSunRoofShade, 2000);
+    }
+
+    /** Janela [sh:sm, eh:em) com virada de meia-noite. Janela vazia (s==e) = nunca. */
+    private boolean isTimeInRange(int t, int sh, int sm, int eh, int em) {
+        int s = sh * 60 + sm, e = eh * 60 + em;
+        if (s == e) return false;
+        return (s < e) ? (t >= s && t < e) : (t >= s || t < e);
+    }
+
+    /** Reagenda a próxima avaliação p/ o próximo boundary de janela (ou o teto). No-op se desligado. */
+    private void rescheduleCurtainEvaluation() {
+        if (backgroundHandler == null) return;
+        backgroundHandler.removeCallbacks(curtainScheduleRunnable);
+        boolean openEnabled = sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_OPEN_SUNROOF_CURTAIN_ON_START.getKey(), false);
+        boolean closeEnabled = sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_CLOSE_SUNROOF_CURTAIN_ON_TIME.getKey(), false);
+        if (!openEnabled && !closeEnabled) return; // desligado: não fica acordando
+        long delay = computeCurtainDelayMs(openEnabled, closeEnabled);
+        traceCurtain("curtain_schedule_next", "delayMs", delay);
+        backgroundHandler.postDelayed(curtainScheduleRunnable, delay);
+    }
+
+    /** ms até o próximo boundary (start/end das janelas habilitadas), alinhado ao minuto, com teto. */
+    private long computeCurtainDelayMs(boolean openEnabled, boolean closeEnabled) {
+        Calendar now = Calendar.getInstance();
+        int nowMin = now.get(Calendar.HOUR_OF_DAY) * 60 + now.get(Calendar.MINUTE);
+        int nowSec = now.get(Calendar.SECOND);
+
+        int[] edges = new int[4];
+        int n = 0;
+        if (openEnabled) {
+            edges[n++] = clampMinuteOfDay(sharedPreferences.getInt(SharedPreferencesKeys.OPEN_SUNROOF_CURTAIN_START_HOUR.getKey(), 18),
+                    sharedPreferences.getInt(SharedPreferencesKeys.OPEN_SUNROOF_CURTAIN_START_MINUTE.getKey(), 0));
+            edges[n++] = clampMinuteOfDay(sharedPreferences.getInt(SharedPreferencesKeys.OPEN_SUNROOF_CURTAIN_END_HOUR.getKey(), 9),
+                    sharedPreferences.getInt(SharedPreferencesKeys.OPEN_SUNROOF_CURTAIN_END_MINUTE.getKey(), 0));
+        }
+        if (closeEnabled) {
+            edges[n++] = clampMinuteOfDay(sharedPreferences.getInt(SharedPreferencesKeys.CLOSE_SUNROOF_CURTAIN_START_HOUR.getKey(), 9),
+                    sharedPreferences.getInt(SharedPreferencesKeys.CLOSE_SUNROOF_CURTAIN_START_MINUTE.getKey(), 0));
+            edges[n++] = clampMinuteOfDay(sharedPreferences.getInt(SharedPreferencesKeys.CLOSE_SUNROOF_CURTAIN_END_HOUR.getKey(), 17),
+                    sharedPreferences.getInt(SharedPreferencesKeys.CLOSE_SUNROOF_CURTAIN_END_MINUTE.getKey(), 0));
+        }
+
+        int bestAheadMin = 24 * 60;
+        for (int i = 0; i < n; i++) {
+            int ahead = ((edges[i] - nowMin) % 1440 + 1440) % 1440;
+            if (ahead == 0) ahead = 1440; // estamos no minuto do boundary: o próximo é o de amanhã
+            if (ahead < bestAheadMin) bestAheadMin = ahead;
+        }
+
+        long delay = (long) bestAheadMin * 60_000L - (long) nowSec * 1000L + 2_000L; // alinha ao minuto +2s
+        if (delay < 5_000L) delay = 5_000L;
+        if (delay > CURTAIN_RESCHEDULE_CAP_MS) delay = CURTAIN_RESCHEDULE_CAP_MS;
+        return delay;
+    }
+
+    private int clampMinuteOfDay(int h, int m) {
+        int v = h * 60 + m;
+        if (v < 0) return 0;
+        if (v > 1439) return 1439;
+        return v;
+    }
+
+    /** Reagenda na hora quando qualquer pref da cortina muda (senão a config nova só valeria no teto). */
+    private void registerCurtainPrefsListener() {
+        if (curtainPrefsListener != null) return;
+        curtainPrefsListener = (prefs, key) -> {
+            if (key != null && key.contains("SunroofCurtain") && backgroundHandler != null) {
+                // Debounce: hora+minuto viram 2 escritas; coalesce e re-avalia/reagenda 1x.
+                backgroundHandler.removeCallbacks(curtainScheduleRunnable);
+                backgroundHandler.postDelayed(curtainScheduleRunnable, 800);
+            }
+        };
+        sharedPreferences.registerOnSharedPreferenceChangeListener(curtainPrefsListener);
     }
 
     public boolean isTurnLightOn() {

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -1236,9 +1236,26 @@ public class ServiceManager {
         // saída e trancaria o app por dentro. É a mesma razão do force_steering_integration do
         // enter(); a saída limpa a flag ANTES de chamar este método, então o estado do usuário volta
         // normalmente.
-        if (StealthModeManager.isActive()) {
-            Log.w(TAG, "Modo Concessionária ativo; mantendo o botão 1 do volante integrado (porta de saída)");
+        // Vale também durante o ENSAIO: ele roda antes de ativar, e é aqui que os botões usados pela
+        // sequência precisam estar capturados — senão o dono não consegue concluir o ensaio.
+        if (StealthModeManager.isActive() || StealthModeManager.isAwaitingConfirmation()) {
+            // O botão 1 fica sempre integrado (porta de saída histórica). O botão 2 só entra quando a
+            // sequência ESCOLHIDA pelo dono usa ele: integrar à toa mudaria a função nativa do botão
+            // à vista do mecânico, que é justamente o que este modo evita. Mas se a sequência precisa
+            // dele e a integração não subir, os toques nunca chegam ao dispatchKeyEvent e o dono fica
+            // trancado do lado de fora — por isso a checagem, e não uma escolha fixa.
+            boolean needsButton2 = false;
+            try {
+                needsButton2 = StealthExitSequence.current().contains(StealthExitSequence.Step.BUTTON2);
+            } catch (Exception e) {
+                Log.e(TAG, "não deu pra ler a sequência de saída; assumindo que o botão 2 é necessário", e);
+                needsButton2 = true; // lado seguro: sobra integração, não falta porta de saída
+            }
+            Log.w(TAG, "Modo Concessionária ativo; botão 1 integrado (porta de saída), botão 2 = " + needsButton2);
             enableSteeringWheelButton1Integration();
+            if (needsButton2) {
+                enableSteeringWheelButton2Integration();
+            }
             return;
         }
         if (sharedPreferences.getBoolean(SharedPreferencesKeys.ENABLE_STEERING_WHEEL_CUSTOM_BUTTONS.getKey(), false)) {
@@ -1333,7 +1350,10 @@ public class ServiceManager {
         // Estas três chaves já estavam em DEFAULT_KEYS, então chegam sem configuração extra.
         boolean isLeft = CarConstants.CAR_BASIC_LEFT_TURN_LIGHT_STATUS.getValue().equals(key);
         boolean isRight = CarConstants.CAR_BASIC_RIGHT_TURN_LIGHT_STATUS.getValue().equals(key);
-        if (!isLeft && !isRight) return;
+        // A luz alta tambem serve de passo: ja esta em DEFAULT_KEYS, entao chega por evento como as
+        // setas, sem configuracao extra.
+        boolean isHighBeam = CarConstants.CAR_BASIC_HIGH_BEAM_LIGHT_STATUS.getValue().equals(key);
+        if (!isLeft && !isRight && !isHighBeam) return;
 
         // O mesmo detector serve a dois momentos: o ENSAIO (o dono prova que sabe sair, antes de
         // ativar) e a SAÍDA de verdade. Fora dos dois, é inerte.
@@ -1360,93 +1380,81 @@ public class ServiceManager {
         } catch (Exception ignored) {
         }
 
-        // Só com o carro PARADO. Manobrar para estacionar produz esquerda-direita-esquerda-direita
-        // sem nenhuma intenção de sair do modo; parado, a alternância só acontece de propósito.
-        // Velocidade ilegível conta como "em movimento": é o lado seguro (no pior caso o dono
-        // repete o gesto), e sair sozinho na garagem de terceiros seria bem pior.
+        StealthExitSequence.Step step = isLeft
+                ? StealthExitSequence.Step.LEFT
+                : isRight
+                        ? StealthExitSequence.Step.RIGHT
+                        : StealthExitSequence.Step.HIGH_BEAM;
+        feedStealthExitStep(step, rehearsing);
+    }
+
+    /**
+     * Ponto unico onde os passos da sequencia de saida entram, venham das setas ou dos botoes do
+     * volante. Antes eram dois detectores separados com contadores proprios, o que impedia uma
+     * sequencia MISTA ("seta esquerda, botao 1, seta direita"): cada um so enxergava a propria
+     * metade e nenhum dos dois fechava. Os guardas de contexto (pisca-alerta, carro parado, modo
+     * inativo) ficam com quem chama, que e quem tem os dados do CAN.
+     */
+    private void feedStealthExitStep(StealthExitSequence.Step step, boolean rehearsing) {
+        // Gate de MARCHA P, no ponto único: antes ele estava só no caminho das setas, então pelos
+        // botões do volante a sequência avançava com o carro andando. Exigir P deixa a saída ser um
+        // ato deliberado, com o carro estacionado — parado num semáforo o gesto poderia sair sem
+        // querer, e manobrar produz seta-seta naturalmente.
+        //
+        // Marcha ilegível conta como "não está em P": lado seguro. No pior caso o dono repete o
+        // gesto; sair sozinho na garagem de terceiros seria bem pior.
+        boolean inPark;
         try {
-            String rawSpeed = getData(CarConstants.CAR_BASIC_VEHICLE_SPEED.getValue());
-            float speed = rawSpeed == null || rawSpeed.trim().isEmpty()
-                    ? Float.MAX_VALUE
-                    : Float.parseFloat(rawSpeed.trim());
-            if (speed > 0.5f) {
-                stealthExitTurnIndex = 0;
-                stealthExitLastTurnSide = null;
-                return;
-            }
+            String gear = getData(CarConstants.CAR_BASIC_GEAR_STATUS.getValue());
+            inPark = gear != null && "3".equals(gear.trim());   // 3 = P (ver getGearLabel)
         } catch (Exception e) {
-            stealthExitTurnIndex = 0;
-            stealthExitLastTurnSide = null;
+            inPark = false;
+        }
+        if (!inPark) {
+            StealthExitSequence.reset();
+            // No ensaio o dono está olhando a tela: sem este aviso ele repetiria o gesto sem
+            // entender por que o contador não anda.
+            if (rehearsing) {
+                StealthModeManager.onConfirmationBlocked("Coloque o carro em P para fazer a sequência.");
+            }
             return;
         }
 
-        String side = isLeft ? "L" : "R";
-        if (side.equals(stealthExitLastTurnSide)) return; // mesma seta piscando: não avança
+        StealthExitSequence.Outcome outcome = StealthExitSequence.feed(step, StealthExitSequence.current());
+        if (outcome == StealthExitSequence.Outcome.IGNORED) return;
 
-        long now = SystemClock.uptimeMillis();
-        if (stealthExitLastTurnAtMs != 0L && now - stealthExitLastTurnAtMs > STEALTH_EXIT_TURN_WINDOW_MS) {
-            stealthExitTurnIndex = 0; // demorou demais entre os lados -> recomeça
-        }
-        stealthExitLastTurnSide = side;
-        stealthExitLastTurnAtMs = now;
-
-        if (!STEALTH_EXIT_TURN_SEQUENCE[stealthExitTurnIndex].equals(side)) {
-            // Lado fora de ordem: recomeça, mas já aproveita este acionamento se ele serve de 1º.
-            stealthExitTurnIndex = STEALTH_EXIT_TURN_SEQUENCE[0].equals(side) ? 1 : 0;
-            Log.w(TAG, "Stealth exit (setas): fora de ordem, recomeçando em " + stealthExitTurnIndex);
+        if (outcome == StealthExitSequence.Outcome.PROGRESS) {
+            if (rehearsing) StealthModeManager.onConfirmationStep(StealthExitSequence.progress(), false);
             return;
         }
 
-        stealthExitTurnIndex++;
-        Log.w(TAG, "Stealth exit (setas): " + stealthExitTurnIndex + "/" + STEALTH_EXIT_TURN_SEQUENCE.length);
-        if (stealthExitTurnIndex < STEALTH_EXIT_TURN_SEQUENCE.length) {
-            if (rehearsing) StealthModeManager.onConfirmationStep(stealthExitTurnIndex, false);
-            return;
-        }
-
-        stealthExitTurnIndex = 0;
-        stealthExitLastTurnSide = null;
-        stealthExitLastTurnAtMs = 0L;
+        int total = StealthExitSequence.current().size();
         if (rehearsing) {
-            Log.w(TAG, "Ensaio da saída concluído");
-            StealthModeManager.onConfirmationStep(STEALTH_EXIT_TURN_SEQUENCE.length, true);
+            Log.w(TAG, "Ensaio da saida concluido");
+            StealthModeManager.onConfirmationStep(total, true);
             return;
         }
-        Log.w(TAG, "Stealth exit (setas) completo; saindo do Modo Concessionária");
-        StealthModeManager.exit(App.getContext(), "TURN_SIGNAL_SEQUENCE");
+        Log.w(TAG, "Sequencia de saida completa; confirmando");
+        StealthModeManager.onExitSequenceCompleted(App.getContext(), "EXIT_SEQUENCE");
     }
 
     private void handleStealthExitSequence(KeyEvent keyEvent) {
         if (keyEvent == null) return;
-        if (keyEvent.getKeyCode() != STEALTH_EXIT_BUTTON_1_KEY) return;
+        StealthExitSequence.Step step;
+        switch (keyEvent.getKeyCode()) {
+            case 517:  step = StealthExitSequence.Step.BUTTON1; break;  // botao 1, toque curto
+            case 1031: step = StealthExitSequence.Step.BUTTON2; break;  // botao 2, toque curto
+            default: return;
+        }
 
-        if (!StealthModeManager.isActive()) {
-            stealthExitPressCount = 0;
-            stealthExitLastPressAtMs = 0L;
+        boolean rehearsing = StealthModeManager.isAwaitingConfirmation();
+        if (!StealthModeManager.isActive() && !rehearsing) {
+            StealthExitSequence.reset();
             return;
         }
-
-        long now = SystemClock.uptimeMillis();
-        if (stealthExitLastPressAtMs != 0L && now - stealthExitLastPressAtMs < STEALTH_EXIT_DEBOUNCE_MS) {
-            return; // repique do mesmo toque
-        }
-        if (stealthExitLastPressAtMs != 0L && now - stealthExitLastPressAtMs > STEALTH_EXIT_WINDOW_MS) {
-            stealthExitPressCount = 0; // demorou demais entre toques -> recomeça
-        }
-        stealthExitLastPressAtMs = now;
-
-        stealthExitPressCount++;
-        Log.w(TAG, "Stealth exit sequence: toque " + stealthExitPressCount + "/" + STEALTH_EXIT_PRESSES);
-        if (stealthExitPressCount < STEALTH_EXIT_PRESSES) return;
-
-        stealthExitPressCount = 0;
-        stealthExitLastPressAtMs = 0L;
-        Log.w(TAG, "Stealth exit sequence complete; leaving Modo Concessionária");
-        StealthModeManager.exit(App.getContext(), "STEERING_SEQUENCE");
+        feedStealthExitStep(step, rehearsing);
     }
 
-    // Toque curto. Se houver acao de DUPLO configurada, espera ~350ms pra ver se vem um 2o toque
-    // (senao dispara o curto na hora, sem atraso). O 2o toque dentro da janela vira DUPLO.
     private void onSteeringCustomShortPress(int button) {
         final int idx = button - 1;
         long now = System.currentTimeMillis();

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthExitPin.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthExitPin.kt
@@ -1,0 +1,139 @@
+package br.com.redesurftank.havalshisuku.managers
+
+import android.content.Context
+import android.os.SystemClock
+import android.util.Base64
+import android.util.Log
+import androidx.core.content.edit
+import br.com.redesurftank.App
+import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+/**
+ * PIN de confirmação da saída do Modo Concessionária.
+ *
+ * A sequência do volante/setas prova INTENÇÃO (não foi sem querer); o PIN prova IDENTIDADE (é o
+ * dono, não alguém que reparou no gesto). Por isso um não substitui o outro: o PIN só é pedido
+ * depois que a sequência fecha.
+ *
+ * O número nunca é gravado — só o SHA-256 de (sal + PIN), com um sal aleatório por carro. Um PIN
+ * de 4 dígitos tem só 10 mil combinações, então o hash sozinho não seria grande obstáculo pra quem
+ * tivesse o arquivo em mãos; o que realmente segura aqui é o bloqueio progressivo por tentativa
+ * errada, que torna a força bruta inviável em quem está sentado no carro.
+ *
+ * **Sem porta dos fundos.** Esquecer o PIN com o modo ativo se resolve reinstalando o app e
+ * perdendo as configurações — o aviso disso está na tela que liga o PIN, e é decisão do dono.
+ */
+object StealthExitPin {
+
+    private const val TAG = "StealthExitPin"
+    private const val PREFS = "haval_prefs"
+
+    const val MIN_LENGTH = 4
+    const val MAX_LENGTH = 8
+
+    /** Erros tolerados antes de começar a atrasar as tentativas. */
+    private const val FREE_ATTEMPTS = 3
+
+    /** Espera após cada erro além dos tolerados: 30s, 60s, 120s... até o teto. */
+    private const val LOCKOUT_BASE_MS = 30_000L
+    private const val LOCKOUT_MAX_MS = 10 * 60_000L
+
+    @Volatile private var failedAttempts = 0
+    @Volatile private var lockedUntilMs = 0L
+
+    private fun prefs(context: Context = App.getDeviceProtectedContext()) =
+            context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    fun isEnabled(): Boolean =
+            prefs().getBoolean(SharedPreferencesKeys.ENABLE_STEALTH_EXIT_PIN.key, false) &&
+                    !prefs().getString(SharedPreferencesKeys.STEALTH_EXIT_PIN_HASH.key, "").isNullOrEmpty()
+
+    /** Grava o PIN (só o hash). Devolve null quando deu certo, ou o motivo da recusa. */
+    fun setPin(pin: String): String? {
+        val digits = pin.trim()
+        if (digits.length < MIN_LENGTH) return "O PIN precisa de pelo menos $MIN_LENGTH dígitos."
+        if (digits.length > MAX_LENGTH) return "O PIN pode ter no máximo $MAX_LENGTH dígitos."
+        if (!digits.all { it.isDigit() }) return "Use apenas números."
+        return try {
+            val salt = ByteArray(16).also { SecureRandom().nextBytes(it) }
+            val saltB64 = Base64.encodeToString(salt, Base64.NO_WRAP)
+            prefs().edit {
+                putString(SharedPreferencesKeys.STEALTH_EXIT_PIN_SALT.key, saltB64)
+                putString(SharedPreferencesKeys.STEALTH_EXIT_PIN_HASH.key, hash(digits, saltB64))
+            }
+            reset()
+            null
+        } catch (t: Throwable) {
+            Log.e(TAG, "falha ao gravar o PIN", t)
+            "Não foi possível gravar o PIN."
+        }
+    }
+
+    fun clearPin() {
+        prefs().edit {
+            remove(SharedPreferencesKeys.STEALTH_EXIT_PIN_HASH.key)
+            remove(SharedPreferencesKeys.STEALTH_EXIT_PIN_SALT.key)
+        }
+        reset()
+    }
+
+    private fun hash(pin: String, saltB64: String): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        md.update(Base64.decode(saltB64, Base64.NO_WRAP))
+        return Base64.encodeToString(md.digest(pin.toByteArray(Charsets.UTF_8)), Base64.NO_WRAP)
+    }
+
+    /** Quanto falta do bloqueio, em ms. 0 = pode tentar. */
+    fun lockoutRemainingMs(): Long =
+            (lockedUntilMs - SystemClock.elapsedRealtime()).coerceAtLeast(0L)
+
+    fun reset() {
+        failedAttempts = 0
+        lockedUntilMs = 0L
+    }
+
+    sealed class Result {
+        object Ok : Result()
+        data class Wrong(val remainingFreeAttempts: Int) : Result()
+        data class Locked(val remainingMs: Long) : Result()
+    }
+
+    fun verify(pin: String): Result {
+        val remaining = lockoutRemainingMs()
+        if (remaining > 0) return Result.Locked(remaining)
+
+        val saltB64 = prefs().getString(SharedPreferencesKeys.STEALTH_EXIT_PIN_SALT.key, "").orEmpty()
+        val expected = prefs().getString(SharedPreferencesKeys.STEALTH_EXIT_PIN_HASH.key, "").orEmpty()
+        if (saltB64.isEmpty() || expected.isEmpty()) {
+            // PIN marcado como ligado mas sem hash: não trancar o dono por um estado inconsistente.
+            Log.w(TAG, "PIN ligado sem hash gravado; liberando")
+            return Result.Ok
+        }
+
+        val ok = try {
+            MessageDigest.isEqual(
+                    hash(pin.trim(), saltB64).toByteArray(Charsets.UTF_8),
+                    expected.toByteArray(Charsets.UTF_8)
+            )
+        } catch (t: Throwable) {
+            Log.e(TAG, "falha ao conferir o PIN", t)
+            false
+        }
+
+        if (ok) {
+            reset()
+            return Result.Ok
+        }
+
+        failedAttempts++
+        val over = failedAttempts - FREE_ATTEMPTS
+        if (over > 0) {
+            val wait = (LOCKOUT_BASE_MS shl (over - 1).coerceAtMost(5)).coerceAtMost(LOCKOUT_MAX_MS)
+            lockedUntilMs = SystemClock.elapsedRealtime() + wait
+            return Result.Locked(wait)
+        }
+        return Result.Wrong((FREE_ATTEMPTS - failedAttempts).coerceAtLeast(0))
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthExitSequence.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthExitSequence.kt
@@ -1,0 +1,178 @@
+package br.com.redesurftank.havalshisuku.managers
+
+import android.os.SystemClock
+import android.util.Log
+import br.com.redesurftank.App
+import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys
+
+/**
+ * A sequência que tira o carro do Modo Concessionária.
+ *
+ * Antes era fixa (`L,R,L,R`). Agora o dono monta a dele, e cada passo pode ser uma seta ou um
+ * botão do volante — misturar os dois é o que torna a sequência realmente pessoal.
+ *
+ * **Por que setas sozinhas não bastariam:** o carro só avisa quando a luz da seta ACENDE, e acender
+ * a mesma seta duas vezes seguidas não produz dois eventos distinguíveis. Com só duas letras que
+ * não podem se repetir, toda sequência é obrigada a alternar, e a única liberdade seria o lado
+ * inicial e o tamanho. Os botões do volante quebram essa amarra: `B1,B1` é perfeitamente
+ * detectável (são dois toques), então `L,B1,B1,R` existe.
+ *
+ * O mesmo motor serve ao ENSAIO (o dono prova que sabe sair, antes de ativar) e à SAÍDA real.
+ */
+object StealthExitSequence {
+
+    private const val TAG = "StealthExitSequence";
+
+    enum class Step(val token: String, val label: String, val short: String) {
+        LEFT("L", "Seta esquerda", "←"),
+        RIGHT("R", "Seta direita", "→"),
+        BUTTON1("B1", "Botão 1 do volante", "①"),
+        BUTTON2("B2", "Botão 2 do volante", "②"),
+        HIGH_BEAM("HB", "Luz alta (passada de farol)", "⇈");
+
+        /**
+         * Passos que chegam como ESTADO DE LUZ não podem se repetir em seguida.
+         *
+         * A seta pisca sozinha enquanto a alavanca está acionada, então "acendeu" chega várias vezes
+         * para um único gesto — por isso repetição não conta. A luz alta em tese daria para piscar
+         * duas vezes seguidas, mas uma passada de farol costuma gerar mais de um evento, e contar
+         * errado aqui significa o dono não conseguir sair do modo. Fica na mesma regra: sem repetir.
+         * Os botões do volante são toques discretos e podem repetir à vontade.
+         */
+        val isLightSignal: Boolean
+            get() = this == LEFT || this == RIGHT || this == HIGH_BEAM
+
+        companion object {
+            fun fromToken(token: String): Step? =
+                    values().firstOrNull { it.token.equals(token.trim(), ignoreCase = true) }
+        }
+    }
+
+    const val MIN_STEPS = 3
+    const val MAX_STEPS = 8
+
+    /** Continua sendo a sequência histórica: quem já usava o modo não é surpreendido. */
+    val DEFAULT: List<Step> = listOf(Step.LEFT, Step.RIGHT, Step.LEFT, Step.RIGHT)
+
+    /**
+     * Prazo para a sequência INTEIRA, contado do primeiro passo. Antes era uma folga por passo, o
+     * que deixava uma sequência de 6 passos durar minutos: quem observasse o dono teria tempo de
+     * sobra para anotar. Com um prazo total, quem não sabe a sequência de cor não chega ao fim.
+     */
+    const val TOTAL_WINDOW_MS = 30_000L
+
+    /** Repique do mesmo toque do botão (o volante repete o evento). */
+    private const val BUTTON_DEBOUNCE_MS = 300L
+
+    // ---- persistência ---------------------------------------------------------------------
+
+    fun parse(raw: String?): List<Step> {
+        if (raw.isNullOrBlank()) return DEFAULT
+        val steps = raw.split(',').mapNotNull { Step.fromToken(it) }
+        return if (validate(steps) == null) steps else DEFAULT
+    }
+
+    fun format(steps: List<Step>): String = steps.joinToString(",") { it.token }
+
+    /** Texto amigável pra tela e pro ensaio: "← → ① ①". */
+    fun describe(steps: List<Step>): String = steps.joinToString(" ") { it.short }
+
+    /** Devolve null quando a sequência é válida, ou o motivo da recusa. */
+    fun validate(steps: List<Step>): String? {
+        if (steps.size < MIN_STEPS) return "Use pelo menos $MIN_STEPS passos."
+        if (steps.size > MAX_STEPS) return "No máximo $MAX_STEPS passos."
+        for (i in 1 until steps.size) {
+            val prev = steps[i - 1]
+            val cur = steps[i]
+            if (cur.isLightSignal && cur == prev) {
+                // Não é preciosismo: o carro não emite dois acendimentos distinguíveis, então uma
+                // sequência assim nunca seria reconhecida e trancaria o dono do lado de fora.
+                return "${cur.label} não pode aparecer duas vezes seguidas — o carro não distingue."
+            }
+        }
+        return null
+    }
+
+    /** O dono optou por montar a própria sequência? Senão, vale a padrão. */
+    @JvmStatic
+    fun isCustom(): Boolean =
+            App.getDeviceProtectedContext()
+                    .getSharedPreferences("haval_prefs", android.content.Context.MODE_PRIVATE)
+                    .getBoolean(SharedPreferencesKeys.STEALTH_EXIT_SEQUENCE_CUSTOM.key, false)
+
+    @JvmStatic
+    fun current(): List<Step> =
+            if (!isCustom()) DEFAULT
+            else parse(
+                    App.getDeviceProtectedContext()
+                            .getSharedPreferences("haval_prefs", android.content.Context.MODE_PRIVATE)
+                            .getString(SharedPreferencesKeys.STEALTH_EXIT_SEQUENCE.key, null)
+            )
+
+    // ---- máquina de estados ---------------------------------------------------------------
+
+    @Volatile private var index = 0
+    @Volatile private var lastStep: Step? = null
+    @Volatile private var lastAtMs = 0L
+    @Volatile private var firstAtMs = 0L
+
+    enum class Outcome { IGNORED, PROGRESS, COMPLETED }
+
+    @JvmStatic
+    @Synchronized
+    fun reset() {
+        index = 0
+        lastStep = null
+        lastAtMs = 0L
+        firstAtMs = 0L
+    }
+
+    /** Quantos passos já foram reconhecidos (pro ensaio mostrar progresso). */
+    @JvmStatic
+    @Synchronized
+    fun progress(): Int = index
+
+    /**
+     * Alimenta o motor com um passo executado pelo dono.
+     *
+     * Os guardas de contexto (pisca-alerta ligado, carro em movimento, modo inativo) ficam de fora
+     * de propósito: quem sabe disso é o ServiceManager, que tem os dados do CAN em mãos.
+     */
+    @JvmStatic
+    @JvmOverloads
+    @Synchronized
+    fun feed(step: Step, expected: List<Step> = current()): Outcome {
+        if (expected.isEmpty()) return Outcome.IGNORED
+        val now = SystemClock.uptimeMillis()
+
+        if (step.isLightSignal && step == lastStep) {
+            // Mesma seta acendendo de novo: o carro repete o evento enquanto pisca.
+            return Outcome.IGNORED
+        }
+        if (!step.isLightSignal && step == lastStep && now - lastAtMs < BUTTON_DEBOUNCE_MS) {
+            return Outcome.IGNORED // repique do mesmo toque
+        }
+        if (firstAtMs != 0L && now - firstAtMs > TOTAL_WINDOW_MS) {
+            index = 0 // estourou o prazo da sequência inteira
+            firstAtMs = 0L
+        }
+
+        lastStep = step
+        lastAtMs = now
+
+        if (expected[index] != step) {
+            // Passo fora de ordem: recomeça, mas aproveita este acionamento se ele serve de 1º.
+            index = if (expected[0] == step) 1 else 0
+            Log.w(TAG, "fora de ordem; recomeçando em $index")
+            return if (index > 0) Outcome.PROGRESS else Outcome.IGNORED
+        }
+
+        index++
+        if (index == 1) firstAtMs = now
+        Log.w(TAG, "passo $index/${expected.size}")
+        if (index < expected.size) return Outcome.PROGRESS
+
+        reset()
+        return Outcome.COMPLETED
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthModeManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthModeManager.kt
@@ -1,0 +1,942 @@
+package br.com.redesurftank.havalshisuku.managers
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.widget.Toast
+import br.com.redesurftank.App
+import br.com.redesurftank.havalshisuku.SplashActivity
+import br.com.redesurftank.havalshisuku.ambientlight.AmbientLightService
+import br.com.redesurftank.havalshisuku.diagnostics.ClusterPersistentEventLogger
+import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys
+import br.com.redesurftank.havalshisuku.services.BottomBarService
+import br.com.redesurftank.havalshisuku.services.ForegroundService
+import br.com.redesurftank.havalshisuku.utils.ShizukuUtils
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * MODO CONCESSIONÁRIA — devolve o carro ao comportamento de fábrica antes de levar à revisão.
+ *
+ * ARQUITETURA: DESLIGAR AS PREFERÊNCIAS DE VERDADE (não master switch).
+ *
+ * A primeira versão era um master switch: uma flag consultada em N pontos de ação. Falhou no
+ * carro — o painel continuou com o tema porque `ProjectorManager` criava as Presentations do
+ * cluster incondicionalmente (as prefs só decidiam o que era PINTADO dentro da janela). A lição:
+ * gate espalhado obriga a caçar TODOS os caminhos, e sempre escapa um.
+ *
+ * Isso foi consertado na ORIGEM, não aqui: `ProjectorManager.initialize()` agora consulta
+ * ENABLE_VIRTUAL_CLUSTER / ENABLE_INSTRUMENT_PROJECTOR antes de criar cada projector, e derruba o
+ * que estiver vivo com a pref desligada. Ou seja: desligar o Virtual Cluster passou a devolver o
+ * painel ao nativo para QUALQUER usuário, e este modo herda o comportamento de graça — sem gate.
+ *
+ * Agora o modo:
+ *  1. grava um RETRATO completo de `haval_prefs` (JSON, com os tipos) em
+ *     [SharedPreferencesKeys.STEALTH_PREFS_SNAPSHOT], com `commit()`, ANTES de mexer em nada;
+ *  2. desliga as preferências que ativam funcionalidades (ver [featureKeysToDisable]);
+ *  3. reaplica o estado desligado pelos MESMOS pontos que o boot usa.
+ *
+ * Com as preferências realmente desligadas, o app roda pelo caminho já testado de quem nunca ligou
+ * nenhuma dessas features — em vez de um caminho novo cheio de gates. Sair = restaurar o retrato
+ * (tipos originais, removendo o que não existia) e reaplicar.
+ *
+ * VOLTA: o ícone do launcher some, então não há como abrir o app. As portas de volta são:
+ *  1. 3 toques CURTOS no botão 1 do volante em até 8s (ServiceManager.dispatchKeyEvent);
+ *  2. o broadcast do StealthExitReceiver, por telnet/adb — o comando exato está no KDoc daquele
+ *     receiver (precisa de `-n <componente>`; broadcast implícito não chega no Android 8+).
+ *
+ * Toda etapa é isolada em try/catch: uma etapa que falhe NUNCA pode impedir as outras — sobretudo
+ * no [exit], que é o único caminho de recuperação.
+ */
+object StealthModeManager {
+    private const val TAG = "StealthModeManager"
+    private const val PREFS_NAME = "haval_prefs"
+
+    /** Onde guardamos a lista do que escondemos, para saber o que devolver na volta. */
+    private const val HIDDEN_PACKAGES_KEY = "stealthHiddenPackages"
+
+    /**
+     * Chaves DO PRÓPRIO MODO. Ficam fora do retrato e fora da restauração: são o estado que
+     * controla a volta, não configuração do usuário. Se entrassem no retrato, restaurar apagaria
+     * a lista de apps escondidos antes de devolvê-los.
+     */
+    private val INTERNAL_KEYS =
+        setOf(
+            SharedPreferencesKeys.STEALTH_MODE_ACTIVE.key,
+            SharedPreferencesKeys.STEALTH_PREFS_SNAPSHOT.key,
+            HIDDEN_PACKAGES_KEY
+        )
+
+    /**
+     * Exceções ao desligamento automático: preferências cujo nome começa com `ENABLE_` mas que NÃO
+     * são feature visível — são a infraestrutura privilegiada que o app usa para funcionar (e para
+     * reverter este modo). Desligá-las deixaria o app sem braços.
+     */
+    private val NEVER_DISABLE =
+        setOf(
+            // Hooks do Frida: é por eles que o app instala/patcheia coisas no system_server.
+            // Não aparecem na tela e desligar a pref não desfaz o que já está injetado — só tiraria
+            // capacidade do app, sem ganho nenhum de disfarce.
+            SharedPreferencesKeys.ENABLE_FRIDA_HOOKS,
+            SharedPreferencesKeys.ENABLE_FRIDA_HOOK_SYSTEM_SERVER
+        )
+
+    /**
+     * Preferências de ATIVAÇÃO que não começam com `ENABLE_`. Critério da lista: entra tudo que,
+     * sozinho, LIGA um comportamento — automação do carro, algo desenhado na tela, patch montado,
+     * app do sistema desativado, controle de rede. Ficam de fora: valores de ajuste (horários,
+     * limites, cores, offsets), estado interno de bookkeeping (`*_DISABLED_BY_APP`, contadores de
+     * tráfego, últimas telas) e preferências de UI do próprio app (canal beta, uso avançado) —
+     * nenhum deles faz nada por conta própria, e o retrato devolve todos intactos na saída.
+     */
+    private val EXTRA_FEATURE_KEYS =
+        listOf(
+            // --- Automações do carro (janelas, teto, cortina, volume) ---
+            SharedPreferencesKeys.CLOSE_WINDOW_ON_POWER_OFF,
+            SharedPreferencesKeys.CLOSE_WINDOW_ON_FOLD_MIRROR,
+            SharedPreferencesKeys.CLOSE_SUNROOF_ON_POWER_OFF,
+            SharedPreferencesKeys.CLOSE_SUNROOF_ON_FOLD_MIRROR,
+            SharedPreferencesKeys.CLOSE_WINDOWS_ON_SPEED,
+            SharedPreferencesKeys.CLOSE_SUNROOF_ON_SPEED,
+            SharedPreferencesKeys.CLOSE_SUNROOF_SUN_SHADE_ON_CLOSE_SUNROOF,
+            SharedPreferencesKeys.SET_STARTUP_VOLUME,
+            // --- Comportamentos do carro que o app SUPRIME (false = volta ao de fábrica) ---
+            SharedPreferencesKeys.DISABLE_MONITORING,
+            SharedPreferencesKeys.DISABLE_AVAS,
+            SharedPreferencesKeys.DISABLE_AVM_CAR_STOPPED,
+            // --- Debloat: false faz o boot reinstalar (pm install-existing) os apps do OEM ---
+            SharedPreferencesKeys.DISABLE_NATIVE_NAVIGATION,
+            SharedPreferencesKeys.DISABLE_NATIVE_VOICE,
+            SharedPreferencesKeys.DISABLE_NATIVE_WEATHER,
+            // --- Bluetooth / hotspot ao desligar ou recolher o retrovisor ---
+            SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF,
+            SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF,
+            SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_FOLD_MIRROR,
+            SharedPreferencesKeys.DISABLE_HOTSPOT_ON_FOLD_MIRROR,
+            // --- Barra inferior e painel lateral (desenhados por cima da UI do OEM) ---
+            SharedPreferencesKeys.PERSISTENT_BOTTOM_BAR,
+            SharedPreferencesKeys.BOTTOM_BAR_AUTO_HIDE,
+            SharedPreferencesKeys.HIDE_LEFT_NAV_PANE,
+            // --- Cluster / projeção ---
+            SharedPreferencesKeys.CLUSTER_PROJECTION_OPENS_DASHBOARD,
+            SharedPreferencesKeys.CLUSTER_HIDE_SPEEDOMETER_ON_MAPS,
+            SharedPreferencesKeys.CLUSTER_V2_TRIP_INFO,
+            SharedPreferencesKeys.TRIP_CONSISTENCY_CLUSTER_ACTIVE,
+            SharedPreferencesKeys.TRIP_CONSISTENCY_CLUSTER_SCORE,
+            SharedPreferencesKeys.AUTO_MOVE_PROJECTION_TO_CLUSTER,
+            // --- Patches montados no Android Auto / CarPlay (CarPlay tem default TRUE) ---
+            SharedPreferencesKeys.AA_PATCH_AUTO_MOUNT,
+            SharedPreferencesKeys.CARPLAY_PATCH_AUTO_MOUNT,
+            // --- Luz ambiente (BLE/DMX) ---
+            SharedPreferencesKeys.AMBIENT_LIGHT_BLE_ENABLED,
+            SharedPreferencesKeys.AMBIENT_LIGHT_SYNC_DRIVE_MODE,
+            SharedPreferencesKeys.AMBIENT_LIGHT_ANIMATIONS_ENABLED,
+            SharedPreferencesKeys.AMBIENT_LIGHT_MUSIC_ANIMATION_ENABLED,
+            SharedPreferencesKeys.AMBIENT_LIGHT_AUTO_RECONNECT,
+            // --- Conectividade (roteamento, prioridade de WiFi, corte de 4G, telemetria OEM) ---
+            SharedPreferencesKeys.MOBILE_DATA_CONTROL_ENABLED,
+            SharedPreferencesKeys.BLOCK_CAR_MOBILE_DATA,
+            SharedPreferencesKeys.MOBILE_DATA_AUTOBLOCK,
+            SharedPreferencesKeys.MOBILE_DATA_BLOCK_ON_WIFI,
+            SharedPreferencesKeys.MOBILE_DATA_BLOCK_ON_PROJECTION,
+            SharedPreferencesKeys.BLOCK_DATATRACK_TELEMETRY,
+            // --- Aviso de voz do cinto: o duck da música é ativação própria ---
+        )
+
+    /**
+     * A única preferência de ativação que não é booleana: o pacote que o cluster abre sozinho no
+     * startup (InstrumentProjector2.triggerAutoLaunch). Vazio = não abre nada. Sem isto, um app
+     * configurado subiria no painel depois de um ciclo de ignição — o pior tipo de denúncia.
+     */
+    private val CLEAR_ON_ENTER = listOf(SharedPreferencesKeys.DEFAULT_DISPLAY_APP_PACKAGE)
+
+    /**
+     * A ÚNICA exclusão da varredura de apps de terceiros: o próprio Impulse.
+     *
+     * Não existem mais duas listas (uma de "não mexer" e outra de "só o ícone"). Depois do teste
+     * no carro o dono decidiu que TODO app de terceiro é tratado igual — só o ícone some, o app
+     * continua rodando (ver [hideThirdPartyApps]). Com isso, o Shizuku e os apps de terceiros deixaram de ser
+     * casos especiais: nada é suspenso, então nada tranca a porta por dentro nem derruba sessão
+     * de ninguém.
+     *
+     * O Impulse fica de fora porque o ícone dele é tratado à parte, por
+     * [setLauncherIconEnabled] (`setComponentEnabledSetting` no próprio processo, com
+     * DONT_KILL_APP) — deixá-lo também na varredura genérica só duplicaria o comando.
+     */
+    private val NEVER_TOUCH = setOf("br.com.redesurftank.havalshisuku")
+
+    // ===== Ensaio da saída, ANTES de ativar =====
+    // Sugestão de um colega, e a proteção que faltava: em vez de explicar o gesto num texto
+    // que ninguém lê, o dono EXECUTA a saída antes de entrar. Assim ele prova que sabe sair e, de
+    // quebra, prova que o gesto funciona NESTE carro — foi exatamente aqui que a versão anterior
+    // falhou (chave de seta não suportada) e o carro ficou preso com o modo ligado.
+    @Volatile private var awaitingConfirmation = false
+    @Volatile private var confirmationProgress = 0
+    @Volatile private var confirmationListener: ((Int, Boolean) -> Unit)? = null
+
+    @JvmStatic
+    fun isAwaitingConfirmation(): Boolean = awaitingConfirmation
+
+    /** Arma o ensaio. [onProgress] recebe (passos de 0 a 4, concluído). */
+    @JvmStatic
+    fun armConfirmation(onProgress: (Int, Boolean) -> Unit) {
+        awaitingConfirmation = true
+        confirmationProgress = 0
+        confirmationListener = onProgress
+        onProgress(0, false)
+    }
+
+    @JvmStatic
+    fun cancelConfirmation() {
+        awaitingConfirmation = false
+        confirmationProgress = 0
+        confirmationListener = null
+    }
+
+    /** Chamado pelo detector de setas a cada troca de lado válida durante o ensaio. */
+    @JvmStatic
+    fun onConfirmationStep(step: Int, done: Boolean) {
+        confirmationProgress = step
+        val listener = confirmationListener
+        if (done) {
+            awaitingConfirmation = false
+            confirmationListener = null
+        }
+        Handler(Looper.getMainLooper()).post { listener?.invoke(step, done) }
+    }
+
+    private fun prefs() =
+        App.getDeviceProtectedContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /**
+     * Consultado pelos dois gates que sobraram (o central do OnDataChanged e a suspensão das ações
+     * do volante), pela detecção da sequência de saída e pelo ensureSteeringWheelButtonIntegration
+     * (que precisa manter o botão 1 nosso mesmo com as prefs desligadas). Lê a pref direto —
+     * device-protected storage, igual aos outros managers — pra funcionar antes do unlock.
+     */
+    @JvmStatic
+    fun isActive(): Boolean =
+        try {
+            prefs().getBoolean(SharedPreferencesKeys.STEALTH_MODE_ACTIVE.key, false)
+        } catch (t: Throwable) {
+            Log.e(TAG, "Falha lendo a flag do Modo Concessionária; assumindo desligado", t)
+            false
+        }
+
+    /** Grava a flag com commit(): é o estado que define se o app tem volta, não pode ficar em cache. */
+    private fun setActive(active: Boolean) {
+        prefs().edit().putBoolean(SharedPreferencesKeys.STEALTH_MODE_ACTIVE.key, active).commit()
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Retrato das preferências
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Serializa TODO o conteúdo de `haval_prefs` num JSON `{ chave: {t: tipo, v: valor} }` e grava
+     * em [SharedPreferencesKeys.STEALTH_PREFS_SNAPSHOT] com `commit()` — síncrono de propósito: o
+     * retrato tem que estar no disco antes da primeira alteração, senão um kill no meio da entrada
+     * levaria as configurações do usuário junto.
+     *
+     * @return true se o retrato foi gravado. false ABORTA a entrada no modo (ver [enter]).
+     */
+    private fun snapshotPreferences(): Boolean =
+        try {
+            val root = JSONObject()
+            for ((key, value) in prefs().all) {
+                if (key in INTERNAL_KEYS) continue
+                val entry = JSONObject()
+                when (value) {
+                    is Boolean -> entry.put("t", "b").put("v", value)
+                    is Int -> entry.put("t", "i").put("v", value)
+                    is Long -> entry.put("t", "l").put("v", value)
+                    is Float -> entry.put("t", "f").put("v", value.toDouble())
+                    is String -> entry.put("t", "s").put("v", value)
+                    is Set<*> -> {
+                        val arr = JSONArray()
+                        for (item in value) {
+                            if (item is String) arr.put(item)
+                        }
+                        entry.put("t", "ss").put("v", arr)
+                    }
+                    null -> continue
+                    else -> {
+                        Log.w(TAG, "Tipo desconhecido em '$key' (${value.javaClass}); fora do retrato")
+                        continue
+                    }
+                }
+                root.put(key, entry)
+            }
+            val ok =
+                prefs().edit()
+                    .putString(SharedPreferencesKeys.STEALTH_PREFS_SNAPSHOT.key, root.toString())
+                    .commit()
+            Log.w(TAG, "Retrato das preferências gravado: ${root.length()} chaves (commit=$ok)")
+            ClusterPersistentEventLogger.log(
+                "stealth_prefs_snapshot",
+                mapOf("keys" to root.length(), "committed" to ok)
+            )
+            ok
+        } catch (t: Throwable) {
+            Log.e(TAG, "Falha ao gravar o retrato das preferências", t)
+            false
+        }
+
+    /**
+     * A lista do que é desligado ao entrar.
+     *
+     * CRITÉRIO: (1) TODA preferência cujo nome no enum começa com `ENABLE_` — é a convenção do
+     * projeto para "liga uma funcionalidade" — menos as de [NEVER_DISABLE]; (2) mais as de
+     * ativação que não seguem a convenção, listadas em [EXTRA_FEATURE_KEYS].
+     *
+     * A parte automática é de propósito: uma feature nova que siga a convenção `ENABLE_` já nasce
+     * coberta, sem ninguém precisar lembrar de vir aqui — que foi exatamente como a versão de
+     * master switch deixou caminhos escapando.
+     */
+    private fun featureKeysToDisable(): List<String> {
+        val keys = LinkedHashSet<String>()
+        for (pref in SharedPreferencesKeys.values()) {
+            if (pref in NEVER_DISABLE) continue
+            if (pref.name.startsWith("ENABLE_")) keys.add(pref.key)
+        }
+        for (pref in EXTRA_FEATURE_KEYS) keys.add(pref.key)
+        keys.removeAll(INTERNAL_KEYS)
+        return keys.toList()
+    }
+
+    /**
+     * Escreve `false` em todas as chaves de [featureKeysToDisable] — inclusive nas que nem existem
+     * ainda, porque várias têm default TRUE (aviso de cinto, patch do CarPlay, fundo do display 1)
+     * e "não existir" não as desliga. Chaves que hoje guardam outro tipo são puladas: sobrescrever
+     * um Int com Boolean derrubaria quem as lê com getInt.
+     */
+    private fun disableFeaturePreferences() {
+        val p = prefs()
+        val current = p.all
+        val editor = p.edit()
+        var written = 0
+        var skipped = 0
+        for (key in featureKeysToDisable()) {
+            val existing = current[key]
+            if (existing != null && existing !is Boolean) {
+                Log.w(TAG, "Pulando '$key': valor atual não é booleano (${existing.javaClass.simpleName})")
+                skipped++
+                continue
+            }
+            editor.putBoolean(key, false)
+            written++
+        }
+        for (pref in CLEAR_ON_ENTER) {
+            val existing = current[pref.key]
+            if (existing != null && existing !is String) continue
+            editor.putString(pref.key, "")
+        }
+        val ok = editor.commit()
+        Log.w(TAG, "Preferências desligadas: $written (puladas: $skipped, commit=$ok)")
+        ClusterPersistentEventLogger.log(
+            "stealth_prefs_disabled",
+            mapOf("written" to written, "skipped" to skipped, "committed" to ok)
+        )
+    }
+
+    /**
+     * Devolve o retrato: cada chave volta com o TIPO original e o que não estava no retrato é
+     * REMOVIDO (voltando ao default do código). O retrato é apagado logo depois, pelo [exit].
+     *
+     * Nunca trava: retrato ausente ou corrompido só loga e retorna false — o [exit] segue com as
+     * outras etapas. Ficar preso no modo é muito pior do que ter que reconfigurar.
+     */
+    private fun restorePreferences(): Boolean {
+        val raw =
+            try {
+                prefs().getString(SharedPreferencesKeys.STEALTH_PREFS_SNAPSHOT.key, null)
+            } catch (t: Throwable) {
+                Log.e(TAG, "Falha lendo o retrato das preferências", t)
+                null
+            }
+        if (raw.isNullOrBlank()) {
+            Log.e(TAG, "Sem retrato das preferências para restaurar; seguindo com a saída")
+            ClusterPersistentEventLogger.log("stealth_prefs_restore_missing")
+            return false
+        }
+        return try {
+            val root = JSONObject(raw)
+            val p = prefs()
+            val editor = p.edit()
+
+            // 1) Some com o que nasceu depois do retrato (e não é chave interna do modo).
+            for (key in p.all.keys.toList()) {
+                if (key in INTERNAL_KEYS) continue
+                if (!root.has(key)) editor.remove(key)
+            }
+
+            // 2) Devolve cada chave do retrato com o tipo original.
+            var restored = 0
+            val names = root.keys()
+            while (names.hasNext()) {
+                val key = names.next()
+                if (key in INTERNAL_KEYS) continue
+                val entry = root.optJSONObject(key) ?: continue
+                when (entry.optString("t")) {
+                    "b" -> editor.putBoolean(key, entry.optBoolean("v", false))
+                    "i" -> editor.putInt(key, entry.optInt("v", 0))
+                    "l" -> editor.putLong(key, entry.optLong("v", 0L))
+                    "f" -> editor.putFloat(key, entry.optDouble("v", 0.0).toFloat())
+                    "s" -> editor.putString(key, entry.optString("v", ""))
+                    "ss" -> {
+                        val arr = entry.optJSONArray("v") ?: JSONArray()
+                        val set = LinkedHashSet<String>()
+                        for (i in 0 until arr.length()) set.add(arr.optString(i))
+                        editor.putStringSet(key, set)
+                    }
+                    else -> {
+                        Log.w(TAG, "Entrada '$key' do retrato tem tipo desconhecido; ignorada")
+                        continue
+                    }
+                }
+                restored++
+            }
+
+            val ok = editor.commit()
+            Log.w(TAG, "Preferências restauradas: $restored (commit=$ok)")
+            ClusterPersistentEventLogger.log(
+                "stealth_prefs_restored",
+                mapOf("restored" to restored, "committed" to ok)
+            )
+            ok
+        } catch (t: Throwable) {
+            Log.e(TAG, "Retrato das preferências corrompido; seguindo com a saída assim mesmo", t)
+            ClusterPersistentEventLogger.log(
+                "stealth_prefs_restore_failed",
+                mapOf("error" to t.toString())
+            )
+            false
+        }
+    }
+
+    /** Apaga o retrato. O modo não deve deixar lixo para trás. */
+    private fun clearSnapshot() {
+        prefs().edit().remove(SharedPreferencesKeys.STEALTH_PREFS_SNAPSHOT.key).commit()
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Ícones dos apps
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Activity de launcher de [pkg], ou null se o app não tiver ícone.
+     *
+     * [includeDisabled] existe porque, depois de `pm disable`, o componente SOME das buscas
+     * normais do PackageManager — procurar o ícone para devolvê-lo daria "esse app nunca teve
+     * ícone". Toda leitura feita no caminho de VOLTA precisa da flag.
+     */
+    private fun launcherActivityOf(pkg: String, includeDisabled: Boolean = false): String? = try {
+        val pm = App.getContext().packageManager
+        val intent = Intent(Intent.ACTION_MAIN)
+            .addCategory(Intent.CATEGORY_LAUNCHER)
+            .setPackage(pkg)
+        val flags = if (includeDisabled) PackageManager.MATCH_DISABLED_COMPONENTS else 0
+        pm.queryIntentActivities(intent, flags)
+            .firstOrNull()
+            ?.activityInfo
+            ?.name
+    } catch (t: Throwable) {
+        Log.e(TAG, "Não consegui resolver a activity de launcher de $pkg", t)
+        null
+    }
+
+    /**
+     * Some com o ícone de [pkg] sem tocar no app: `pm disable` mira SÓ a activity do launcher.
+     * O processo, os serviços e as permissões do app continuam exatamente como estavam.
+     */
+    private fun setThirdPartyIconEnabled(pkg: String, enabled: Boolean) {
+        // Ao reabilitar, a activity já está desabilitada — sem MATCH_DISABLED_COMPONENTS a busca
+        // volta vazia e o ícone ficaria escondido para sempre.
+        val activity = launcherActivityOf(pkg, includeDisabled = enabled)
+        if (activity == null) {
+            Log.w(TAG, "$pkg não tem activity de launcher; nada a esconder")
+            return
+        }
+        val verb = if (enabled) "enable" else "disable"
+        ShizukuUtils.runCommandAndGetOutput(arrayOf("pm", verb, "$pkg/$activity"))
+        Log.w(TAG, "Ícone de $pkg: $verb ($activity)")
+    }
+
+    /**
+     * Esconde o ÍCONE dos apps instalados pelo dono, deixando na tela só os nativos do sistema.
+     * Os apps continuam rodando normalmente — só somem da área de trabalho e da gaveta.
+     *
+     * POR QUE NUNCA `pm hide`: a versão anterior suspendia cada app de terceiro. Suspender não é
+     * "esconder": o app fica impedido de rodar enquanto durar o modo — não recebe broadcast, não
+     * sobe serviço, nada. No carro isso matou a sessão de um app de terceiros e exigiu reautorizar o Shizuku
+     * na volta. O disfarce que o dono quer é visual, então o comando certo é
+     * `pm disable <pkg>/<activityDeLauncher>` — mira só o ícone.
+     *
+     * RESSALVA HONESTA sobre o `pm disable`: o shell não expõe DONT_KILL_APP, então trocar o
+     * estado do componente MATA o processo do app uma vez, na hora. A diferença para o `pm hide`
+     * é que aqui a morte é pontual e reversível sozinha: o app não fica suspenso, então serviço
+     * com START_STICKY, alarme ou broadcast o trazem de volta em seguida. Não é "zero impacto",
+     * é "cai e levanta" em vez de "fica no chão até sair do modo".
+     *
+     * `pm list packages -3` é exatamente a distinção pedida: lista apenas o que não veio de
+     * fábrica.
+     *
+     * O REGISTRO GUARDA `pkg/activity`, não só o pacote. Dois motivos: depois do disable a
+     * activity não aparece mais numa busca comum (ver [launcherActivityOf]), e ela pode mudar
+     * numa atualização do app — guardar o par é o que garante devolver exatamente o que foi
+     * tirado. Ele é gravado ANTES do primeiro disable: se o processo morrer no meio do laço, a
+     * volta ainda sabe o que devolver.
+     */
+    private fun hideThirdPartyApps() {
+        val raw = ShizukuUtils.runCommandAndGetOutput(arrayOf("pm", "list", "packages", "-3"))
+        val packages = raw.lineSequence()
+            .map { it.trim().removePrefix("package:").trim() }
+            .filter { it.isNotEmpty() && it !in NEVER_TOUCH }
+            .distinct()
+            .toList()
+        if (packages.isEmpty()) {
+            Log.w(TAG, "Nenhum app de terceiros para esconder")
+            return
+        }
+
+        // Resolve TODAS as activities antes de desabilitar a primeira: uma vez desabilitada, a
+        // activity some da busca e o par pkg/activity não seria mais recuperável.
+        val targets = packages.mapNotNull { pkg ->
+            val activity = launcherActivityOf(pkg)
+            if (activity == null) {
+                Log.w(TAG, "$pkg não tem activity de launcher; nada a esconder")
+                null
+            } else {
+                "$pkg/$activity"
+            }
+        }
+        if (targets.isEmpty()) {
+            Log.w(TAG, "Nenhum ícone de app de terceiros para esconder")
+            return
+        }
+
+        prefs().edit().putString(HIDDEN_PACKAGES_KEY, targets.joinToString(",")).commit()
+        var hidden = 0
+        for (target in targets) {
+            try {
+                ShizukuUtils.runCommandAndGetOutput(arrayOf("pm", "disable", target))
+                hidden++
+            } catch (t: Throwable) {
+                Log.e(TAG, "Falha ao esconder o ícone de $target", t)
+            }
+        }
+        Log.w(TAG, "Ícones de apps de terceiros escondidos: $hidden/${targets.size}")
+        ClusterPersistentEventLogger.log(
+            "stealth_hide_apps",
+            mapOf("requested" to targets.size, "hidden" to hidden)
+        )
+    }
+
+    /**
+     * Reinicia a central logo depois de ativar o modo.
+     *
+     * Aplicar tudo com o sistema em pe deixa a tela travada em preto: sao janelas derrubadas,
+     * icones desabilitados e um punhado de servicos parados ao mesmo tempo, e o launcher nao se
+     * recompoe sozinho. O dono reiniciou na mao e o carro voltou exatamente como devia — com cara
+     * de fabrica — entao o reinicio passa a fazer parte da ativacao, nao ser tarefa dele.
+     *
+     * Reiniciar tambem e o que faz o painel voltar ao nativo de verdade: no boot seguinte, com as
+     * preferencias ja desligadas, os projetores do cluster simplesmente nao sobem.
+     *
+     * So com o carro PARADO: reiniciar a central em movimento tiraria camera de re, ar e som de
+     * quem esta dirigindo. Velocidade ilegivel conta como em movimento.
+     */
+    private fun rebootHeadUnitAfterEnter(context: Context) {
+        try {
+            val raw = ServiceManager.getInstance()
+                .getData(br.com.redesurftank.havalshisuku.models.CarConstants.CAR_BASIC_VEHICLE_SPEED.value)
+            val speed = raw?.trim()?.toFloatOrNull() ?: Float.MAX_VALUE
+            if (speed > 0.5f) {
+                Log.w(TAG, "Carro em movimento (speed=$speed); NAO reiniciando a central")
+                toast(context, "Modo Concessionária ativo — reinicie a central quando parar")
+                return
+            }
+        } catch (t: Throwable) {
+            Log.e(TAG, "Velocidade ilegivel; nao reiniciando a central", t)
+            toast(context, "Modo Concessionária ativo — reinicie a central quando parar")
+            return
+        }
+
+        toast(context, "Modo Concessionária ativo — reiniciando a central…")
+        ClusterPersistentEventLogger.log("stealth_reboot", mapOf("reason" to "ENTER"))
+        // Folga para o toast aparecer e para as preferências assentarem em disco (o snapshot e a
+        // flag já foram gravados com commit(), então um corte aqui não perde o retrato).
+        Handler(Looper.getMainLooper()).postDelayed({
+            try {
+                ShizukuUtils.runCommandAndGetOutput(arrayOf("svc", "power", "reboot"))
+                ShizukuUtils.runCommandAndGetOutput(arrayOf("reboot"))
+            } catch (t: Throwable) {
+                Log.e(TAG, "Falha ao reiniciar a central", t)
+            }
+        }, 4000L)
+    }
+
+    /**
+     * Reinicia os apps de terceiros na saida do modo.
+     *
+     * Desabilitar a activity de launcher derruba o processo do app uma vez, e ele costuma voltar
+     * num estado meio-vivo: um app de terceiros ficava com a tela do celular presa em dados antigos ate
+     * levar um force-stop na mao. Um `am force-stop` limpa isso — o app sobe de novo pelo proprio
+     * servico/alarme, ou no primeiro toque do dono.
+     *
+     * O proprio Impulse e o Shizuku ficam de fora: derrubar o primeiro mataria quem esta
+     * executando esta restauracao, e o segundo e a fonte do privilegio que a executa.
+     */
+    private fun restartThirdPartyApps() {
+        val keepAlive = setOf(
+            "br.com.redesurftank.havalshisuku",
+            "moe.shizuku.privileged.api"
+        )
+        val raw = ShizukuUtils.runCommandAndGetOutput(arrayOf("pm", "list", "packages", "-3"))
+        val packages = raw.lineSequence()
+            .map { it.trim().removePrefix("package:").trim() }
+            .filter { it.isNotEmpty() && it !in keepAlive }
+            .distinct()
+            .toList()
+        var restarted = 0
+        for (pkg in packages) {
+            try {
+                ShizukuUtils.runCommandAndGetOutput(arrayOf("am", "force-stop", pkg))
+                restarted++
+            } catch (t: Throwable) {
+                Log.e(TAG, "Falha ao reiniciar $pkg", t)
+            }
+        }
+        Log.w(TAG, "Apps de terceiros reiniciados: $restarted/${packages.size}")
+        ClusterPersistentEventLogger.log(
+            "stealth_restart_apps",
+            mapOf("requested" to packages.size, "restarted" to restarted)
+        )
+    }
+
+    /**
+     * Devolve os ícones. Best-effort, um a um, e TODAS as etapas rodam SEMPRE.
+     *
+     * BUG CORRIGIDO: aqui havia um `return` quando a lista salva estava em branco, colocado ANTES
+     * das etapas seguintes de restauração. Bastava a lista faltar (modo entrado por outra versão,
+     * preferência perdida, entrada abortada no meio) para a função ir embora sem devolver nada —
+     * foi assim que o ícone do Shizuku ficou para trás no carro. Agora a lista vazia só significa
+     * "não tenho registro", e a varredura por estado observado continua.
+     */
+    private fun restoreThirdPartyApps() {
+        val stored = prefs().getString(HIDDEN_PACKAGES_KEY, "").orEmpty()
+        val entries = stored.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+
+        var restored = 0
+        for (entry in entries) {
+            try {
+                if (entry.contains('/')) {
+                    ShizukuUtils.runCommandAndGetOutput(arrayOf("pm", "enable", entry))
+                } else {
+                    // Formato ANTIGO: versões anteriores gravavam só o pacote e usavam `pm hide`.
+                    // Se o app foi atualizado com o modo ativo, é este o lixo que sobrou — desfaz
+                    // a suspensão e, por garantia, reabilita o ícone.
+                    ShizukuUtils.runCommandAndGetOutput(arrayOf("pm", "unhide", entry))
+                    setThirdPartyIconEnabled(entry, true)
+                }
+                restored++
+            } catch (t: Throwable) {
+                Log.e(TAG, "Falha ao restaurar $entry", t)
+            }
+        }
+
+        // Rede de segurança — roda mesmo sem lista nenhuma. Ver [reenableDisabledLauncherIcons].
+        var swept = 0
+        step("sweep_disabled_icons") { swept = reenableDisabledLauncherIcons() }
+
+        // Só limpa o registro depois de tentar todos — se algo falhou, uma nova saída retenta.
+        prefs().edit().remove(HIDDEN_PACKAGES_KEY).commit()
+        Log.w(TAG, "Ícones restaurados: $restored/${entries.size} (varredura devolveu $swept)")
+        ClusterPersistentEventLogger.log(
+            "stealth_restore_apps",
+            mapOf("requested" to entries.size, "restored" to restored, "swept" to swept)
+        )
+    }
+
+    /**
+     * RESTAURAÇÃO POR ESTADO OBSERVADO: reabilita qualquer ícone de app de terceiro que esteja
+     * desabilitado, mesmo que a lista salva não saiba dele.
+     *
+     * Por que existe: até agora a saída só desfazia o que a versão ATUAL sabia ter feito. Quando o
+     * app foi atualizado com o modo ligado, o registro veio de outra versão (ou de um formato
+     * diferente) e sobrou lixo — o ícone de um app de terceiros ficou desabilitado e nada o devolvia. Olhar o
+     * estado real do sistema conserta independentemente de quem escondeu, e de qual versão.
+     *
+     * LIMITES DE PRECAUÇÃO, para não "consertar" o que o dono desligou de propósito:
+     *  - só apps de terceiro (`pm list packages -3`); nada do sistema é tocado;
+     *  - só a activity de LAUNCHER; nenhum outro componente entra na varredura;
+     *  - só o estado COMPONENT_ENABLED_STATE_DISABLED, que é exatamente o que `pm disable` grava.
+     *    COMPONENT_ENABLED_STATE_DISABLED_USER (o caminho do usuário / `pm disable-user`) e
+     *    DISABLED_UNTIL_USED (do sistema) ficam intocados de propósito.
+     *
+     * @return quantos ícones foram devolvidos.
+     */
+    private fun reenableDisabledLauncherIcons(): Int {
+        val pm = App.getContext().packageManager
+        val raw = ShizukuUtils.runCommandAndGetOutput(arrayOf("pm", "list", "packages", "-3"))
+        var fixed = 0
+        for (line in raw.lineSequence()) {
+            val pkg = line.trim().removePrefix("package:").trim()
+            if (pkg.isEmpty() || pkg in NEVER_TOUCH) continue
+            try {
+                val activity = launcherActivityOf(pkg, includeDisabled = true) ?: continue
+                val state = pm.getComponentEnabledSetting(ComponentName(pkg, activity))
+                if (state != PackageManager.COMPONENT_ENABLED_STATE_DISABLED) continue
+                ShizukuUtils.runCommandAndGetOutput(arrayOf("pm", "enable", "$pkg/$activity"))
+                Log.w(TAG, "Varredura: ícone de $pkg estava desabilitado; devolvido ($activity)")
+                fixed++
+            } catch (t: Throwable) {
+                Log.e(TAG, "Varredura: falha ao checar/devolver o ícone de $pkg", t)
+            }
+        }
+        Log.w(TAG, "Varredura de ícones desabilitados: $fixed devolvido(s)")
+        return fixed
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Entrada / saída
+    // ---------------------------------------------------------------------------------------
+
+    fun enter(context: Context, reason: String) {
+        val appContext = context.applicationContext
+        Log.w(TAG, "Entrando no Modo Concessionária (reason=$reason)")
+
+        // ANTES de qualquer coisa: garantir que os botões do volante cheguem até nós. Sem a
+        // integração custom habilitada, o head unit trata o botão como função nativa e os toques
+        // NUNCA chegam ao app — a sequência de saída simplesmente não existiria. Forçamos
+        // independentemente das preferências; o exit() devolve o estado do usuário.
+        // (A sequência usa o botão 1; o 2 vai junto por ser inofensivo e simétrico.)
+        //
+        // ORDEM IMPORTA — este passo vem ANTES do retrato de propósito: enableSteeringWheelButtonN
+        // grava a config NATIVA do botão em STEERING_WHEEL_CUSTOM_BUTON_N_ACTION_ORIGINAL antes de
+        // trocá-la por 99. Se o retrato fosse tirado antes, essa chave não estaria nele e a saída a
+        // removeria — aí disableNativeSteeringWheelButtonN não teria o valor original pra devolver e
+        // o botão ficaria preso em 99 (nosso) sem nenhuma ação configurada, ou seja, morto.
+        step("force_steering_integration") {
+            ServiceManager.getInstance().enableSteeringWheelButton1Integration()
+            ServiceManager.getInstance().enableSteeringWheelButton2Integration()
+        }
+
+        // O retrato é a condição de segurança da entrada: sem ele, desligar as preferências
+        // significaria perder a configuração do usuário. Falhou => não entra.
+        if (!snapshotPreferences()) {
+            Log.e(TAG, "Não foi possível salvar as preferências; ABORTANDO a entrada no modo")
+            ClusterPersistentEventLogger.log("stealth_mode_enter_aborted", mapOf("reason" to reason))
+            toast(appContext, "Não consegui salvar suas configurações — Modo Concessionária NÃO foi ativado")
+            return
+        }
+
+        step("set_flag") { setActive(true) }
+        step("disable_feature_prefs") { disableFeaturePreferences() }
+        step("hide_launcher_icon") { setLauncherIconEnabled(appContext, false) }
+
+        // Agora força a aplicação do estado desligado pelos mesmos pontos do boot.
+        //
+        // O refresh() sozinho já basta desde que ProjectorManager.initialize() passou a respeitar
+        // ENABLE_VIRTUAL_CLUSTER / ENABLE_INSTRUMENT_PROJECTOR: com as prefs em false ele derruba a
+        // Presentation viva e não recria nenhuma — o painel volta a ser o nativo. O stopProjectors()
+        // logo depois é redundância barata, para o caso de o refresh falhar no meio.
+        // Presentation.dismiss() exige a UI thread; por isso o onMain.
+        onMain {
+            step("refresh_projectors") { ProjectorManager.getInstance().refresh() }
+            step("stop_projectors") { ProjectorManager.getInstance().stopProjectors() }
+        }
+        // A barra inferior e o overlay flutuante de CPU/RAM são desenhados pelo MESMO serviço
+        // (BottomBarService); o onDestroy dele já devolve o `wm overscan` para 0,0,0,0.
+        step("stop_bottom_bar") {
+            appContext.stopService(Intent(appContext, BottomBarService::class.java))
+        }
+        step("stop_ambient_light") { AmbientLightService.stop(appContext) }
+        // Com a pref já em false, updateSchedule() cancela os alarmes e não reagenda nada.
+        step("cancel_auto_brightness") { AutoBrightnessManager.getInstance().updateSchedule() }
+        // A notificação persistente denuncia o app pelo nome. Troca AGORA para a versão neutra —
+        // sem isto ela só mudaria no próximo start do serviço. (A flag já está em true acima, então
+        // o serviço monta a discreta.)
+        step("quiet_notification") { ForegroundService.refreshNotificationForStealth() }
+
+        // Trabalho de shell via Shizuku: nunca na thread chamadora (a UI).
+        //
+        // hide_third_party_apps entrou aqui (era síncrono): cada `pm` é um processo novo pelo
+        // Shizuku, e agora são dois por app (resolver a activity + desabilitar). Numa lista de
+        // uma dúzia de apps isso é segundos de bloqueio — de pé na thread que chamou enter(),
+        // que é a da UI. Vai primeiro na fila porque é o efeito que o dono vê na tela.
+        background("apply_off_state") {
+            step("hide_third_party_apps") { hideThirdPartyApps() }
+            step("unmount_android_auto") { AndroidAutoPatchManager.removeMounts() }
+            step("unmount_carplay") { CarPlayPatchManager.removeMounts() }
+            // onServicesReady() só LIGA; para desligar é o setEnabled(false) (a pref já está false).
+            step("stop_hot_router") { HotRouterManager.getInstance().setEnabled(false) }
+            // Devolve o 4G e a telemetria OEM: no modo o carro tem que se comportar como de fábrica.
+            step("release_mobile_data") { MobileDataManager.recomputeAndApply(appContext) }
+            step("release_datatrack") { MobileDataManager.applyDatatrackState() }
+            // Reinstala (pm install-existing) os apps do OEM que o debloat tinha removido.
+            step("restore_native_apps") { ServiceManager.getInstance().ensureDebloatedSystemApps() }
+        }
+
+        step("log") {
+            ClusterPersistentEventLogger.log("stealth_mode_enter", mapOf("reason" to reason))
+        }
+        // O toast final e o reinicio ficam a cargo de rebootHeadUnitAfterEnter: aplicar tudo com
+        // o sistema em pe deixa a tela travada em preto, e o reinicio e o que faz o painel voltar
+        // ao nativo de verdade (no boot seguinte os projetores nem sobem).
+        step("reboot_head_unit") { rebootHeadUnitAfterEnter(appContext) }
+    }
+
+    @JvmStatic
+    fun exit(context: Context, reason: String) {
+        val appContext = context.applicationContext
+        Log.w(TAG, "Saindo do Modo Concessionária (reason=$reason)")
+
+        // A flag cai PRIMEIRO: tudo que é reaplicado abaixo tem que enxergar o app já normal.
+        step("clear_flag") { setActive(false) }
+        // Depois as preferências: todas as reaplicações abaixo leem delas. Dentro de step() como
+        // todo o resto — nada nesta função pode abortar a saída pela metade.
+        var restored = false
+        step("restore_prefs") { restored = restorePreferences() }
+        step("clear_snapshot") { clearSnapshot() }
+        // Devolve os botões ao que as preferências do usuário mandam (pode ser função nativa).
+        step("restore_steering_integration") {
+            ServiceManager.getInstance().ensureSteeringWheelButtonIntegration()
+        }
+        step("show_launcher_icon") { setLauncherIconEnabled(appContext, true) }
+        // Flag já em false lá em cima, então isto reemite a notificação normal do serviço.
+        step("restore_notification") { ForegroundService.refreshNotificationForStealth() }
+        onMain { step("restart_projectors") { ProjectorManager.getInstance().refresh() } }
+        step("restart_bottom_bar") { restartBottomBarLikeBoot(appContext) }
+        step("restart_ambient_light") { AmbientLightService.startIfEnabled(appContext) }
+        // updateSchedule() já retorna cedo se a pref do usuário estiver desligada.
+        step("restore_auto_brightness") { AutoBrightnessManager.getInstance().updateSchedule() }
+
+        background("reapply_user_state") {
+            // restore_third_party_apps entrou aqui (era síncrono) e vai PRIMEIRO: é o que o dono
+            // precisa ver de volta. Um dos caminhos de saída é o StealthExitReceiver, cujo
+            // onReceive roda na main thread com o prazo de ANR do broadcast — e a devolução dos
+            // ícones agora varre a lista instalada além da lista salva, ou seja, mais `pm` ainda.
+            // Bloquear ali arriscaria o sistema derrubar justo o caminho de recuperação.
+            step("restore_third_party_apps") { restoreThirdPartyApps() }
+            step("restart_third_party_apps") { restartThirdPartyApps() }
+            // Mesma rotina e mesmo gate por pref que o ForegroundService usa no boot.
+            step("remount_android_auto") {
+                if (prefs().getBoolean(SharedPreferencesKeys.AA_PATCH_AUTO_MOUNT.key, false)) {
+                    AndroidAutoPatchManager.ensureMounted()
+                }
+            }
+            step("remount_carplay") {
+                if (prefs().getBoolean(SharedPreferencesKeys.CARPLAY_PATCH_AUTO_MOUNT.key, true)) {
+                    CarPlayPatchManager.ensureMounted()
+                }
+            }
+            // onServicesReady() é o ponto do boot: liga só se a pref restaurada mandar.
+            step("restart_hot_router") { HotRouterManager.getInstance().onServicesReady() }
+            step("reapply_mobile_data") { MobileDataManager.recomputeAndApply(appContext) }
+            step("reapply_datatrack") { MobileDataManager.applyDatatrackState() }
+            step("reapply_debloat") { ServiceManager.getInstance().ensureDebloatedSystemApps() }
+        }
+
+        step("log") {
+            ClusterPersistentEventLogger.log(
+                "stealth_mode_exit",
+                mapOf("reason" to reason, "prefsRestored" to restored)
+            )
+        }
+        toast(
+            appContext,
+            if (restored) "Impulse reativado"
+            else "Impulse reativado — não achei o retrato das configurações, confira os ajustes"
+        )
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Etapas
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Some/volta com o ícone do launcher. SplashActivity é quem carrega o intent-filter LAUNCHER
+     * (ver AndroidManifest.xml); DONT_KILL_APP mantém o processo vivo — é ele que ainda escuta o
+     * volante pra poder desfazer isso.
+     */
+    private fun setLauncherIconEnabled(context: Context, enabled: Boolean) {
+        val component = ComponentName(context, SplashActivity::class.java)
+        val state =
+            if (enabled) PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+            else PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        context.packageManager.setComponentEnabledSetting(
+            component,
+            state,
+            PackageManager.DONT_KILL_APP
+        )
+        Log.w(TAG, "Ícone do launcher " + (if (enabled) "reativado" else "escondido"))
+    }
+
+    /** Mesmo caminho do BottomBarBootReceiver: sobe o serviço e reaplica o overscan salvo. */
+    private fun restartBottomBarLikeBoot(context: Context) {
+        val p = prefs()
+        if (!p.getBoolean(SharedPreferencesKeys.PERSISTENT_BOTTOM_BAR.key, false)) {
+            Log.d(TAG, "Barra inferior desligada nas preferências; nada a religar")
+            return
+        }
+        if (!android.provider.Settings.canDrawOverlays(context)) {
+            Log.e(TAG, "Sem permissão de overlay; não dá pra religar a barra inferior")
+            return
+        }
+        context.startService(Intent(context, BottomBarService::class.java))
+        val overscan = p.getInt(SharedPreferencesKeys.PERSISTENT_BOTTOM_BAR_OVERSCAN.key, 20)
+        background("reapply_overscan") {
+            ShizukuUtils.runCommandAndGetOutput(arrayOf("wm", "overscan", "0,0,0,$overscan"))
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Utilitários — nenhuma etapa pode derrubar as seguintes
+    // ---------------------------------------------------------------------------------------
+
+    private inline fun step(name: String, body: () -> Unit) {
+        try {
+            body()
+        } catch (t: Throwable) {
+            Log.e(TAG, "Etapa '$name' do Modo Concessionária falhou (seguindo adiante)", t)
+            try {
+                ClusterPersistentEventLogger.log(
+                    "stealth_mode_step_failed",
+                    mapOf("step" to name, "error" to t.toString())
+                )
+            } catch (ignored: Throwable) {
+            }
+        }
+    }
+
+    private fun onMain(body: () -> Unit) {
+        try {
+            Handler(Looper.getMainLooper()).post(body)
+        } catch (t: Throwable) {
+            Log.e(TAG, "Falha ao postar etapa na UI thread", t)
+        }
+    }
+
+    private fun background(name: String, body: () -> Unit) {
+        try {
+            Thread({ step(name, body) }, "StealthMode-$name").start()
+        } catch (t: Throwable) {
+            Log.e(TAG, "Falha ao iniciar a thread da etapa '$name'", t)
+        }
+    }
+
+    private fun toast(context: Context, message: String) {
+        onMain {
+            try {
+                Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+            } catch (t: Throwable) {
+                Log.e(TAG, "Falha ao exibir o toast do Modo Concessionária", t)
+            }
+        }
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthModeManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthModeManager.kt
@@ -82,7 +82,12 @@ object StealthModeManager {
             // Não aparecem na tela e desligar a pref não desfaz o que já está injetado — só tiraria
             // capacidade do app, sem ganho nenhum de disfarce.
             SharedPreferencesKeys.ENABLE_FRIDA_HOOKS,
-            SharedPreferencesKeys.ENABLE_FRIDA_HOOK_SYSTEM_SERVER
+            SharedPreferencesKeys.ENABLE_FRIDA_HOOK_SYSTEM_SERVER,
+            // O PIN de saída. A varredura automática pega tudo que começa com ENABLE_, e isso
+            // desligava justamente a trava da porta de saída ao entrar no modo: na hora de sair,
+            // isEnabled() era false e a sequência saía direto, sem pedir nada. Não é disfarce
+            // nenhum desligá-lo — ele só existe DENTRO do modo.
+            SharedPreferencesKeys.ENABLE_STEALTH_EXIT_PIN
         )
 
     /**
@@ -183,10 +188,36 @@ object StealthModeManager {
 
     /** Arma o ensaio. [onProgress] recebe (passos de 0 a 4, concluído). */
     @JvmStatic
-    fun armConfirmation(onProgress: (Int, Boolean) -> Unit) {
+    @Volatile private var confirmationBlockedListener: ((String) -> Unit)? = null
+
+    /** Avisa a tela do ensaio que uma condição não foi atendida (ex.: carro fora de P). */
+    @JvmStatic
+    fun onConfirmationBlocked(reason: String) {
+        if (!awaitingConfirmation) return
+        val listener = confirmationBlockedListener ?: return
+        Handler(Looper.getMainLooper()).post { listener.invoke(reason) }
+    }
+
+    @JvmStatic
+    @JvmOverloads
+    fun armConfirmation(
+            onProgress: (Int, Boolean) -> Unit,
+            onBlocked: ((String) -> Unit)? = null
+    ) {
+        confirmationBlockedListener = onBlocked
         awaitingConfirmation = true
         confirmationProgress = 0
         confirmationListener = onProgress
+        StealthExitSequence.reset()
+        // O ensaio acontece ANTES de ativar, e é justamente na ativação que os botões do volante
+        // passam a ser capturados. Sem isto, uma sequência com ① ou ② nunca completaria o ensaio:
+        // o toque continuaria indo pra função nativa e o dono ficaria preso na tela de ensaio,
+        // sem conseguir ativar — e sem entender por quê.
+        try {
+            ServiceManager.getInstance().ensureSteeringWheelButtonIntegration()
+        } catch (t: Throwable) {
+            Log.w(TAG, "não deu pra preparar os botões do volante pro ensaio", t)
+        }
         onProgress(0, false)
     }
 
@@ -195,6 +226,14 @@ object StealthModeManager {
         awaitingConfirmation = false
         confirmationProgress = 0
         confirmationListener = null
+        confirmationBlockedListener = null
+        StealthExitSequence.reset()
+        // Desistiu de ativar: devolve os botões à configuração normal do dono.
+        try {
+            ServiceManager.getInstance().ensureSteeringWheelButtonIntegration()
+        } catch (t: Throwable) {
+            Log.w(TAG, "não deu pra restaurar os botões do volante", t)
+        }
     }
 
     /** Chamado pelo detector de setas a cada troca de lado válida durante o ensaio. */
@@ -205,6 +244,7 @@ object StealthModeManager {
         if (done) {
             awaitingConfirmation = false
             confirmationListener = null
+            confirmationBlockedListener = null
         }
         Handler(Looper.getMainLooper()).post { listener?.invoke(step, done) }
     }
@@ -789,6 +829,30 @@ object StealthModeManager {
         // o sistema em pe deixa a tela travada em preto, e o reinicio e o que faz o painel voltar
         // ao nativo de verdade (no boot seguinte os projetores nem sobem).
         step("reboot_head_unit") { rebootHeadUnitAfterEnter(appContext) }
+    }
+
+    /**
+     * A sequência fechou. Se o dono ligou o PIN, ainda falta provar QUEM é: a sequência mostra
+     * intenção (não foi sem querer), o PIN mostra identidade. Sem PIN, sai direto como antes.
+     */
+    @JvmStatic
+    fun onExitSequenceCompleted(context: Context, reason: String) {
+        if (!StealthExitPin.isEnabled()) {
+            exit(context, reason)
+            return
+        }
+        Log.w(TAG, "[$reason] sequência ok; pedindo PIN")
+        // Janela sobreposta, NÃO Activity: com o app escondido não há tela em primeiro plano, e o
+        // Android recusa abrir Activity a partir de segundo plano. A primeira versão usava Activity
+        // e no carro ela nunca apareceu — a saída acontecia sem pedir PIN nenhum, que é o oposto do
+        // que a feature promete.
+        val shown = StealthPinOverlay.show { exit(context, "${reason}_PIN_OK") }
+        if (!shown) {
+            // Nem o overlay subiu (sem permissão de sobreposição, por exemplo). Ficar preso no modo
+            // sem nenhum recurso é pior que o modo ser burlável: sai e registra.
+            Log.e(TAG, "[$reason] teclado do PIN não subiu; saindo sem ele")
+            exit(context, "${reason}_PIN_UI_FALHOU")
+        }
     }
 
     @JvmStatic

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthPinOverlay.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthPinOverlay.kt
@@ -1,0 +1,254 @@
+package br.com.redesurftank.havalshisuku.managers
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import android.widget.Button
+import android.widget.GridLayout
+import android.widget.LinearLayout
+import android.widget.TextView
+import br.com.redesurftank.App
+
+/**
+ * Pede o PIN de saída do Modo Concessionária numa JANELA SOBREPOSTA, não numa Activity.
+ *
+ * A primeira versão era uma Activity, e no carro ela simplesmente não abria: o Android bloqueia
+ * abrir tela a partir de segundo plano, e como o app está escondido no modo, não há Activity em
+ * primeiro plano para autorizar. O resultado foi o pior possível — a sequência saía do modo sem
+ * pedir PIN nenhum. Uma janela de overlay não passa por essa restrição: é o mesmo mecanismo da
+ * barra inferior e do indicador de CPU/RAM, que já sobem sobre qualquer app.
+ *
+ * Sem marca do app de propósito: quem estiver com o carro vê um teclado numérico, não uma pista de
+ * que existe algo instalado.
+ */
+object StealthPinOverlay {
+
+    private const val TAG = "StealthPinOverlay"
+
+    private var root: View? = null
+    private var onSuccess: (() -> Unit)? = null
+    private val autoHide = Handler(Looper.getMainLooper())
+
+    /**
+     * A janela cobre a tela inteira: se ficar presa, a central vira um tijolo. Some sozinha depois
+     * disso, e o dono simplesmente refaz a sequência. Ninguém fica sem central por causa de um
+     * teclado esquecido na tela.
+     */
+    private const val AUTO_HIDE_MS = 90_000L
+
+    @JvmStatic
+    fun isShowing(): Boolean = root != null
+
+    /** Mostra o teclado. [onOk] roda quando o PIN confere. */
+    @JvmStatic
+    fun show(onOk: () -> Unit): Boolean {
+        val handler = Handler(Looper.getMainLooper())
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            var ok = false
+            handler.post { ok = show(onOk) }
+            return true // otimista: o post não falha; o resultado real vai pro log
+        }
+        if (root != null) return true
+        onSuccess = onOk
+        return try {
+            val ctx = App.getContext()
+            val wm = ctx.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+            val view = buildView(ctx)
+            val lp =
+                    WindowManager.LayoutParams(
+                            // Do tamanho do teclado, centralizado — não a tela inteira. A versão
+                            // anterior era MATCH_PARENT com FLAG_LAYOUT_NO_LIMITS, e essa flag deixa
+                            // a janela ultrapassar os limites da tela: o resultado foi um painel
+                            // preto inteiro com o teclado jogado na esquerda.
+                            WindowManager.LayoutParams.WRAP_CONTENT,
+                            WindowManager.LayoutParams.WRAP_CONTENT,
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+                            } else {
+                                @Suppress("DEPRECATION") WindowManager.LayoutParams.TYPE_PHONE
+                            },
+                            // Sem FLAG_NOT_FOCUSABLE: sem foco o toque nos botões não chega.
+                            // Sem NO_LIMITS: é ele que tira a janela do enquadramento da tela.
+                            WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN,
+                            android.graphics.PixelFormat.TRANSLUCENT
+                    )
+            lp.gravity = Gravity.CENTER
+            wm.addView(view, lp)
+            root = view
+            armAutoHide()
+            Log.w(TAG, "teclado do PIN na tela")
+            true
+        } catch (t: Throwable) {
+            Log.e(TAG, "não deu pra mostrar o teclado do PIN", t)
+            onSuccess = null
+            false
+        }
+    }
+
+    /** (Re)agenda o recolhimento. Chamado a cada toque pra ninguém ter o teclado puxado no meio. */
+    private fun armAutoHide() {
+        autoHide.removeCallbacksAndMessages(null)
+        autoHide.postDelayed({
+            if (root != null) {
+                Log.w(TAG, "teclado do PIN sem uso; recolhendo pra não travar a central")
+                hide()
+            }
+        }, AUTO_HIDE_MS)
+    }
+
+    @JvmStatic
+    fun hide() {
+        autoHide.removeCallbacksAndMessages(null)
+        val view = root ?: return
+        root = null
+        onSuccess = null
+        try {
+            val wm = App.getContext().getSystemService(Context.WINDOW_SERVICE) as WindowManager
+            wm.removeView(view)
+        } catch (t: Throwable) {
+            Log.w(TAG, "falha ao remover o teclado", t)
+        }
+    }
+
+    private fun dp(v: Int): Int =
+            (v * App.getContext().resources.displayMetrics.density).toInt()
+
+    private fun buildView(ctx: Context): View {
+        var typed = ""
+
+        val dots = TextView(ctx).apply {
+            textSize = 26f
+            setTextColor(Color.parseColor("#4CA6FF"))
+            letterSpacing = 0.4f
+            gravity = Gravity.CENTER
+        }
+        val message = TextView(ctx).apply {
+            textSize = 13f
+            setTextColor(Color.parseColor("#FF6B6B"))
+            gravity = Gravity.CENTER
+            visibility = View.GONE
+        }
+        val title = TextView(ctx).apply {
+            text = "Digite o PIN"
+            textSize = 20f
+            setTextColor(Color.WHITE)
+            gravity = Gravity.CENTER
+        }
+
+        fun render() {
+            dots.text = "•".repeat(typed.length).ifEmpty { " " }
+        }
+        render()
+
+        val grid = GridLayout(ctx).apply {
+            columnCount = 3
+            setPadding(0, dp(12), 0, 0)
+        }
+
+        fun key(label: String, onClick: () -> Unit): Button =
+                Button(ctx).apply {
+                    text = label
+                    textSize = 18f
+                    setTextColor(Color.WHITE)
+                    background = GradientDrawable().apply {
+                        cornerRadius = dp(8).toFloat()
+                        setColor(Color.parseColor("#1A1F26"))
+                    }
+                    layoutParams = GridLayout.LayoutParams().apply {
+                        width = dp(78)
+                        height = dp(52)
+                        setMargins(dp(5), dp(5), dp(5), dp(5))
+                    }
+                    setOnClickListener {
+                        armAutoHide()
+                        onClick()
+                    }
+                }
+
+        fun submit() {
+            when (val r = StealthExitPin.verify(typed)) {
+                is StealthExitPin.Result.Ok -> {
+                    val cb = onSuccess
+                    hide()
+                    cb?.invoke()
+                }
+                is StealthExitPin.Result.Wrong -> {
+                    typed = ""
+                    render()
+                    message.text = "PIN incorreto. Restam ${r.remainingFreeAttempts}."
+                    message.visibility = View.VISIBLE
+                }
+                is StealthExitPin.Result.Locked -> {
+                    typed = ""
+                    render()
+                    message.text = "Muitas tentativas. Espere ${r.remainingMs / 1000}s."
+                    message.visibility = View.VISIBLE
+                }
+            }
+        }
+
+        for (d in listOf("1", "2", "3", "4", "5", "6", "7", "8", "9")) {
+            grid.addView(key(d) {
+                if (typed.length < StealthExitPin.MAX_LENGTH) {
+                    typed += d
+                    render()
+                    message.visibility = View.GONE
+                }
+            })
+        }
+        grid.addView(key("<") {
+            if (typed.isNotEmpty()) {
+                typed = typed.dropLast(1)
+                render()
+            }
+        })
+        grid.addView(key("0") {
+            if (typed.length < StealthExitPin.MAX_LENGTH) {
+                typed += "0"
+                render()
+                message.visibility = View.GONE
+            }
+        })
+        grid.addView(key("OK") {
+            if (typed.length >= StealthExitPin.MIN_LENGTH) submit()
+        })
+
+        val cancel = TextView(ctx).apply {
+            text = "Cancelar"
+            textSize = 13f
+            setTextColor(android.graphics.Color.parseColor("#6B7480"))
+            gravity = Gravity.CENTER
+            setPadding(dp(16), dp(14), dp(16), dp(4))
+            // Só fecha o teclado; o carro continua no modo. É a válvula de escape pra quem abriu
+            // sem querer — sem ela, a tela ficaria bloqueada até o prazo automático vencer.
+            setOnClickListener { hide() }
+        }
+
+        val panel = LinearLayout(ctx).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER_HORIZONTAL
+            setPadding(dp(28), dp(24), dp(28), dp(24))
+            background = GradientDrawable().apply {
+                cornerRadius = dp(14).toFloat()
+                setColor(Color.parseColor("#14181D"))
+                // Contorno discreto: sem o fundo escurecido atrás, o painel precisa se destacar
+                // sozinho de qualquer tela que estiver embaixo.
+                setStroke(dp(1), Color.parseColor("#2C3139"))
+            }
+            addView(title)
+            addView(dots)
+            addView(message)
+            addView(grid)
+            addView(cancel)
+        }
+
+        return panel
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/UpdateNoticeManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/UpdateNoticeManager.kt
@@ -1,0 +1,127 @@
+package br.com.redesurftank.havalshisuku.managers
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.util.Log
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.core.content.edit
+import br.com.redesurftank.App
+import br.com.redesurftank.havalshisuku.BuildConfig
+import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys
+import br.com.redesurftank.havalshisuku.utils.ReleaseUpdateChecker
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Verifica UMA vez por partida se saiu versão nova e avisa discretamente.
+ *
+ * **De propósito não sabe ONDE buscar.** Quem sabe é o [ReleaseUpdateChecker], e o endereço dele é
+ * a única linha que difere entre este fork e o repositório de origem — cada um aponta pro seu
+ * próprio local de releases. Mantendo essa decisão fora daqui, esta função fica idêntica nos dois
+ * lados e nunca conflita num merge.
+ *
+ * Também não baixa nem instala nada: só avisa. Instalar envolve o caminho do Frida e é decisão do
+ * dono, na tela de Informações.
+ */
+object UpdateNoticeManager {
+
+    private const val TAG = "UpdateNoticeManager"
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * Versão nova disponível, ou null. Lido pela barra inferior (card do dashboard) e pelo menu.
+     * É `mutableStateOf` porque quem observa é Compose.
+     */
+    var availableVersion by mutableStateOf<String?>(null)
+        private set
+
+    @Volatile private var alreadyChecked = false
+
+    /**
+     * Espera a rede aparecer antes de tentar.
+     *
+     * Verificar no instante da partida seria furada: ao ligar o carro o WiFi ainda está associando
+     * e o 4G negociando, então a busca falharia quase sempre — e um "não consegui verificar"
+     * repetido a cada ignição é pior que não avisar nada.
+     */
+    private const val NETWORK_POLL_MS = 15_000L
+    private const val NETWORK_GIVEUP_MS = 5 * 60_000L
+
+    private fun prefs() =
+            App.getDeviceProtectedContext()
+                    .getSharedPreferences("haval_prefs", Context.MODE_PRIVATE)
+
+    private fun hasNetwork(): Boolean = try {
+        val cm = App.getContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val caps = cm.getNetworkCapabilities(cm.activeNetwork)
+        caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    } catch (t: Throwable) {
+        false
+    }
+
+    /** Chamado no start do app. O app sobe uma vez por ignição, então isto é uma vez por partida. */
+    @JvmStatic
+    fun checkOnStart() {
+        if (alreadyChecked) return
+        if (!prefs().getBoolean(SharedPreferencesKeys.ENABLE_UPDATE_NOTICE.key, true)) return
+        alreadyChecked = true
+        scope.launch {
+            try {
+                var waited = 0L
+                while (!hasNetwork()) {
+                    if (waited >= NETWORK_GIVEUP_MS) {
+                        Log.w(TAG, "sem rede após ${waited / 1000}s; desisto desta partida")
+                        return@launch
+                    }
+                    delay(NETWORK_POLL_MS)
+                    waited += NETWORK_POLL_MS
+                }
+
+                val current = BuildConfig.VERSION_NAME.removePrefix("v")
+                // Mesma regra da tela de Informações: quem está numa build "-preview" acompanha o
+                // canal beta; quem está numa estável, as estáveis. Se as duas discordassem, o card
+                // apontaria uma novidade que a tela não confirma.
+                val onPreview = BuildConfig.VERSION_NAME.contains("-preview")
+                val result = ReleaseUpdateChecker.getAllReleaseInfo()
+                val candidate = (if (onPreview) result.latestPreview else result.latestRelease)
+                        ?: return@launch
+                val candidateVersion = candidate.tag.removePrefix("v")
+
+                if (ReleaseUpdateChecker.compareVersions(candidateVersion, current) <= 0) {
+                    Log.w(TAG, "nenhuma versão nova (atual $current)")
+                    return@launch
+                }
+                val dismissed = prefs()
+                        .getString(SharedPreferencesKeys.UPDATE_NOTICE_DISMISSED_VERSION.key, "")
+                if (candidateVersion == dismissed) {
+                    // Já avisou e o dono dispensou: cala até sair OUTRA versão. Sem isto, o mesmo
+                    // card voltaria toda manhã pra quem simplesmente não quer atualizar agora.
+                    Log.w(TAG, "versão $candidateVersion já foi dispensada")
+                    return@launch
+                }
+                Log.w(TAG, "versão nova disponível: $candidateVersion (atual $current)")
+                availableVersion = candidateVersion
+            } catch (t: Throwable) {
+                Log.e(TAG, "falha ao verificar atualização", t)
+            }
+        }
+    }
+
+    /** O dono dispensou o aviso desta versão. Volta a avisar só quando sair outra. */
+    @JvmStatic
+    fun dismiss() {
+        val v = availableVersion ?: return
+        availableVersion = null
+        prefs().edit {
+            putString(SharedPreferencesKeys.UPDATE_NOTICE_DISMISSED_VERSION.key, v)
+        }
+        Log.w(TAG, "aviso da versão $v dispensado")
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/ReleaseInfo.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/ReleaseInfo.kt
@@ -3,7 +3,14 @@ package br.com.redesurftank.havalshisuku.models
 data class ReleaseInfo(
     val tag: String,
     val downloadUrl: String,
-    val isPrerelease: Boolean
+    val isPrerelease: Boolean,
+    /**
+     * O texto da release, como escrito na publicacao. Vem de graca na MESMA consulta que ja
+     * buscava a versao — nao precisa de arquivo separado nem de outra requisicao.
+     *
+     * Vazio quando a release foi publicada sem descricao; a tela trata esse caso.
+     */
+    val notes: String = ""
 )
 
 data class UpdateCheckResult(

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -117,6 +117,14 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
     // em vez de por gates espalhados. Ao SAIR, o retrato é restaurado chave a chave (tipos
     // originais, removendo o que não existia) e apagado. Ver StealthModeManager.
     STEALTH_MODE_ACTIVE("stealthModeActive", "Modo Concessionária ativo"),
+    ENABLE_UPDATE_NOTICE(
+            "enableUpdateNotice",
+            "Avisar quando houver versão nova"
+    ),
+    UPDATE_NOTICE_DISMISSED_VERSION(
+            "updateNoticeDismissedVersion",
+            "Última versão cujo aviso o dono dispensou"
+    ),
     STEALTH_EXIT_SEQUENCE_CUSTOM(
             "stealthExitSequenceCustom",
             "Usar sequência própria de saída (em vez da padrão das setas)"

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -110,6 +110,17 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
     ENABLE_AA_CLUSTER_OFFSET("enableAaClusterOffset", "Habilitar deslocamento do Android Auto no cluster"),
     AA_CLUSTER_LEFT_OFFSET("aaClusterLeftOffset", "Deslocamento horizontal do Android Auto no cluster (px)"),
     CAR_MONITOR_PROPERTIES("carMonitorProperties", "Propriedades do monitoramento do carro"),
+    // ===== Modo Concessionária =====
+    // Ao ENTRAR, o modo grava um retrato (JSON, com os tipos) de TODAS as preferências em
+    // STEALTH_PREFS_SNAPSHOT e então DESLIGA DE VERDADE as preferências que ativam
+    // funcionalidades. O app passa a rodar pelo caminho já testado de quem não usa nenhuma delas,
+    // em vez de por gates espalhados. Ao SAIR, o retrato é restaurado chave a chave (tipos
+    // originais, removendo o que não existia) e apagado. Ver StealthModeManager.
+    STEALTH_MODE_ACTIVE("stealthModeActive", "Modo Concessionária ativo"),
+    STEALTH_PREFS_SNAPSHOT(
+            "stealthPrefsSnapshot",
+            "Retrato das preferências gravado ao entrar no Modo Concessionária (JSON com tipos)"
+    ),
     BYPASS_SELF_INSTALLATION_INTEGRITY_CHECK(
             "bypassSelfInstallationIntegrityCheck",
             "Ignorar verificação de integridade da instalação"

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -117,6 +117,26 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
     // em vez de por gates espalhados. Ao SAIR, o retrato é restaurado chave a chave (tipos
     // originais, removendo o que não existia) e apagado. Ver StealthModeManager.
     STEALTH_MODE_ACTIVE("stealthModeActive", "Modo Concessionária ativo"),
+    STEALTH_EXIT_SEQUENCE_CUSTOM(
+            "stealthExitSequenceCustom",
+            "Usar sequência própria de saída (em vez da padrão das setas)"
+    ),
+    STEALTH_EXIT_SEQUENCE(
+            "stealthExitSequence",
+            "Sequência que tira o carro do Modo Concessionária (ex.: L,R,B1,B1)"
+    ),
+    ENABLE_STEALTH_EXIT_PIN(
+            "enableStealthExitPin",
+            "Pedir PIN depois da sequência de saída do Modo Concessionária"
+    ),
+    STEALTH_EXIT_PIN_HASH(
+            "stealthExitPinHash",
+            "Hash do PIN de saída (o número nunca é gravado)"
+    ),
+    STEALTH_EXIT_PIN_SALT(
+            "stealthExitPinSalt",
+            "Sal do hash do PIN de saída"
+    ),
     STEALTH_PREFS_SNAPSHOT(
             "stealthPrefsSnapshot",
             "Retrato das preferências gravado ao entrar no Modo Concessionária (JSON com tipos)"

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -257,6 +257,14 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
             "openSunroofCurtainMaxTemp",
             "Temperatura externa máxima para abrir cortina"
     ),
+    ENABLE_CLOSE_SUNROOF_CURTAIN_ON_TIME(
+            "enableCloseSunroofCurtainOnTime",
+            "Habilitar fechamento da cortina do teto solar por horário"
+    ),
+    CLOSE_SUNROOF_CURTAIN_START_HOUR("closeSunroofCurtainStartHour", "Hora de início para fechar cortina"),
+    CLOSE_SUNROOF_CURTAIN_START_MINUTE("closeSunroofCurtainStartMinute", "Minuto de início para fechar cortina"),
+    CLOSE_SUNROOF_CURTAIN_END_HOUR("closeSunroofCurtainEndHour", "Hora fim para fechar cortina"),
+    CLOSE_SUNROOF_CURTAIN_END_MINUTE("closeSunroofCurtainEndMinute", "Minuto fim para fechar cortina"),
     PENDING_RESET_TARGET_VERSION(
             "pendingResetTargetVersion",
             "Versão alvo para resetar dados ao voltar para canal estável"

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/services/BottomBarService.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/services/BottomBarService.kt
@@ -235,7 +235,13 @@ class BottomBarService : LifecycleService() {
     private val REFERENCE_OVERSCAN = 20
     private val MAX_HOLD_CORRECTIONS = 4
     private val HOLD_SETTLE_MS = 250L
-    private val LEFT_NAV_PANE_REHIDE_DELAY_MS = 5_000L
+    /** De quanto em quanto tempo conferir se o painel voltou. */
+    private val LEFT_NAV_PANE_POLL_MS = 5_000L
+
+
+    /** Esconde a navegacao para todos os apps. */
+    private val LEFT_NAV_PANE_HIDE_VALUE = "immersive.navigation=*"
+
 
     /**
      * Physical width of the left navigation pane, in px: the largest on-screen offset our bar window
@@ -277,27 +283,68 @@ class BottomBarService : LifecycleService() {
      * value is a no-op that SettingsProvider will not broadcast - so clear it first to force
      * PolicyControl to re-read and re-apply the flags.
      */
-    private fun scheduleLeftNavPaneRehide() {
+    /**
+     * Enquanto a preferencia pedir o painel oculto, confere a cada [LEFT_NAV_PANE_POLL_MS] se ele
+     * voltou (deslize do dono) e, se voltou, esconde.
+     *
+     * **Por que ler antes de escrever:** esconder de verdade exige apagar e reescrever o
+     * `policy_control` — reescrever o mesmo valor e um no-op que o sistema nao anuncia, e sem
+     * anuncio ele nao reaplica. Mas a chave vazia significa "nao esconda nada", entao o apagar
+     * REVELA o painel por um instante. Foi isso que fez a versao anterior piscar sozinha a cada 5s:
+     * ela escrevia sem saber se havia algo a esconder, e a propria escrita criava o que esconder.
+     *
+     * Conferindo antes, a escrita so acontece com o painel JA visivel — e ai o "apagar" nao revela
+     * coisa alguma, porque ele ja esta a mostra. Mesmo mecanismo, sem piscar nenhum.
+     */
+    private fun startLeftNavPaneWatcher() {
         if (leftNavPaneRehideJob?.isActive == true) return
-
         leftNavPaneRehideJob =
                 lifecycleScope.launch(Dispatchers.IO) {
-                    delay(LEFT_NAV_PANE_REHIDE_DELAY_MS)
-                    if (!BottomBarState.leftNavPaneHidden) return@launch
-                    Log.w("BottomBarService", "[NAV_PANE] re-hiding after swipe reveal")
-                    ShizukuUtils.runCommandAndGetOutput(
-                            arrayOf("settings", "delete", "global", "policy_control")
-                    )
-                    ShizukuUtils.runCommandAndGetOutput(
-                            arrayOf(
-                                    "settings",
-                                    "put",
-                                    "global",
-                                    "policy_control",
-                                    "immersive.navigation=*"
-                            )
-                    )
+                    while (true) {
+                        delay(LEFT_NAV_PANE_POLL_MS)
+                        if (!BottomBarState.leftNavPaneHidden) continue
+                        // Tela apagada nao tem painel pra esconder; nao gasta leitura.
+                        if (!ServiceManager.getInstance().isMainScreenOn) continue
+                        if (!isLeftNavPaneVisible()) continue
+                        Log.w("BottomBarService", "[NAV_PANE] painel visivel; escondendo")
+                        hideLeftNavPaneNow()
+                    }
                 }
+    }
+
+    /**
+     * Le do WindowManager se a barra de navegacao esta na tela. `isVisible` alterna limpo entre os
+     * dois estados (medido no carro: true/true/false com o painel aberto, false/false/true com ele
+     * fechado), entao basta ele.
+     *
+     * O grep roda NO CARRO: o dump lista todas as janelas, e so as poucas linhas que importam
+     * atravessam.
+     */
+    private fun isLeftNavPaneVisible(): Boolean = try {
+        val out = ShizukuUtils.runCommandAndGetOutput(
+                arrayOf(
+                        "sh", "-c",
+                        "dumpsys window windows 2>/dev/null | " +
+                                "grep -A 40 'Window{.*NavigationBar}' | grep -m1 'isVisible='"
+                )
+        )
+        out.contains("isVisible=true")
+    } catch (t: Throwable) {
+        Log.w("BottomBarService", "[NAV_PANE] nao deu pra ler o estado do painel", t)
+        false // na duvida NAO escreve: escrever as cegas e o que fazia piscar
+    }
+
+    /** Apaga e reescreve pra forcar o sistema a reaplicar. Só chamado com o painel JÁ visível. */
+    private fun hideLeftNavPaneNow() {
+        ShizukuUtils.runCommandAndGetOutput(
+                arrayOf("settings", "delete", "global", "policy_control")
+        )
+        ShizukuUtils.runCommandAndGetOutput(
+                arrayOf(
+                        "settings", "put", "global", "policy_control",
+                        LEFT_NAV_PANE_HIDE_VALUE
+                )
+        )
     }
 
     /** Real display width in px (1920 here) - the width both overlay windows are held at. */
@@ -378,12 +425,10 @@ class BottomBarService : LifecycleService() {
             cachedLeftGutterPx = observedPaneWidth
         }
 
-        // The pane can be swiped back in from the left edge even while the user has asked for it to
-        // stay hidden. Its frame inset reappearing is the only signal we get, so use that to re-arm
-        // the hide.
-        if (BottomBarState.leftNavPaneHidden && observedPaneWidth > 0) {
-            scheduleLeftNavPaneRehide()
-        }
+        // O inset do painel NAO muda quando ele volta por deslize — medido no carro: zero eventos
+        // [NAV_PANE] no logcat depois de varios deslizes. O que escondia antes era o proprio ciclo
+        // de piscar, por acidente; ao mata-lo, a ilusao de "auto-ocultar" caiu junto. Quem detecta
+        // agora e o watcher abaixo, que le o estado real da janela.
 
         // With the pane hidden on purpose there is nothing to stay clear of, so hand the content the
         // full width instead of leaving a permanent empty gutter.
@@ -451,6 +496,7 @@ class BottomBarService : LifecycleService() {
         updateFridaStatus(prefs)
 
         showBottomBar()
+        startLeftNavPaneWatcher()
         observeMenuState()
         observeDashboardActivityState()
         observeVisibility()

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
@@ -40,6 +40,7 @@ import br.com.redesurftank.havalshisuku.managers.AndroidAutoPatchManager;
 import br.com.redesurftank.havalshisuku.managers.CarPlayPatchManager;
 import br.com.redesurftank.havalshisuku.managers.DisplayAppLauncher;
 import br.com.redesurftank.havalshisuku.managers.ServiceManager;
+import br.com.redesurftank.havalshisuku.managers.StealthModeManager;
 import br.com.redesurftank.havalshisuku.managers.HotRouterManager;
 import br.com.redesurftank.havalshisuku.models.CommandListener;
 import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys;
@@ -53,7 +54,24 @@ public class ForegroundService extends Service implements Shizuku.OnBinderDeadLi
 
     private static final String TAG = "ForegroundService";
     private static final String CHANNEL_ID = "ForegroundServiceChannel";
+    /**
+     * Canal do Modo Concessionaria. IMPORTANCE_MIN e o mais discreto que o Android 9 aceita para
+     * um foreground service: sem som, sem vibracao e sem icone na barra de status. Um FGS NAO pode
+     * ficar sem notificacao nenhuma nesta versao do Android, entao o alvo e "nao chamar atencao e
+     * nao dizer o nome do app", nao "sumir".
+     *
+     * Canal SEPARADO de proposito: a importancia de um NotificationChannel nao pode ser rebaixada
+     * pelo app depois de criado (so o usuario mexe), entao reaproveitar o canal normal deixaria a
+     * notificacao presa em IMPORTANCE_LOW.
+     */
+    private static final String QUIET_CHANNEL_ID = "ForegroundServiceChannelQuiet";
     private static final int NOTIFICATION_ID = 1;
+
+    /**
+     * Instancia viva do servico, para o StealthModeManager pedir a troca da notificacao no
+     * instante em que o modo entra ou sai. volatile: quem chama vem de outra thread.
+     */
+    private static volatile ForegroundService runningInstance;
     private static final int MAX_AUTOMATIC_SHIZUKU_BOOTSTRAP_UID = 10999;
     private static final long SHIZUKU_BINDER_RECEIVE_TIMEOUT_MS = 15000L;
     private static final int SHIZUKU_BINDER_TIMEOUTS_BEFORE_RESTART = 3;
@@ -284,6 +302,7 @@ public class ForegroundService extends Service implements Shizuku.OnBinderDeadLi
     public void onCreate() {
         super.onCreate();
         ClusterPersistentEventLogger.logText("foreground_service_on_create", "created=true");
+        runningInstance = this;
         createNotificationChannel();
         handlerThread = new HandlerThread("BackgroundThread");
         handlerThread.start();
@@ -378,9 +397,8 @@ public class ForegroundService extends Service implements Shizuku.OnBinderDeadLi
             backgroundHandler.removeCallbacksAndMessages(null);
 
             var context = getApplicationContext();
-            // Criar notificação para o Foreground Service
-            Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID).setContentTitle("Aplicação em execução").setContentText("Seu app está rodando em segundo plano").setSmallIcon(android.R.drawable.ic_notification_overlay) // Ícone de notificação
-                    .build();
+            // Criar notificacao para o Foreground Service (discreta no Modo Concessionaria).
+            Notification notification = buildServiceNotification();
 
             startForeground(NOTIFICATION_ID, notification);
 
@@ -503,11 +521,7 @@ public class ForegroundService extends Service implements Shizuku.OnBinderDeadLi
         }
         Log.w(TAG, "Simulator Service started");
 
-        Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
-                .setContentTitle("Haval App (Simulator)")
-                .setContentText("Simulador em execução")
-                .setSmallIcon(android.R.drawable.ic_notification_overlay)
-                .build();
+        Notification notification = buildServiceNotification();
 
         startForeground(NOTIFICATION_ID, notification);
 
@@ -736,9 +750,90 @@ public class ForegroundService extends Service implements Shizuku.OnBinderDeadLi
     }
 
     private void createNotificationChannel() {
-        NotificationChannel channel = new NotificationChannel(CHANNEL_ID, "Background Service Channel", NotificationManager.IMPORTANCE_LOW);
         NotificationManager manager = getSystemService(NotificationManager.class);
+        if (manager == null) {
+            Log.e(TAG, "NotificationManager indisponivel; nao da pra criar os canais");
+            return;
+        }
+        NotificationChannel channel = new NotificationChannel(CHANNEL_ID, "Background Service Channel", NotificationManager.IMPORTANCE_LOW);
         manager.createNotificationChannel(channel);
+
+        // Criado junto do normal: o modo pode entrar a qualquer momento e o canal precisa existir
+        // antes da primeira notificacao postada nele.
+        NotificationChannel quiet = new NotificationChannel(QUIET_CHANNEL_ID, "Servico do sistema", NotificationManager.IMPORTANCE_MIN);
+        quiet.setShowBadge(false);
+        quiet.enableLights(false);
+        quiet.enableVibration(false);
+        quiet.setSound(null, null);
+        quiet.setLockscreenVisibility(Notification.VISIBILITY_SECRET);
+        manager.createNotificationChannel(quiet);
+    }
+
+    /**
+     * O UNICO lugar que monta a notificacao do foreground service. Antes ela era construida em
+     * dois pontos (o start normal e o do simulador), o que faria a decisao do Modo Concessionaria
+     * valer num e no outro nao.
+     *
+     * No modo, a notificacao nao pode DIZER que o Impulse esta rodando: titulo neutro, sem
+     * subtitulo, sem relogio, no canal IMPORTANCE_MIN.
+     */
+    private Notification buildServiceNotification() {
+        boolean stealth = false;
+        try {
+            stealth = StealthModeManager.isActive();
+        } catch (Throwable t) {
+            Log.e(TAG, "Falha lendo a flag do Modo Concessionaria; usando a notificacao normal", t);
+        }
+
+        if (stealth) {
+            return new NotificationCompat.Builder(this, QUIET_CHANNEL_ID)
+                    .setContentTitle("Servico do sistema")
+                    .setSmallIcon(android.R.drawable.ic_notification_overlay)
+                    .setPriority(NotificationCompat.PRIORITY_MIN)
+                    .setShowWhen(false)
+                    .setSilent(true)
+                    .setOngoing(true)
+                    .setVisibility(NotificationCompat.VISIBILITY_SECRET)
+                    .build();
+        }
+
+        String title = br.com.redesurftank.havalshisuku.BuildConfig.SIMULATOR_MODE
+                ? "Haval App (Simulator)"
+                : "Aplicacao em execucao";
+        String text = br.com.redesurftank.havalshisuku.BuildConfig.SIMULATOR_MODE
+                ? "Simulador em execucao"
+                : "Seu app esta rodando em segundo plano";
+        return new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setSmallIcon(android.R.drawable.ic_notification_overlay)
+                .build();
+    }
+
+    /**
+     * Reemite a notificacao com o mesmo NOTIFICATION_ID para a troca de canal/conteudo valer na
+     * hora — sem isso, a notificacao antiga ficaria na tela ate o proximo start do servico.
+     * Chamado pelo StealthModeManager ao entrar e ao sair do modo.
+     *
+     * Estatico e tolerante a servico morto: se nao ha instancia viva, nao ha notificacao para
+     * trocar, e o proximo onStartCommand ja monta a certa.
+     */
+    public static void refreshNotificationForStealth() {
+        ForegroundService service = runningInstance;
+        if (service == null) {
+            Log.w(TAG, "Sem ForegroundService vivo; nada a reemitir");
+            return;
+        }
+        try {
+            NotificationManager manager = service.getSystemService(NotificationManager.class);
+            if (manager == null) {
+                return;
+            }
+            manager.notify(NOTIFICATION_ID, service.buildServiceNotification());
+            Log.w(TAG, "Notificacao do foreground service reemitida (stealth=" + StealthModeManager.isActive() + ")");
+        } catch (Throwable t) {
+            Log.e(TAG, "Falha ao reemitir a notificacao do foreground service", t);
+        }
     }
 
     @Override
@@ -765,6 +860,9 @@ public class ForegroundService extends Service implements Shizuku.OnBinderDeadLi
         }
         Shizuku.removeBinderReceivedListener(this::shizukuBinderReceived);
         Shizuku.removeBinderDeadListener(this);
+        if (runningInstance == this) {
+            runningInstance = null;
+        }
         Log.w(TAG, "Service destroyed");
         super.onDestroy();
     }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
@@ -342,6 +342,8 @@ public class ForegroundService extends Service implements Shizuku.OnBinderDeadLi
     private void startCarPlaySystemUiIconWatchdogSafely(String reason) {
         try {
             DisplayAppLauncher.INSTANCE.startCarPlaySystemUiIconWatchdog();
+            // Verifica UMA vez por partida se saiu versao nova (espera a rede aparecer sozinho).
+            br.com.redesurftank.havalshisuku.managers.UpdateNoticeManager.checkOnStart();
         } catch (Exception e) {
             Log.e(TAG, "CarPlay SystemUI icon watchdog scheduling failed (" + reason + "): " + e.getMessage(), e);
         }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/components/BottomBarUI.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/components/BottomBarUI.kt
@@ -1,5 +1,6 @@
 package br.com.redesurftank.havalshisuku.ui.components
 
+import br.com.redesurftank.havalshisuku.managers.UpdateNoticeManager
 import android.content.Context
 import android.media.AudioManager
 import android.os.SystemClock
@@ -2774,6 +2775,7 @@ private fun DashboardHeader(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
+                        DashboardUpdateChip()
                         DashboardStatusChip(
                                 icon = Icons.Default.DeviceThermostat,
                                 text = "Cabine ${formatTemperature(snapshot.insideTemp)}"
@@ -2838,6 +2840,72 @@ private fun DashboardHeaderControlButton(
                 }
         }
 }
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun DashboardUpdateChip() {
+        // Só existe quando há versão nova. Nada de placeholder "tudo atualizado": o dashboard é
+        // olhado de relance dirigindo, e um chip permanente que quase sempre diz "nada a fazer" só
+        // gasta espaço e atenção.
+        val version = UpdateNoticeManager.availableVersion ?: return
+        val context = LocalContext.current
+        val accent = Color(0xFF4A9EFF)
+        Surface(
+                modifier = Modifier
+                        .height(44.dp)
+                        .combinedClickable(
+                                onClick = { openInformacoesScreen(context) },
+                                // Toque longo dispensa: quem não quer atualizar agora silencia esta
+                                // versão e só volta a ser avisado quando sair OUTRA.
+                                onLongClick = { UpdateNoticeManager.dismiss() }
+                        ),
+                color = accent.copy(alpha = 0.20f),
+                shape = RoundedCornerShape(8.dp),
+                border = BorderStroke(1.dp, accent.copy(alpha = 0.55f))
+        ) {
+                Row(
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                        Icon(
+                                Icons.Default.FileDownload,
+                                contentDescription = "Nova versão disponível",
+                                tint = accent,
+                                modifier = Modifier.size(20.dp)
+                        )
+                        Text(
+                                text = version,
+                                color = Color.White,
+                                fontSize = 13.sp,
+                                fontFamily = DashboardReadableFont,
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 1
+                        )
+                }
+        }
+}
+
+/** Abre o app já na tela de Informações, onde fica o botão de atualizar. */
+private fun openInformacoesScreen(context: android.content.Context) {
+        try {
+                context.startActivity(
+                        android.content.Intent(
+                                        context,
+                                        br.com.redesurftank.havalshisuku.MainActivity::class.java
+                                )
+                                .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                                .putExtra(
+                                        br.com.redesurftank.havalshisuku.MainActivity.EXTRA_SCREEN,
+                                        "Informações"
+                                )
+                )
+        } catch (t: Throwable) {
+                android.util.Log.e("BottomBarUI", "não deu pra abrir Informações", t)
+        }
+}
+
+
 
 @Composable
 private fun DashboardNativeMenuButton(onClick: () -> Unit) {

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/components/SettingsRedesign.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/components/SettingsRedesign.kt
@@ -94,12 +94,13 @@ object SettingsGroups {
     const val SPEED = "Por velocidade"
     const val DRIVE = "Condução & energia"
     const val CLIMATE = "Climatização & conforto"
+    const val COMFORT = "Conforto & conveniência"
     const val SAFETY = "Segurança & avisos"
     const val DISPLAY = "Tela & som"
     const val FEATURES = "Recursos & integração"
     // Subaba "Performance" — último grupo de Configurações (depois de Recursos & integração).
     const val PERFORMANCE = "Performance"
-    val ORDER = listOf(SHUTDOWN, SPEED, DRIVE, CLIMATE, SAFETY, DISPLAY, FEATURES, PERFORMANCE)
+    val ORDER = listOf(SHUTDOWN, SPEED, DRIVE, CLIMATE, COMFORT, SAFETY, DISPLAY, FEATURES, PERFORMANCE)
 }
 
 // ---------------------------------------------------------------------------

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/navigation/AppNavigation.kt
@@ -1,5 +1,6 @@
 package br.com.redesurftank.havalshisuku.ui.navigation
 
+import br.com.redesurftank.havalshisuku.managers.UpdateNoticeManager
 import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -32,7 +33,7 @@ private val RailBackground = Color(0xFF0D0E12)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MainScreen(modifier: Modifier = Modifier) {
+fun MainScreen(modifier: Modifier = Modifier, initialScreen: String? = null) {
     val prefs = App.getDeviceProtectedContext()
         .getSharedPreferences("haval_prefs", Context.MODE_PRIVATE)
     val advancedUse = prefs.getBoolean(SharedPreferencesKeys.ADVANCE_USE.key, false)
@@ -41,7 +42,13 @@ fun MainScreen(modifier: Modifier = Modifier) {
         if (item.title == "Frida Hooks") advancedUse else true
     }
 
-    var selectedItem by remember { mutableStateOf(0) }
+    // Abre direto na aba pedida (o chip de atualização manda "Informações"). Título desconhecido
+    // ou ausente cai na primeira aba, como sempre.
+    var selectedItem by remember {
+        mutableStateOf(
+                menuItems.indexOfFirst { it.title == initialScreen }.takeIf { it >= 0 } ?: 0
+        )
+    }
 
     val configuration = LocalConfiguration.current
     val density = LocalDensity.current
@@ -169,6 +176,18 @@ private fun RailItem(
             fontSize = 16.sp,
             color = if (selected) ImpTokens.Accent else ImpTokens.TextPrimary
         )
+        // Aviso de versao nova: um ponto ao lado de "Informacoes", que e onde fica o botao de
+        // atualizar. Deliberadamente sem texto e sem popup — quem abriu o app pra fazer outra coisa
+        // nao deve ser interrompido; quem quiser saber, o ponto conduz ate la.
+        if (item.title == "Informações" && UpdateNoticeManager.availableVersion != null) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(ImpTokens.Accent)
+            )
+        }
     }
 }
 

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -840,6 +840,34 @@ fun BasicSettingsTab() {
                         prefs.getFloat(SharedPreferencesKeys.OPEN_SUNROOF_CURTAIN_MAX_TEMP.key, -1f)
                 )
         }
+        var enableCloseSunroofCurtainOnTime by remember {
+                mutableStateOf(
+                        prefs.getBoolean(
+                                SharedPreferencesKeys.ENABLE_CLOSE_SUNROOF_CURTAIN_ON_TIME.key,
+                                false
+                        )
+                )
+        }
+        var closeCurtainStartHour by remember {
+                mutableIntStateOf(
+                        prefs.getInt(SharedPreferencesKeys.CLOSE_SUNROOF_CURTAIN_START_HOUR.key, 9)
+                )
+        }
+        var closeCurtainStartMinute by remember {
+                mutableIntStateOf(
+                        prefs.getInt(SharedPreferencesKeys.CLOSE_SUNROOF_CURTAIN_START_MINUTE.key, 0)
+                )
+        }
+        var closeCurtainEndHour by remember {
+                mutableIntStateOf(
+                        prefs.getInt(SharedPreferencesKeys.CLOSE_SUNROOF_CURTAIN_END_HOUR.key, 17)
+                )
+        }
+        var closeCurtainEndMinute by remember {
+                mutableIntStateOf(
+                        prefs.getInt(SharedPreferencesKeys.CLOSE_SUNROOF_CURTAIN_END_MINUTE.key, 0)
+                )
+        }
         var enablePersistHevSoc by remember {
                 mutableStateOf(
                         prefs.getBoolean(SharedPreferencesKeys.ENABLE_PERSIST_HEV_SOC_TARGET.key, false)
@@ -1476,6 +1504,7 @@ fun BasicSettingsTab() {
                                 title =
                                         SharedPreferencesKeys.ENABLE_OPEN_SUNROOF_CURTAIN_ON_START
                                                 .description,
+                                group = SettingsGroups.COMFORT,
                                 description =
                                         "Abre automaticamente a cortina do teto solar ao ligar o veículo",
                                 checked = enableOpenSunroofCurtainOnStart,
@@ -1834,6 +1863,209 @@ fun BasicSettingsTab() {
                                                  }
                                          } else null
                          ),
+
+                        SettingItem(
+                                title =
+                                        SharedPreferencesKeys.ENABLE_CLOSE_SUNROOF_CURTAIN_ON_TIME
+                                                .description,
+                                group = SettingsGroups.COMFORT,
+                                description =
+                                        "Fecha automaticamente a cortina do teto solar por horário (ao ligar dentro da janela ou ao cruzá-la dirigindo)",
+                                checked = enableCloseSunroofCurtainOnTime,
+                                onCheckedChange = { checked ->
+                                        enableCloseSunroofCurtainOnTime = checked
+                                        prefs.edit {
+                                                putBoolean(
+                                                        SharedPreferencesKeys
+                                                                .ENABLE_CLOSE_SUNROOF_CURTAIN_ON_TIME
+                                                                .key,
+                                                        checked
+                                                )
+                                        }
+                                },
+                                customContent =
+                                        if (enableCloseSunroofCurtainOnTime) {
+                                                {
+                                                        var showCloseCurtainStartPicker by remember {
+                                                                mutableStateOf(false)
+                                                        }
+                                                        var showCloseCurtainEndPicker by remember {
+                                                                mutableStateOf(false)
+                                                        }
+
+                                                        if (showCloseCurtainStartPicker) {
+                                                                val timeSetListener =
+                                                                        TimePickerDialog.OnTimeSetListener {
+                                                                                _,
+                                                                                hour,
+                                                                                minute ->
+                                                                                closeCurtainStartHour = hour
+                                                                                closeCurtainStartMinute = minute
+                                                                                prefs.edit {
+                                                                                        putInt(
+                                                                                                SharedPreferencesKeys
+                                                                                                        .CLOSE_SUNROOF_CURTAIN_START_HOUR
+                                                                                                        .key,
+                                                                                                hour
+                                                                                        )
+                                                                                        putInt(
+                                                                                                SharedPreferencesKeys
+                                                                                                        .CLOSE_SUNROOF_CURTAIN_START_MINUTE
+                                                                                                        .key,
+                                                                                                minute
+                                                                                        )
+                                                                                }
+                                                                                showCloseCurtainStartPicker = false
+                                                                        }
+                                                                TimePickerDialog(
+                                                                                LocalContext.current,
+                                                                                timeSetListener,
+                                                                                closeCurtainStartHour,
+                                                                                closeCurtainStartMinute,
+                                                                                true
+                                                                        )
+                                                                        .show()
+                                                        }
+
+                                                        if (showCloseCurtainEndPicker) {
+                                                                val timeSetListener =
+                                                                        TimePickerDialog.OnTimeSetListener {
+                                                                                _,
+                                                                                hour,
+                                                                                minute ->
+                                                                                closeCurtainEndHour = hour
+                                                                                closeCurtainEndMinute = minute
+                                                                                prefs.edit {
+                                                                                        putInt(
+                                                                                                SharedPreferencesKeys
+                                                                                                        .CLOSE_SUNROOF_CURTAIN_END_HOUR
+                                                                                                        .key,
+                                                                                                hour
+                                                                                        )
+                                                                                        putInt(
+                                                                                                SharedPreferencesKeys
+                                                                                                        .CLOSE_SUNROOF_CURTAIN_END_MINUTE
+                                                                                                        .key,
+                                                                                                minute
+                                                                                        )
+                                                                                }
+                                                                                showCloseCurtainEndPicker = false
+                                                                        }
+                                                                TimePickerDialog(
+                                                                                LocalContext.current,
+                                                                                timeSetListener,
+                                                                                closeCurtainEndHour,
+                                                                                closeCurtainEndMinute,
+                                                                                true
+                                                                        )
+                                                                        .show()
+                                                        }
+
+                                                        Column(
+                                                                verticalArrangement =
+                                                                        Arrangement.spacedBy(12.dp)
+                                                        ) {
+                                                                HorizontalDivider(
+                                                                        color = Color(0xFF3A3F47),
+                                                                        thickness = 1.dp
+                                                                )
+
+                                                                Spacer(
+                                                                        modifier =
+                                                                                Modifier.height(12.dp)
+                                                                )
+
+                                                                Row(
+                                                                        modifier =
+                                                                                Modifier.fillMaxWidth(),
+                                                                        horizontalArrangement =
+                                                                                Arrangement.SpaceEvenly
+                                                                ) {
+                                                                        Box(
+                                                                                modifier =
+                                                                                        Modifier.weight(1f)
+                                                                                                .clickable {
+                                                                                                        showCloseCurtainStartPicker =
+                                                                                                                true
+                                                                                                }
+                                                                                                .background(
+                                                                                                        Color(0xFF2A2F37),
+                                                                                                        RoundedCornerShape(8.dp)
+                                                                                                )
+                                                                                                .padding(16.dp),
+                                                                                contentAlignment =
+                                                                                        Alignment.Center
+                                                                        ) {
+                                                                                Column(
+                                                                                        horizontalAlignment =
+                                                                                                Alignment
+                                                                                                        .CenterHorizontally
+                                                                                ) {
+                                                                                        Text(
+                                                                                                "Início",
+                                                                                                color = Color.White,
+                                                                                                fontSize = 14.sp
+                                                                                        )
+                                                                                        Spacer(
+                                                                                                modifier =
+                                                                                                        Modifier.height(4.dp)
+                                                                                        )
+                                                                                        Text(
+                                                                                                "${String.format("%02d", closeCurtainStartHour)}:${String.format("%02d", closeCurtainStartMinute)}",
+                                                                                                color = Color(0xFF4A9EFF),
+                                                                                                fontSize = 18.sp,
+                                                                                                fontWeight =
+                                                                                                        FontWeight.Medium
+                                                                                        )
+                                                                                }
+                                                                        }
+                                                                        Spacer(
+                                                                                modifier =
+                                                                                        Modifier.width(12.dp)
+                                                                        )
+                                                                        Box(
+                                                                                modifier =
+                                                                                        Modifier.weight(1f)
+                                                                                                .clickable {
+                                                                                                        showCloseCurtainEndPicker =
+                                                                                                                true
+                                                                                                }
+                                                                                                .background(
+                                                                                                        Color(0xFF2A2F37),
+                                                                                                        RoundedCornerShape(8.dp)
+                                                                                                )
+                                                                                                .padding(16.dp),
+                                                                                contentAlignment =
+                                                                                        Alignment.Center
+                                                                        ) {
+                                                                                Column(
+                                                                                        horizontalAlignment =
+                                                                                                Alignment
+                                                                                                        .CenterHorizontally
+                                                                                ) {
+                                                                                        Text(
+                                                                                                "Fim",
+                                                                                                color = Color.White,
+                                                                                                fontSize = 14.sp
+                                                                                        )
+                                                                                        Spacer(
+                                                                                                modifier =
+                                                                                                        Modifier.height(4.dp)
+                                                                                        )
+                                                                                        Text(
+                                                                                                "${String.format("%02d", closeCurtainEndHour)}:${String.format("%02d", closeCurtainEndMinute)}",
+                                                                                                color = Color(0xFF4A9EFF),
+                                                                                                fontSize = 18.sp,
+                                                                                                fontWeight =
+                                                                                                        FontWeight.Medium
+                                                                                        )
+                                                                                }
+                                                                        }
+                                                                }
+                                                        }
+                                                }
+                                        } else null
+                        ),
 
                         SettingItem(
                                 title = "Manter desativado monitoramento de distrações",

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/InformacoesScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/InformacoesScreen.kt
@@ -1012,6 +1012,7 @@ fun InformacoesTab() {
                                                                                                 8.dp
                                                                                         )
                                                                         )
+                                                                        ReleaseNotes(result.latestPreview!!.notes)
                                                                         Button(
                                                                                 onClick = {
                                                                                         showUpdateCheckDialog =
@@ -1189,6 +1190,7 @@ fun InformacoesTab() {
                                                                                                 8.dp
                                                                                         )
                                                                         )
+                                                                        ReleaseNotes(result.latestRelease.notes)
                                                                         Button(
                                                                                 onClick = {
                                                                                         showUpdateCheckDialog =
@@ -1452,4 +1454,33 @@ fun InformacoesTab() {
                         }
                 )
         }
+}
+
+/**
+ * Mostra o que mudou na versao, com o texto escrito na propria release.
+ *
+ * Ate agora quem atualizava ficava procurando pelo app o que tinha mudado. A nota ja vinha na
+ * MESMA consulta que busca a versao — estava sendo descartada no parser. Nao precisa de arquivo
+ * separado no repositorio nem de outra requisicao.
+ *
+ * Altura limitada com rolagem: nota longa nao pode empurrar o botao de atualizar pra fora da tela,
+ * que e a razao de o dialogo existir.
+ */
+@Composable
+private fun ReleaseNotes(notes: String) {
+        if (notes.isBlank()) return
+        Column(
+                modifier =
+                        Modifier.fillMaxWidth()
+                                .heightIn(max = 180.dp)
+                                .verticalScroll(rememberScrollState())
+        ) {
+                Text(
+                        text = notes,
+                        color = AppColors.TextSecondary,
+                        fontSize = 13.sp,
+                        lineHeight = 18.sp
+                )
+        }
+        Spacer(modifier = Modifier.height(12.dp))
 }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/InformacoesScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/InformacoesScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Wifi
@@ -39,6 +40,7 @@ import br.com.redesurftank.App
 import br.com.redesurftank.havalshisuku.TAG
 import br.com.redesurftank.havalshisuku.R
 import br.com.redesurftank.havalshisuku.managers.ServiceManager
+import br.com.redesurftank.havalshisuku.managers.StealthModeManager
 import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys
 import br.com.redesurftank.havalshisuku.models.UpdateCheckResult
 import br.com.redesurftank.havalshisuku.ui.components.AppColors
@@ -100,6 +102,15 @@ fun InformacoesTab() {
                         ActivityResultContracts.StartActivityForResult()
                 ) { /* Permission requested */}
         var showPermissionDialog by remember { mutableStateOf(false) }
+        // Modo Concessionária: nunca ativa direto do toque — o ícone do app some depois
+        // disso, então passa por uma confirmação explícita.
+        // O fluxo tem 3 etapas de propósito (sugestão de um colega): ENSAIO -> PRONTO ->
+        // ativa e reinicia. Fazer o dono EXECUTAR a saída antes de entrar prova que ele sabe sair
+        // e que o gesto funciona neste carro — foi justamente por isso que a versão anterior
+        // deixou o carro preso, com uma sequência que o head unit nunca chegava a emitir.
+        var showStealthConfirm by remember { mutableStateOf(false) }
+        var stealthStep by remember { mutableStateOf(0) }      // 0 = ensaio, 1 = pronto
+        var stealthProgress by remember { mutableStateOf(0) }  // 0..4 setas feitas
 
         LaunchedEffect(Unit) {
                 try {
@@ -404,7 +415,127 @@ fun InformacoesTab() {
                                                 )
                                         }
                                 }
+
+                                HorizontalDivider(color = ImpTokens.Hairline)
+
+                                // ===== Modo Concessionária =====
+                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        Text(
+                                                "Modo Concessionária",
+                                                color = Color.White,
+                                                fontSize = 18.sp,
+                                                fontWeight = FontWeight.Medium
+                                        )
+                                        Text(
+                                                "Deixa o carro como saiu de fábrica antes de levar à revisão: o ícone do Impulse some do menu, o painel volta ao nativo, a barra inferior e as luzes saem, os patches do Android Auto/CarPlay são desmontados e as automações param. Suas configurações são salvas e devolvidas na volta.",
+                                                color = ImpTokens.TextSecondary,
+                                                fontSize = 14.sp
+                                        )
+                                        Text(
+                                                "Para voltar: com o carro parado, acione as setas: esquerda, direita, esquerda, direita, com até 8s entre eles.",
+                                                color = ImpTokens.TextSecondary,
+                                                fontSize = 14.sp
+                                        )
+                                        Row(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                horizontalArrangement = Arrangement.End
+                                        ) {
+                                                Button(
+                                                        onClick = {
+                                                                stealthStep = 0
+                                                                stealthProgress = 0
+                                                                StealthModeManager.armConfirmation { step, done ->
+                                                                        stealthProgress = step
+                                                                        if (done) stealthStep = 1
+                                                                }
+                                                                showStealthConfirm = true
+                                                        },
+                                                        modifier = Modifier.height(48.dp),
+                                                        colors =
+                                                                ButtonDefaults.buttonColors(
+                                                                        containerColor =
+                                                                                Color(0xFFB3261E)
+                                                                ),
+                                                        shape =
+                                                                RoundedCornerShape(
+                                                                        AppDimensions
+                                                                                .ButtonCornerRadius
+                                                                )
+                                                ) {
+                                                        Icon(
+                                                                Icons.Default.Build,
+                                                                contentDescription =
+                                                                        "Modo Concessionária",
+                                                                modifier = Modifier.size(20.dp)
+                                                        )
+                                                        Spacer(modifier = Modifier.width(8.dp))
+                                                        Text(
+                                                                "Ativar Modo Concessionária",
+                                                                color = Color.White
+                                                        )
+                                                }
+                                        }
+                                }
                         }
+                }
+
+                if (showStealthConfirm) {
+                        AlertDialog(
+                                onDismissRequest = {
+                                        showStealthConfirm = false
+                                        StealthModeManager.cancelConfirmation()
+                                },
+                                containerColor = ImpTokens.Container,
+                                title = {
+                                        Text(
+                                                if (stealthStep == 0) "Ensaie a saída" else "Tudo certo!",
+                                                color = Color.White,
+                                                fontWeight = FontWeight.SemiBold
+                                        )
+                                },
+                                text = {
+                                        Column {
+                                                if (stealthStep == 0) {
+                                                        Text(
+                                                                "Antes de ativar, faça agora o gesto que devolve o carro ao normal — com o carro parado:\n\nSeta ESQUERDA → DIREITA → ESQUERDA → DIREITA",
+                                                                color = ImpTokens.TextSecondary,
+                                                                fontSize = 14.sp
+                                                        )
+                                                        Spacer(modifier = Modifier.height(12.dp))
+                                                        Text(
+                                                                "$stealthProgress de 4",
+                                                                color = if (stealthProgress > 0) Color(0xFF4CAF50) else ImpTokens.TextSecondary,
+                                                                fontSize = 20.sp,
+                                                                fontWeight = FontWeight.Bold
+                                                        )
+                                                } else {
+                                                        Text(
+                                                                "Você fez o gesto corretamente — é assim que vai sair do modo.\n\nAo confirmar: o ícone do Impulse e os dos apps instalados somem, tudo que o app liga é desligado, e A CENTRAL VAI REINICIAR sozinha para aplicar.\n\nSuas configurações ficam salvas e voltam inteiras na saída.",
+                                                                color = ImpTokens.TextSecondary,
+                                                                fontSize = 14.sp
+                                                        )
+                                                }
+                                        }
+                                },
+                                confirmButton = {
+                                        if (stealthStep == 1) {
+                                                TextButton(
+                                                        onClick = {
+                                                                showStealthConfirm = false
+                                                                StealthModeManager.enter(context, "UI")
+                                                        }
+                                                ) { Text("Confirmar e reiniciar", color = Color(0xFFE05252)) }
+                                        }
+                                },
+                                dismissButton = {
+                                        TextButton(
+                                                onClick = {
+                                                        showStealthConfirm = false
+                                                        StealthModeManager.cancelConfirmation()
+                                                }
+                                        ) { Text("Cancelar", color = ImpTokens.TextSecondary) }
+                                }
+                        )
                 }
 
                 // Seção de Contribuição

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/InformacoesScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/InformacoesScreen.kt
@@ -40,6 +40,12 @@ import br.com.redesurftank.App
 import br.com.redesurftank.havalshisuku.TAG
 import br.com.redesurftank.havalshisuku.R
 import br.com.redesurftank.havalshisuku.managers.ServiceManager
+import android.widget.Toast
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import br.com.redesurftank.havalshisuku.managers.StealthExitPin
+import br.com.redesurftank.havalshisuku.managers.StealthExitSequence
 import br.com.redesurftank.havalshisuku.managers.StealthModeManager
 import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys
 import br.com.redesurftank.havalshisuku.models.UpdateCheckResult
@@ -110,7 +116,17 @@ fun InformacoesTab() {
         // deixou o carro preso, com uma sequência que o head unit nunca chegava a emitir.
         var showStealthConfirm by remember { mutableStateOf(false) }
         var stealthStep by remember { mutableStateOf(0) }      // 0 = ensaio, 1 = pronto
-        var stealthProgress by remember { mutableStateOf(0) }  // 0..4 setas feitas
+        var stealthProgress by remember { mutableStateOf(0) }  // passos já reconhecidos
+        var stealthSeq by remember { mutableStateOf(StealthExitSequence.current()) }
+        var stealthSeqError by remember { mutableStateOf<String?>(null) }
+        var stealthPinOn by remember { mutableStateOf(StealthExitPin.isEnabled()) }
+        var stealthPinTyped by remember { mutableStateOf("") }
+        var showStealthPinSetup by remember { mutableStateOf(false) }
+        var stealthCustomSeq by remember { mutableStateOf(StealthExitSequence.isCustom()) }
+        // Resumo mostrado UMA vez após salvar: como só o hash do PIN fica gravado, este é o único
+        // momento em que dá pra ver o número. Existe pra ser fotografado.
+        var stealthSummaryPin by remember { mutableStateOf<String?>(null) }
+        var stealthBlocked by remember { mutableStateOf<String?>(null) }
 
         LaunchedEffect(Unit) {
                 try {
@@ -432,10 +448,161 @@ fun InformacoesTab() {
                                                 fontSize = 14.sp
                                         )
                                         Text(
-                                                "Para voltar: com o carro parado, acione as setas: esquerda, direita, esquerda, direita, com até 8s entre eles.",
+                                                "Para voltar:",
                                                 color = ImpTokens.TextSecondary,
                                                 fontSize = 14.sp
                                         )
+                                        Text(
+                                                if (stealthSeq.isEmpty()) "—"
+                                                else StealthExitSequence.describe(stealthSeq),
+                                                color = Color.White,
+                                                fontSize = 26.sp,
+                                                fontWeight = FontWeight.Bold
+                                        )
+
+                                        // Editor da sequência. As setas não podem se repetir em
+                                        // seguida (o carro não emite dois acendimentos distintos),
+                                        // e o validador recusa isso em vez de deixar o dono montar
+                                        // uma sequência que nunca seria reconhecida.
+                                        Text(
+                                                "Carro em P, e a sequência toda em até ${StealthExitSequence.TOTAL_WINDOW_MS / 1000}s.",
+                                                color = Color(0xFFFFB74D),
+                                                fontSize = 13.sp
+                                        )
+
+                                        Row(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                                verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                                listOf(false to "Padrão das setas", true to "Sequência própria").forEach { (custom, label) ->
+                                                        Row(verticalAlignment = Alignment.CenterVertically) {
+                                                                RadioButton(
+                                                                        selected = stealthCustomSeq == custom,
+                                                                        onClick = {
+                                                                                stealthCustomSeq = custom
+                                                                                prefs.edit {
+                                                                                        putBoolean(
+                                                                                                SharedPreferencesKeys.STEALTH_EXIT_SEQUENCE_CUSTOM.key,
+                                                                                                custom
+                                                                                        )
+                                                                                }
+                                                                                // Marcar "própria" começa do ZERO. Herdar a padrão fazia o
+                                                                                // dono só conseguir ACRESCENTAR nela, sem nunca substituir.
+                                                                                stealthSeq =
+                                                                                        if (custom) emptyList()
+                                                                                        else StealthExitSequence.DEFAULT
+                                                                                stealthSeqError = null
+                                                                        }
+                                                                )
+                                                                Text(label, color = Color.White, fontSize = 13.sp)
+                                                        }
+                                                }
+                                        }
+
+                                        if (stealthCustomSeq) {
+                                        Text(
+                                                "Toque para adicionar (${StealthExitSequence.MIN_STEPS} a ${StealthExitSequence.MAX_STEPS} passos):",
+                                                color = ImpTokens.TextSecondary,
+                                                fontSize = 13.sp
+                                        )
+                                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                                StealthExitSequence.Step.values().forEach { step ->
+                                                        Button(
+                                                                onClick = {
+                                                                        val next = stealthSeq + step
+                                                                        // Enquanto monta, a sequência pode estar INCOMPLETA — o mínimo
+                                                                        // de passos não é motivo pra recusar a digitação. Só recusa o
+                                                                        // que nunca funcionaria: passo repetido e limite de tamanho.
+                                                                        // (Antes o validador completo barrava tudo, e a tela ficava
+                                                                        // presa na sequência padrão.)
+                                                                        val impede = when {
+                                                                                next.size > StealthExitSequence.MAX_STEPS ->
+                                                                                        "No máximo ${StealthExitSequence.MAX_STEPS} passos."
+                                                                                step.isLightSignal && stealthSeq.lastOrNull() == step ->
+                                                                                        "${step.label.substringBefore(" (")} não pode aparecer duas vezes seguidas — o carro não distingue."
+                                                                                else -> null
+                                                                        }
+                                                                        if (impede != null) {
+                                                                                stealthSeqError = impede
+                                                                        } else {
+                                                                                stealthSeq = next
+                                                                                stealthSeqError = null
+                                                                                // Só grava quando já é utilizável; incompleta fica só na tela.
+                                                                                if (StealthExitSequence.validate(next) == null) {
+                                                                                        prefs.edit {
+                                                                                                putString(
+                                                                                                        SharedPreferencesKeys.STEALTH_EXIT_SEQUENCE.key,
+                                                                                                        StealthExitSequence.format(next)
+                                                                                                )
+                                                                                        }
+                                                                                }
+                                                                        }
+                                                                },
+                                                                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp)
+                                                        ) { Text("${step.short}  ${step.label.substringBefore(" (")}", fontSize = 11.sp) }
+                                                }
+                                        }
+                                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                                TextButton(onClick = {
+                                                        // Pode apagar até esvaziar: travar no mínimo deixava o dono preso
+                                                        // nos primeiros passos da sequência anterior.
+                                                        if (stealthSeq.isNotEmpty()) {
+                                                                stealthSeq = stealthSeq.dropLast(1)
+                                                                stealthSeqError = null
+                                                        }
+                                                }) { Text("Apagar", color = ImpTokens.TextSecondary, fontSize = 13.sp) }
+                                                TextButton(onClick = {
+                                                        stealthSeq = emptyList()
+                                                        stealthSeqError = null
+                                                }) { Text("Limpar", color = ImpTokens.TextSecondary, fontSize = 13.sp) }
+                                        }
+                                        if (stealthSeq.size < StealthExitSequence.MIN_STEPS) {
+                                                Text(
+                                                        "Faltam ${StealthExitSequence.MIN_STEPS - stealthSeq.size} passo(s) para valer. Até lá, a sequência padrão continua ativa.",
+                                                        color = ImpTokens.TextSecondary,
+                                                        fontSize = 12.sp
+                                                )
+                                        }
+                                        stealthSeqError?.let {
+                                                Text(it, color = Color(0xFFFF8A80), fontSize = 12.sp)
+                                        }
+
+                                        }
+
+                                        // PIN: a sequência prova intenção, o PIN prova identidade.
+                                        Row(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                horizontalArrangement = Arrangement.SpaceBetween,
+                                                verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                                Column(modifier = Modifier.weight(1f)) {
+                                                        Text("Pedir PIN depois da sequência", color = Color.White, fontSize = 14.sp)
+                                                        Text(
+                                                                if (stealthPinOn)
+                                                                        "Ligado. Se esquecer o PIN com o modo ativo, só reinstalando o app — e as configurações se perdem."
+                                                                else
+                                                                        "Sem PIN, quem descobrir a sequência tira o carro do modo.",
+                                                                color = ImpTokens.TextSecondary,
+                                                                fontSize = 12.sp
+                                                        )
+                                                }
+                                                Switch(
+                                                        checked = stealthPinOn,
+                                                        onCheckedChange = { want ->
+                                                                if (want) {
+                                                                        stealthPinTyped = ""
+                                                                        showStealthPinSetup = true
+                                                                } else {
+                                                                        StealthExitPin.clearPin()
+                                                                        prefs.edit {
+                                                                                putBoolean(SharedPreferencesKeys.ENABLE_STEALTH_EXIT_PIN.key, false)
+                                                                        }
+                                                                        stealthPinOn = false
+                                                                }
+                                                        }
+                                                )
+                                        }
                                         Row(
                                                 modifier = Modifier.fillMaxWidth(),
                                                 horizontalArrangement = Arrangement.End
@@ -444,10 +611,15 @@ fun InformacoesTab() {
                                                         onClick = {
                                                                 stealthStep = 0
                                                                 stealthProgress = 0
-                                                                StealthModeManager.armConfirmation { step, done ->
-                                                                        stealthProgress = step
-                                                                        if (done) stealthStep = 1
-                                                                }
+                                                                stealthBlocked = null
+                                                                StealthModeManager.armConfirmation(
+                                                                        onProgress = { step, done ->
+                                                                                stealthProgress = step
+                                                                                stealthBlocked = null
+                                                                                if (done) stealthStep = 1
+                                                                        },
+                                                                        onBlocked = { reason -> stealthBlocked = reason }
+                                                                )
                                                                 showStealthConfirm = true
                                                         },
                                                         modifier = Modifier.height(48.dp),
@@ -479,7 +651,116 @@ fun InformacoesTab() {
                         }
                 }
 
-                if (showStealthConfirm) {
+                stealthSummaryPin?.let { pin ->
+                AlertDialog(
+                        onDismissRequest = { stealthSummaryPin = null },
+                        containerColor = ImpTokens.Container,
+                        title = { Text("Guarde isto agora", color = Color.White, fontWeight = FontWeight.SemiBold) },
+                        text = {
+                                Column {
+                                        Text(
+                                                "Tire uma foto desta tela. O PIN não pode ser mostrado de novo: o app guarda só um resumo criptográfico dele, nunca o número.",
+                                                color = Color(0xFFFFB74D),
+                                                fontSize = 13.sp
+                                        )
+                                        Spacer(modifier = Modifier.height(16.dp))
+                                        Text("Sequência de saída", color = ImpTokens.TextSecondary, fontSize = 12.sp)
+                                        Text(
+                                                StealthExitSequence.describe(stealthSeq),
+                                                color = Color.White,
+                                                fontSize = 30.sp,
+                                                fontWeight = FontWeight.Bold
+                                        )
+                                        Text(
+                                                stealthSeq.joinToString("  →  ") { it.label.substringBefore(" (") },
+                                                color = ImpTokens.TextSecondary,
+                                                fontSize = 12.sp
+                                        )
+                                        Spacer(modifier = Modifier.height(14.dp))
+                                        Text("PIN", color = ImpTokens.TextSecondary, fontSize = 12.sp)
+                                        Text(
+                                                pin,
+                                                color = Color.White,
+                                                fontSize = 30.sp,
+                                                fontWeight = FontWeight.Bold
+                                        )
+                                        Spacer(modifier = Modifier.height(14.dp))
+                                        Text(
+                                                "Lembre: o carro precisa estar em P e a sequência inteira em até ${StealthExitSequence.TOTAL_WINDOW_MS / 1000}s.",
+                                                color = ImpTokens.TextSecondary,
+                                                fontSize = 12.sp
+                                        )
+                                }
+                        },
+                        confirmButton = {
+                                TextButton(onClick = { stealthSummaryPin = null }) { Text("Já anotei") }
+                        }
+                )
+        }
+
+        if (showStealthPinSetup) {
+                AlertDialog(
+                        onDismissRequest = {
+                                showStealthPinSetup = false
+                                stealthPinTyped = ""
+                        },
+                        containerColor = ImpTokens.Container,
+                        title = { Text("Definir PIN de saída", color = Color.White, fontWeight = FontWeight.SemiBold) },
+                        text = {
+                                Column {
+                                        Text(
+                                                "De ${StealthExitPin.MIN_LENGTH} a ${StealthExitPin.MAX_LENGTH} dígitos. Ele será pedido depois da sequência, na tela da central.",
+                                                color = ImpTokens.TextSecondary,
+                                                fontSize = 14.sp
+                                        )
+                                        Spacer(modifier = Modifier.height(10.dp))
+                                        Text(
+                                                "Guarde bem: esquecer o PIN com o modo ativo só se resolve reinstalando o app, e as configurações se perdem. Não existe atalho de recuperação — é isso que faz o PIN valer alguma coisa.",
+                                                color = Color(0xFFFFB74D),
+                                                fontSize = 13.sp
+                                        )
+                                        Spacer(modifier = Modifier.height(12.dp))
+                                        OutlinedTextField(
+                                                value = stealthPinTyped,
+                                                onValueChange = { v ->
+                                                        stealthPinTyped = v.filter { it.isDigit() }.take(StealthExitPin.MAX_LENGTH)
+                                                },
+                                                label = { Text("PIN") },
+                                                singleLine = true,
+                                                visualTransformation = PasswordVisualTransformation(),
+                                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
+                                        )
+                                }
+                        },
+                        confirmButton = {
+                                TextButton(
+                                        enabled = stealthPinTyped.length >= StealthExitPin.MIN_LENGTH,
+                                        onClick = {
+                                                val err = StealthExitPin.setPin(stealthPinTyped)
+                                                if (err == null) {
+                                                        prefs.edit {
+                                                                putBoolean(SharedPreferencesKeys.ENABLE_STEALTH_EXIT_PIN.key, true)
+                                                        }
+                                                        stealthPinOn = true
+                                                        showStealthPinSetup = false
+                                                        stealthSummaryPin = stealthPinTyped
+                                                        stealthPinTyped = ""
+                                                } else {
+                                                        Toast.makeText(context, err, Toast.LENGTH_LONG).show()
+                                                }
+                                        }
+                                ) { Text("Salvar") }
+                        },
+                        dismissButton = {
+                                TextButton(onClick = {
+                                        showStealthPinSetup = false
+                                        stealthPinTyped = ""
+                                }) { Text("Cancelar", color = ImpTokens.TextSecondary) }
+                        }
+                )
+        }
+
+        if (showStealthConfirm) {
                         AlertDialog(
                                 onDismissRequest = {
                                         showStealthConfirm = false
@@ -497,13 +778,23 @@ fun InformacoesTab() {
                                         Column {
                                                 if (stealthStep == 0) {
                                                         Text(
-                                                                "Antes de ativar, faça agora o gesto que devolve o carro ao normal — com o carro parado:\n\nSeta ESQUERDA → DIREITA → ESQUERDA → DIREITA",
+                                                                "Antes de ativar, faça agora o gesto que devolve o carro ao normal — com o carro em P:\n\n" +
+                                                                        StealthExitSequence.describe(stealthSeq) +
+                                                                        "\n\n(← → = setas, ① ② = botões do volante)",
                                                                 color = ImpTokens.TextSecondary,
                                                                 fontSize = 14.sp
                                                         )
                                                         Spacer(modifier = Modifier.height(12.dp))
+                                                        stealthBlocked?.let { reason ->
+                                                                Text(
+                                                                        reason,
+                                                                        color = Color(0xFFFF8A80),
+                                                                        fontSize = 14.sp
+                                                                )
+                                                                Spacer(modifier = Modifier.height(8.dp))
+                                                        }
                                                         Text(
-                                                                "$stealthProgress de 4",
+                                                                "$stealthProgress de ${stealthSeq.size}",
                                                                 color = if (stealthProgress > 0) Color(0xFF4CAF50) else ImpTokens.TextSecondary,
                                                                 fontSize = 20.sp,
                                                                 fontWeight = FontWeight.Bold

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/utils/ReleaseUpdateChecker.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/utils/ReleaseUpdateChecker.kt
@@ -49,11 +49,18 @@ object ReleaseUpdateChecker {
                     }
 
                     if (downloadUrl != null) {
-                        val info = ReleaseInfo(tag, downloadUrl, isPrerelease)
-                        if (isPrerelease && latestPreview == null) {
-                            latestPreview = info
-                        } else if (!isPrerelease && latestRelease == null) {
-                            latestRelease = info
+                        // optString: release publicada sem descricao devolve null no JSON, e um
+                        // getString ali derrubaria a verificacao inteira por causa do texto.
+                        val notes = release.optString("body", "").trim()
+                        val info = ReleaseInfo(tag, downloadUrl, isPrerelease, notes)
+                        // Escolhe a MAIOR versão (compareVersions), NÃO a 1ª da lista: a ordem da API do
+                        // GitHub é por created_at = data do commit que a tag aponta, que fura fácil (tag
+                        // ancorada num commit antigo / releases por mirror). Sem break precoce. Regressão
+                        // reintroduzida na base PR119 — ver memória haval-ota-self-hosted-releases.
+                        if (isPrerelease) {
+                            if (latestPreview == null || compareVersions(tag, latestPreview!!.tag) > 0) latestPreview = info
+                        } else {
+                            if (latestRelease == null || compareVersions(tag, latestRelease!!.tag) > 0) latestRelease = info
                         }
                     }
 


### PR DESCRIPTION
Cinco coisas, todas testadas no carro (Haval H6 PHEV) exceto onde indicado.

---

## 1. Modo Concessionária

Um botão que devolve o carro à aparência de fábrica antes de levá-lo à revisão. Com ele ativo: o ícone do app some do menu junto com os dos apps instalados, o painel volta ao nativo, a barra inferior e as luzes saem, os patches de Android Auto e CarPlay são desmontados e as automações param. As preferências são salvas e devolvidas inteiras na saída.

**Como se sai:** uma sequência nos controles do carro, com o carro **em P**, dentro de 30s. O padrão é `← → ← →`, e o dono pode montar a dele com até oito passos combinando setas, botões do volante e luz alta. Opcionalmente, um **PIN** depois da sequência — a sequência prova intenção, o PIN prova identidade. Só o hash com sal é gravado; o que segura é o bloqueio progressivo (3 erros livres, depois 30s, 60s, 120s… até 10min).

**Por que os botões do volante entraram:** o carro só avisa quando a *luz* da seta acende, e acender a mesma seta duas vezes seguidas não gera dois eventos distinguíveis. Só com setas, toda sequência é obrigada a alternar e a única liberdade seria o lado inicial e o tamanho. O validador recusa sequências que o carro não conseguiria reconhecer, em vez de deixar montar algo que trancaria o dono do lado de fora.

**Proteções, porque o modo esconde o próprio app:** ensaio obrigatório antes de aplicar (o dono executa a sequência e vê o contador andar — se um passo não chegar naquele carro, ele descobre antes, não depois); o ensaio prepara os botões que a sequência usa; o teclado do PIN é uma janela sobreposta e não uma tela do app, porque com o app escondido o Android recusa abrir Activity a partir de segundo plano; se o teclado não subir, a saída acontece sem ele — ficar preso é pior que o modo ser burlável; e o teclado tem Cancelar mais recolhimento automático em 90s.

**Custo a conhecer:** setas e luz alta são só leitura. Os botões do volante precisam ser capturados, então o botão usado pela sequência perde a função nativa enquanto o modo está ativo — por isso o botão 2 só é integrado quando a sequência realmente usa ele.

---

## 2. Fechamento automático da cortina do teto

Complementa a abertura automática que já existia. Duas automações independentes, cada uma com seu interruptor e sua janela: abrir (padrão 18:00→09:00, com limite de temperatura externa) e fechar (padrão 09:00→17:00, só horário). As duas foram para um grupo novo em Configurações, **Conforto & conveniência**.

Age ao ligar o carro, se já estiver na janela, e **ao cruzar a borda da janela com o carro ligado** — ligar às 16h com abertura marcada para 17h abre sozinho às 17h. Sem verificação periódica: calcula quanto falta para o próximo horário relevante e dorme até lá; com as duas desligadas, nada é agendado.

Age uma vez por janela (mexer na cortina na mão depois não faz ela reabrir); fechar tem precedência se as janelas forem configuradas sobrepostas por engano; janela vazia nunca dispara. A temperatura vale só na abertura — se a leitura ainda não chegou, tenta de novo e, não vindo, **não abre**, nunca às cegas.

⚠️ **Esta é a única parte ainda não validada no carro.**

---

## 3. Painel lateral: some sozinho de novo, e sem piscar

Duas falhas encadeadas, ambas medidas no carro.

O painel piscava a cada 5s sozinho: para reesconder, o código apagava o `policy_control` e reescrevia, porque reescrever o mesmo valor é um no-op que o sistema não anuncia — e sem anúncio ele não reaplica. Só que chave vazia significa "não esconda nada", então o apagar **revelava** o painel por um instante. Essa revelação era observada como "o dono deslizou", que agendava outro reesconder. O remédio criava a doença.

E o gatilho nunca funcionou: o inset do painel **não muda** quando ele volta por deslize (zero eventos no logcat após vários deslizes). O que escondia era o próprio ciclo, por acidente — matando o ciclo, a ilusão de "auto-ocultar após deslizar" caiu junto.

Agora existe detecção real: a cada 5s o app lê do WindowManager se a barra está na tela e só escreve quando há o que esconder. Ler antes de escrever é o que elimina o piscar, por um motivo sutil — o apagar só revela quando a barra está escondida; com ela já visível, não há nada a revelar.

---

## 4. Aviso automático de versão nova

Verifica uma vez por partida e avisa em dois lugares discretos: um chip no dashboard e um ponto ao lado de "Informações". Só avisa — não baixa nem instala.

**Não sabe onde buscar, de propósito.** Quem sabe é o `ReleaseUpdateChecker`, e cada fork aponta para o próprio local de releases. Mantendo essa decisão fora da função, ela fica idêntica em qualquer fork e não conflita em merges.

Calibragem: espera a rede aparecer em vez de verificar no instante da partida (ao ligar o carro o WiFi ainda está associando, e um "não consegui verificar" repetido a cada manhã é pior que não avisar); avisa uma vez por **versão**, e o toque longo dispensa aquela versão; o chip só existe quando há novidade, sem placeholder permanente dizendo "tudo atualizado"; e usa a mesma regra de canal da tela de Informações, senão o chip apontaria uma novidade que a tela não confirma.

---

## 5. O que mudou aparece na tela

Quem atualizava ficava procurando pelo app o que tinha mudado. A tela de atualização passa a mostrar o texto da release.

Não precisou de arquivo no repositório nem de outra requisição: a nota **já vinha** na mesma consulta que busca a versão e estava sendo descartada no parser. Lida com `optString`, porque release publicada sem descrição devolve null e um `getString` ali derrubaria a verificação inteira por causa do texto. Altura limitada com rolagem, para nota longa não empurrar o botão de atualizar para fora da tela.

---

Compila limpo sobre `preview`. Nada específico do fork entrou: a URL de releases continua apontando para este repositório, e a lógica de escolha da release é a que já estava aqui.

---

<details>
<summary><b>📋 Descritivo pronto para a release (clique para abrir)</b></summary>

Texto escrito para o dono do carro, não para quem programa — é só copiar para as notas da versão quando publicar. O que está acima neste PR explica *por que* cada coisa foi feita; isto aqui diz *o que muda* para quem usa.

## Modo Concessionária

Deixa o carro com cara de fábrica antes de levar à revisão: o ícone do app some do menu junto com os dos apps instalados, o painel volta ao nativo, a barra inferior sai e as automações param. Suas configurações são salvas e voltam inteiras.

Para sair, uma sequência nos controles com o carro **em P**, em até 30 segundos. O padrão é seta esquerda, direita, esquerda, direita — e você pode montar a sua, com até oito passos, combinando setas, botões do volante e luz alta. Dá para exigir um PIN depois da sequência.

Antes de ativar, o app pede um **ensaio**: você faz a sequência ali mesmo e vê o contador andar. Serve para garantir que o gesto funciona no seu carro antes de esconder qualquer coisa.

## Cortina do teto fecha sozinha por horário

Complementa a abertura automática que já existia. Agora são duas automações separadas, em Configurações → Conforto & conveniência: uma abre a cortina na janela de horário que você escolher (com limite de temperatura, se quiser), outra fecha.

Funciona também com o carro andando: se a janela começa às 17h e você ligou às 16h, ela age às 17h sem precisar desligar o carro.

## Painel lateral não pisca mais

Com a função de ocultar ligada, o painel ficava aparecendo e sumindo sozinho a cada poucos segundos. Isso acabou.

E ele voltou a se esconder sozinho: puxando o painel de volta com um deslize, ele some em cerca de 5 segundos depois que você terminar de usar.

## Aviso quando sai versão nova

Ao ligar o carro, o app verifica sozinho se há versão nova e avisa de duas formas discretas: um chip no dashboard com o número da versão e um ponto ao lado de "Informações". Tocar leva direto para a tela de atualização.

Não baixa nem instala nada sozinho — só avisa. Se não quiser atualizar agora, um toque longo no chip dispensa aquela versão, e o aviso só volta quando sair outra.

## Veja o que mudou antes de atualizar

A tela de atualização agora mostra o que mudou na versão, em vez de deixar você procurando pelo app o que foi alterado.

</details>
