### PR TITLE
fix(barra): conferir se o ocultar do painel lateral realmente pegou (o home ficava inerte)

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -77,13 +77,55 @@ private fun applyLeftNavPaneVisibility(hidden: Boolean) {
                                                 "immersive.navigation=*"
                                         )
                                 else arrayOf("settings", "delete", "global", "policy_control")
-                        val result =
+                        // CONFERE depois de aplicar, e insiste ate 3 vezes.
+                        //
+                        // Antes era disparo cego: mandava o comando e so registrava a saida, sem
+                        // olhar se pegou. Quando o Shizuku esta fora naquele instante, o comando
+                        // falha em silencio — e no DESLIGAR o estrago e grande: a politica
+                        // `immersive.navigation` fica valendo, a barra de navegacao continua
+                        // transitoria e o Android passa a IGNORAR o toque no botao home. Aconteceu
+                        // no carro: funcao desligada e home morto, enquanto os outros icones da
+                        // mesma faixa (grade de apps, temperatura) seguiam normais — sao interface
+                        // da montadora, nao da barra de navegacao.
+                        var aplicado = false
+                        for (tentativa in 1..3) {
                                 br.com.redesurftank.havalshisuku.utils.ShizukuUtils
                                         .runCommandAndGetOutput(command)
-                        android.util.Log.w(
-                                "BasicSettingsScreen",
-                                "[NAV_PANE] hidden=$hidden result=$result"
-                        )
+                                val agora =
+                                        runCatching {
+                                                        br.com.redesurftank.havalshisuku.utils
+                                                                .ShizukuUtils
+                                                                .runCommandAndGetOutput(
+                                                                        arrayOf(
+                                                                                "settings",
+                                                                                "get",
+                                                                                "global",
+                                                                                "policy_control"
+                                                                        )
+                                                                )
+                                                }
+                                                .getOrDefault("")
+                                                .trim()
+                                // `settings get` devolve a string "null" quando a chave nao existe.
+                                aplicado =
+                                        if (hidden) agora.contains("immersive.navigation")
+                                        else agora.isEmpty() || agora == "null"
+                                android.util.Log.w(
+                                        "BasicSettingsScreen",
+                                        "[NAV_PANE] hidden=$hidden tentativa=$tentativa " +
+                                                "policy_control='$agora' ok=$aplicado"
+                                )
+                                if (aplicado) break
+                                runCatching { Thread.sleep(700) }
+                        }
+                        if (!aplicado) {
+                                android.util.Log.e(
+                                        "BasicSettingsScreen",
+                                        "[NAV_PANE] NAO consegui deixar policy_control no estado " +
+                                                "pedido (hidden=$hidden); com hidden=false isso " +
+                                                "mantem o botao home inerte"
+                                )
+                        }
                 }
                 .start()
 }
@@ -2326,7 +2368,7 @@ fun BasicSettingsTab() {
                                                                                                 16.sp
                                                                                 )
                                                                                 Text(
-                                                                                        "O painel fica oculto e libera os 128px da esquerda para a barra. Deslize da borda esquerda para trazê-lo de volta; ele se esconde de novo após 5s.",
+                                                                                        "O painel fica oculto e libera os 128px da esquerda para a barra. Deslize da borda esquerda para trazê-lo de volta; ele se esconde de novo após 5s.\n\nAtenção: o botão home nativo fica nesse painel, então ele sai junto. Para usá-lo, deslize o painel de volta — ou configure o deslizar para cima da barra como \"Ir para a Home Haval\".",
                                                                                         color =
                                                                                                 Color.Gray,
                                                                                         fontSize =


### PR DESCRIPTION
Complemento do #129 — este defeito só apareceu depois que aquele PR já estava mesclado, então a versão publicada carrega ele.

## O problema

Ao **desligar** "Ocultar painel lateral", o app executava

```
settings delete global policy_control
```

e não conferia se tinha pegado. Se o Shizuku estiver indisponível naquele instante, o comando falha em silêncio: a política `immersive.navigation=*` continua valendo mesmo com o interruptor desligado.

O sintoma no carro é cirúrgico e despista completamente: a barra de navegação segue transitória, o Android passa a **ignorar o toque no botão HOME**, e os outros ícones da mesma faixa (grade de apps, temperatura) continuam funcionando normalmente — porque são interface da montadora, não da barra de navegação. Parece que "só o home quebrou".

Diagnosticado no carro em 25/08. Três hipóteses erradas antes de acertar (painel escondido cobrindo o botão; launcher desabilitado). A confirmação veio de `settings get global policy_control`, que devolveu `immersive.navigation=*` com a função **desligada**. Resolvido na hora com `settings delete global policy_control`.

## A correção

`applyLeftNavPaneVisibility` deixa de ser disparo cego:

- relê `settings get global policy_control` depois de aplicar;
- insiste até 3 vezes, com 700 ms entre as tentativas;
- registra no log cada tentativa e um `Log.e` quando desiste, dizendo explicitamente que com `hidden=false` isso deixa o home inerte.

Detalhe que vale citar: `settings get` devolve a **string** `"null"` quando a chave não existe — então vazio e `"null"` contam como limpo.

Também acrescenta na descrição do interruptor o aviso que faltava: essa função esconde o painel onde o botão home nativo mora, então ele sai junto (e aponta a saída — deslizar o painel de volta, ou usar o "Ir para a Home Haval" no deslizar para cima da barra).

## Escopo

1 arquivo, `BasicSettingsScreen.kt`, +48/−6. Compila (`compileDebugKotlin`) sobre a `preview` atual.

<details>
<summary>Descritivo para a nota de versão</summary>

**Painel lateral — o botão home não morre mais**

Desligar "Ocultar painel lateral" nem sempre desfazia de verdade a mudança. Quando isso acontecia, o botão home da tela parava de responder aos toques — e como os ícones vizinhos continuavam funcionando, parecia defeito da central. Agora o app confere se a mudança pegou e tenta de novo se não pegou.

A tela de configuração também passou a avisar que o botão home nativo fica dentro desse painel, então ele some junto quando a função é ligada.

</details>
