### PR TITLE
feat(gestos): arraste de vários dedos ajusta volume, temperatura e ventilação

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/gestures/GestureBindings.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/gestures/GestureBindings.kt
@@ -1,0 +1,146 @@
+package br.com.redesurftank.havalshisuku.gestures
+
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Action
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Axis
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Zone
+
+/**
+ * Qual gesto faz o que — configuravel pelo dono, em vez de fixo no codigo.
+ *
+ * Um vinculo e a combinacao **numero de dedos + eixo + zona**. A tela sempre trabalha em TERCOS,
+ * porque com a mesma acao podendo se repetir isso ja e superconjunto de tudo: a mesma acao nas tres
+ * zonas e o que significa "tela toda", e em duas delas, "metade". Nao existe uma escolha separada de
+ * "layout" — ela seria estado a mais pelo mesmo poder.
+ *
+ * Puro de proposito (nada de Android): a leitura de configuracao mal formada e exatamente o tipo de
+ * coisa que precisa de teste, e um formato que so roda no aparelho nao se testa.
+ */
+data class GestureBindings(private val slots: Map<Slot, Action>) {
+
+    data class Slot(val fingers: Int, val axis: Axis, val zone: Zone)
+
+    fun actionFor(fingers: Int, axis: Axis, zone: Zone): Action? =
+        slots[Slot(fingers, axis, zone)]
+
+    /** Contagens de dedos que tem ao menos um vinculo — as unicas que armam gesto. */
+    fun activeFingerCounts(): Set<Int> = slots.keys.map { it.fingers }.toSet()
+
+    /** Acima disso e mao apoiada, nao gesto. 0 quando nada esta configurado. */
+    fun maxFingers(): Int = activeFingerCounts().maxOrNull() ?: 0
+
+    fun isEmpty(): Boolean = slots.isEmpty()
+
+    /** Devolve uma copia com um vinculo trocado; `action` nulo remove. */
+    fun with(fingers: Int, axis: Axis, zone: Zone, action: Action?): GestureBindings {
+        val slot = Slot(fingers, axis, zone)
+        val next = slots.toMutableMap()
+        if (action == null) next.remove(slot) else next[slot] = action
+        return GestureBindings(next)
+    }
+
+    /** Preenche as tres zonas de uma linha com a mesma acao — o atalho "tela toda". */
+    fun withWholeRow(fingers: Int, axis: Axis, action: Action?): GestureBindings {
+        var out = this
+        for (zone in Zone.entries) out = out.with(fingers, axis, zone, action)
+        return out
+    }
+
+    /**
+     * Formato: `dedos:eixo:zona=acao`, separados por `;`. Ex.: `3:V:L=driver_temp;3:V:C=volume`.
+     *
+     * Texto simples em vez de JSON porque isso e lido e escrito tambem por quem estiver num shell no
+     * carro, e porque a decodificacao precisa rodar em teste de unidade — o `org.json` do Android e
+     * um esqueleto vazio na JVM.
+     *
+     * [EMPTY_MARKER] existe pra distinguir "o dono desligou tudo" de "nunca foi configurado": sem
+     * ele, apagar o ultimo vinculo faria os padroes ressuscitarem no proximo boot.
+     */
+    fun encode(): String {
+        if (slots.isEmpty()) return EMPTY_MARKER
+        return slots.entries
+            .sortedWith(
+                compareBy({ it.key.fingers }, { it.key.axis.ordinal }, { it.key.zone.ordinal })
+            )
+            .joinToString(";") { (slot, action) ->
+                "${slot.fingers}:${axisCode(slot.axis)}:${zoneCode(slot.zone)}=${action.name.lowercase()}"
+            }
+    }
+
+    companion object {
+        const val EMPTY_MARKER = "-"
+
+        /**
+         * Contagens que a tela oferece.
+         *
+         * DOIS ficou de fora por decisao do dono. Como nao roubamos o toque, dois dedos disputam
+         * com o app que esta na frente — um arraste na metade esquerda com o mapa na tela mexeria
+         * na temperatura E arrastaria o mapa. Entradas de dois dedos numa configuracao antiga sao
+         * descartadas na leitura.
+         */
+        val FINGER_COUNTS = listOf(3, 4)
+
+        /** O que sempre valeu antes de existir configuracao: tres dedos, clima e volume. */
+        val DEFAULT: GestureBindings =
+            GestureBindings(
+                buildMap {
+                    put(Slot(3, Axis.VERTICAL, Zone.LEFT), Action.DRIVER_TEMP)
+                    put(Slot(3, Axis.VERTICAL, Zone.CENTER), Action.VOLUME)
+                    put(Slot(3, Axis.VERTICAL, Zone.RIGHT), Action.PASSENGER_TEMP)
+                    for (zone in Zone.entries) put(Slot(3, Axis.HORIZONTAL, zone), Action.FAN)
+                }
+            )
+
+        /**
+         * Le a configuracao gravada. Vazio/ausente cai no padrao; entradas estragadas sao
+         * IGNORADAS uma a uma, em vez de derrubar o conjunto — configuracao meio lida e melhor que
+         * gesto nenhum, e o dono conserta a que sumiu.
+         */
+        fun decode(raw: String?): GestureBindings {
+            if (raw.isNullOrBlank()) return DEFAULT
+            if (raw.trim() == EMPTY_MARKER) return GestureBindings(emptyMap())
+            val out = mutableMapOf<Slot, Action>()
+            for (entry in raw.split(";")) {
+                val piece = entry.trim()
+                if (piece.isEmpty()) continue
+                val eq = piece.indexOf('=')
+                if (eq <= 0) continue
+                val parts = piece.substring(0, eq).split(":")
+                if (parts.size != 3) continue
+                val fingers = parts[0].trim().toIntOrNull() ?: continue
+                if (fingers !in FINGER_COUNTS) continue
+                val axis = parseAxis(parts[1].trim()) ?: continue
+                val zone = parseZone(parts[2].trim()) ?: continue
+                val action = parseAction(piece.substring(eq + 1).trim()) ?: continue
+                out[Slot(fingers, axis, zone)] = action
+            }
+            return if (out.isEmpty()) DEFAULT else GestureBindings(out)
+        }
+
+        private fun axisCode(axis: Axis) = if (axis == Axis.VERTICAL) "V" else "H"
+
+        private fun zoneCode(zone: Zone) =
+            when (zone) {
+                Zone.LEFT -> "L"
+                Zone.CENTER -> "C"
+                Zone.RIGHT -> "R"
+            }
+
+        private fun parseAxis(code: String): Axis? =
+            when (code.uppercase()) {
+                "V" -> Axis.VERTICAL
+                "H" -> Axis.HORIZONTAL
+                else -> null
+            }
+
+        private fun parseZone(code: String): Zone? =
+            when (code.uppercase()) {
+                "L" -> Zone.LEFT
+                "C" -> Zone.CENTER
+                "R" -> Zone.RIGHT
+                else -> null
+            }
+
+        private fun parseAction(name: String): Action? =
+            Action.entries.firstOrNull { it.name.equals(name, ignoreCase = true) }
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/gestures/GestureFeedbackOverlay.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/gestures/GestureFeedbackOverlay.kt
@@ -1,0 +1,469 @@
+package br.com.redesurftank.havalshisuku.gestures
+
+import android.animation.ValueAnimator
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
+import android.graphics.Typeface
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import android.view.animation.DecelerateInterpolator
+import br.com.redesurftank.App
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * O retorno visual dos gestos: um cartao no centro da tela com o que mudou, o valor novo e um
+ * desenho animado do QUE esta acontecendo — gelo esfriando, chama esquentando, helice girando,
+ * ondas saindo do alto-falante.
+ *
+ * Aparece SOBRE qualquer app, por isso e uma janela do WindowManager e nao um Composable nosso.
+ * Duas flags fazem toda a diferenca:
+ *
+ *  - `FLAG_NOT_TOUCHABLE`: sem ela, o cartao engoliria o toque do app de baixo justamente durante o
+ *    arraste que o invocou. Com ela, e vidro: desenha e deixa passar.
+ *  - `FLAG_NOT_FOCUSABLE`: sem ela, a janela rouba o foco e o app de baixo perde o estado de
+ *    entrada por um instante.
+ *
+ * Tudo e desenhado no Canvas: sem drawable, sem emoji e sem WebView. Nao e purismo — e uma view
+ * efemera por cima de outro app, e depender de recurso ou fonte do sistema aqui e o caminho curto
+ * pra ganhar um retangulo vazio numa unidade com fonte diferente.
+ */
+object GestureFeedbackOverlay {
+
+    private const val TAG = "GestureOverlay"
+    private const val HIDE_DELAY_MS = 1100L
+    private const val POP_MIN_INTERVAL_MS = 140L
+
+    /** O desenho que acompanha cada ajuste. */
+    enum class Motif {
+        /** Floco de neve girando — temperatura CAINDO. */
+        COOLING,
+        /** Chama tremulando — temperatura SUBINDO. */
+        HEATING,
+        /** Helice girando, mais rapido quanto maior a ventilacao. */
+        FAN,
+        /** Alto-falante com ondas saindo (ou recolhendo). */
+        VOLUME,
+    }
+
+    private val handler = Handler(Looper.getMainLooper())
+    private var view: HudView? = null
+
+    private val hideRunnable = Runnable { hideNow() }
+
+    /**
+     * Mostra (ou atualiza) o cartao.
+     *
+     * @param title o que esta sendo ajustado ("Volume", "Motorista", ...)
+     * @param value ja formatado pra leitura ("22.5°", "4", "12")
+     * @param fraction 0..1 — onde o valor esta dentro da faixa possivel
+     * @param accent cor do realce, uma por tipo de ajuste
+     * @param motif o desenho animado
+     * @param direction +1 subindo, -1 descendo — a animacao muda de sentido junto
+     */
+    fun show(
+        title: String,
+        value: String,
+        fraction: Float,
+        accent: Int,
+        motif: Motif,
+        direction: Int,
+    ) {
+        handler.post { showOnMain(title, value, fraction, accent, motif, direction) }
+    }
+
+    fun hide() {
+        handler.post { hideNow() }
+    }
+
+    private fun showOnMain(
+        title: String,
+        value: String,
+        fraction: Float,
+        accent: Int,
+        motif: Motif,
+        direction: Int,
+    ) {
+        try {
+            val existing = view
+            if (existing == null) {
+                val ctx = App.getContext()
+                val wm = ctx.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+                val hud = HudView(ctx)
+                hud.update(title, value, fraction, accent, motif, direction)
+                val lp =
+                    WindowManager.LayoutParams(
+                        WindowManager.LayoutParams.WRAP_CONTENT,
+                        WindowManager.LayoutParams.WRAP_CONTENT,
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+                        } else {
+                            @Suppress("DEPRECATION") WindowManager.LayoutParams.TYPE_PHONE
+                        },
+                        // As duas flags que impedem o cartao de atrapalhar o app de baixo.
+                        WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+                            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                            WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN,
+                        android.graphics.PixelFormat.TRANSLUCENT,
+                    )
+                lp.gravity = Gravity.CENTER
+                wm.addView(hud, lp)
+                view = hud
+                hud.animateIn()
+            } else {
+                existing.update(title, value, fraction, accent, motif, direction)
+                existing.pop()
+            }
+            handler.removeCallbacks(hideRunnable)
+            handler.postDelayed(hideRunnable, HIDE_DELAY_MS)
+        } catch (t: Throwable) {
+            Log.e(TAG, "nao deu pra mostrar o retorno do gesto", t)
+            view = null
+        }
+    }
+
+    private fun hideNow() {
+        val hud = view ?: return
+        handler.removeCallbacks(hideRunnable)
+        hud.animateOut {
+            try {
+                val wm = App.getContext().getSystemService(Context.WINDOW_SERVICE) as WindowManager
+                wm.removeView(hud)
+            } catch (t: Throwable) {
+                Log.w(TAG, "nao deu pra remover o cartao do gesto", t)
+            }
+            view = null
+        }
+    }
+
+    private class HudView(context: Context) : View(context) {
+
+        private val density = context.resources.displayMetrics.density
+        private val metrics = context.resources.displayMetrics
+
+        // Tamanho proporcional a TELA, nao em dp fixo: a constante que fica boa numa central de
+        // 1920x720 fica minuscula numa maior. Os limites cortam os extremos dos dois lados.
+        private val cardH = (metrics.heightPixels * 0.30f).coerceIn(dp(120f), dp(280f))
+        private val cardW = (cardH * 2.6f).coerceAtMost(metrics.widthPixels * 0.45f)
+        private val pad = cardH * 0.16f
+        private val glyphSize = cardH * 0.46f
+        private val textLeft = pad + glyphSize + cardH * 0.10f
+        private val barH = cardH * 0.055f
+
+        // Fundo translucido: o cartao sobe por cima de outro app, e um bloco quase opaco esconde
+        // demais do que esta embaixo. O preco da transparencia e a legibilidade sobre conteudo
+        // claro — dai a sombra atras dos textos e a borda mais marcada, que sustentam o contorno.
+        private val cardPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = 0xA6121620.toInt() }
+        private val borderPaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                style = Paint.Style.STROKE
+                strokeWidth = dp(1.5f)
+                color = 0x4DFFFFFF
+            }
+        private val titlePaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = 0xFFC6CEDA.toInt()
+                textSize = cardH * 0.115f
+                typeface = Typeface.create(Typeface.SANS_SERIF, Typeface.NORMAL)
+                setShadowLayer(dp(5f), 0f, dp(1.5f), 0xCC000000.toInt())
+            }
+        private val valuePaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = Color.WHITE
+                textSize = cardH * 0.40f
+                typeface = Typeface.create(Typeface.SANS_SERIF, Typeface.BOLD)
+                setShadowLayer(dp(7f), 0f, dp(2f), 0xE6000000.toInt())
+            }
+        private val trackPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = 0x3DFFFFFF }
+        private val fillPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        private val glyphStroke =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                style = Paint.Style.STROKE
+                strokeCap = Paint.Cap.ROUND
+                strokeJoin = Paint.Join.ROUND
+            }
+        private val glyphFill = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+
+        private var title = ""
+        private var value = ""
+        private var fraction = 0f
+        private var accent = Color.WHITE
+        private var motif = Motif.VOLUME
+        private var direction = 1
+        private var popAnimator: ValueAnimator? = null
+        private var lastPopAt = 0L
+
+        private val startedAt = SystemClock.uptimeMillis()
+        /** Angulo acumulado da helice: a velocidade muda, mas a pa nao pode saltar de posicao. */
+        private var fanAngle = 0f
+        private var lastFrameAt = startedAt
+
+        private val rect = RectF()
+        private val path = Path()
+
+        fun update(
+            title: String,
+            value: String,
+            fraction: Float,
+            accent: Int,
+            motif: Motif,
+            direction: Int,
+        ) {
+            this.title = title
+            this.value = value
+            this.fraction = fraction.coerceIn(0f, 1f)
+            this.accent = accent
+            this.motif = motif
+            this.direction = if (direction >= 0) 1 else -1
+            fillPaint.color = accent
+            invalidate()
+        }
+
+        fun animateIn() {
+            alpha = 0f
+            scaleX = 0.92f
+            scaleY = 0.92f
+            translationY = dp(20f)
+            animate()
+                .alpha(1f)
+                .scaleX(1f)
+                .scaleY(1f)
+                .translationY(0f)
+                .setDuration(160)
+                .setInterpolator(DecelerateInterpolator())
+                .start()
+        }
+
+        /**
+         * Batidinha que confirma que o gesto continua sendo lido.
+         *
+         * NAO pode rodar a cada passo: num arraste os passos chegam de poucos em poucos
+         * milissegundos, e reiniciar uma animacao de 130ms a essa altura faz o cartao TREMER em vez
+         * de animar — foi exatamente a queixa de "pouco fluido". O texto e a barra seguem
+         * atualizando em todo passo; so a batidinha e que respeita um intervalo minimo.
+         */
+        fun pop() {
+            val now = SystemClock.uptimeMillis()
+            if (now - lastPopAt < POP_MIN_INTERVAL_MS) return
+            lastPopAt = now
+            popAnimator?.cancel()
+            popAnimator =
+                ValueAnimator.ofFloat(1f, 1.04f, 1f).apply {
+                    duration = 130
+                    addUpdateListener {
+                        val s = it.animatedValue as Float
+                        scaleX = s
+                        scaleY = s
+                    }
+                    start()
+                }
+        }
+
+        fun animateOut(onDone: () -> Unit) {
+            popAnimator?.cancel()
+            animate()
+                .alpha(0f)
+                .scaleX(0.96f)
+                .scaleY(0.96f)
+                .setDuration(200)
+                .withEndAction(onDone)
+                .start()
+        }
+
+        override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+            setMeasuredDimension(cardW.toInt(), cardH.toInt())
+        }
+
+        override fun onDraw(canvas: Canvas) {
+            val now = SystemClock.uptimeMillis()
+            val t = (now - startedAt) / 1000f
+            val dt = ((now - lastFrameAt).coerceIn(0L, 100L)) / 1000f
+            lastFrameAt = now
+
+            val r = cardH * 0.16f
+            rect.set(0f, 0f, width.toFloat(), height.toFloat())
+            canvas.drawRoundRect(rect, r, r, cardPaint)
+            rect.inset(borderPaint.strokeWidth / 2f, borderPaint.strokeWidth / 2f)
+            canvas.drawRoundRect(rect, r, r, borderPaint)
+
+            val barTop = cardH - pad - barH
+            drawGlyph(canvas, pad + glyphSize / 2f, (pad + barTop) / 2f, glyphSize / 2f, t, dt)
+
+            val titleBaseline = pad + titlePaint.textSize * 0.9f
+            canvas.drawText(title, textLeft, titleBaseline, titlePaint)
+            canvas.drawText(value, textLeft, titleBaseline + valuePaint.textSize * 0.95f, valuePaint)
+
+            rect.set(pad, barTop, cardW - pad, barTop + barH)
+            canvas.drawRoundRect(rect, barH / 2f, barH / 2f, trackPaint)
+            if (fraction > 0f) {
+                rect.set(pad, barTop, pad + (cardW - 2 * pad) * fraction, barTop + barH)
+                canvas.drawRoundRect(rect, barH / 2f, barH / 2f, fillPaint)
+            }
+
+            // Redesenha no proximo vsync enquanto o cartao existir. Ele vive ~1s por gesto, entao
+            // isso nao e um loop permanente: quando a janela sai, o desenho para junto.
+            postInvalidateOnAnimation()
+        }
+
+        private fun drawGlyph(canvas: Canvas, cx: Float, cy: Float, radius: Float, t: Float, dt: Float) {
+            when (motif) {
+                Motif.COOLING -> drawSnowflake(canvas, cx, cy, radius, t)
+                Motif.HEATING -> drawFlame(canvas, cx, cy, radius, t)
+                Motif.FAN -> drawFan(canvas, cx, cy, radius, dt)
+                Motif.VOLUME -> drawSpeaker(canvas, cx, cy, radius, t)
+            }
+        }
+
+        /** Floco girando devagar, com um leve pulsar — leitura imediata de "esfriando". */
+        private fun drawSnowflake(canvas: Canvas, cx: Float, cy: Float, radius: Float, t: Float) {
+            val pulse = 1f + 0.06f * sin(t * 3.4f)
+            val r = radius * 0.92f * pulse
+            glyphStroke.color = accent
+            glyphStroke.strokeWidth = radius * 0.13f
+            canvas.save()
+            canvas.rotate(t * 22f, cx, cy)
+            for (i in 0 until 6) {
+                val a = Math.toRadians((i * 60).toDouble())
+                val dx = cos(a).toFloat()
+                val dy = sin(a).toFloat()
+                canvas.drawLine(cx - dx * r, cy - dy * r, cx + dx * r, cy + dy * r, glyphStroke)
+                // Ramos: sem eles vira uma estrela generica, com eles le-se floco na hora.
+                for (at in floatArrayOf(0.52f, 0.80f)) {
+                    val bx = cx + dx * r * at
+                    val by = cy + dy * r * at
+                    val len = r * 0.24f * (1f - at * 0.5f)
+                    for (side in intArrayOf(-1, 1)) {
+                        val ba = a + side * 0.9f
+                        canvas.drawLine(
+                            bx,
+                            by,
+                            bx + cos(ba).toFloat() * len,
+                            by + sin(ba).toFloat() * len,
+                            glyphStroke,
+                        )
+                    }
+                }
+            }
+            canvas.restore()
+        }
+
+        /** Chama tremulando: duas camadas, a de dentro mais clara e mais nervosa. */
+        private fun drawFlame(canvas: Canvas, cx: Float, cy: Float, radius: Float, t: Float) {
+            drawFlameLayer(canvas, cx, cy, radius * 1.0f, t * 6.0f, accent)
+            drawFlameLayer(canvas, cx, cy + radius * 0.16f, radius * 0.55f, t * 9.0f, 0xFFFFD54F.toInt())
+        }
+
+        private fun drawFlameLayer(
+            canvas: Canvas,
+            cx: Float,
+            cy: Float,
+            radius: Float,
+            phase: Float,
+            color: Int,
+        ) {
+            val wobble = sin(phase) * radius * 0.16f
+            val top = cy - radius
+            val bottom = cy + radius * 0.85f
+            val half = radius * 0.62f
+            path.reset()
+            path.moveTo(cx + wobble * 0.5f, top)
+            path.cubicTo(
+                cx + half * 1.15f,
+                top + radius * 0.75f,
+                cx + half,
+                bottom - radius * 0.35f,
+                cx,
+                bottom,
+            )
+            path.cubicTo(
+                cx - half,
+                bottom - radius * 0.35f,
+                cx - half * 1.15f,
+                top + radius * 0.75f,
+                cx + wobble * 0.5f,
+                top,
+            )
+            path.close()
+            glyphFill.color = color
+            canvas.drawPath(path, glyphFill)
+        }
+
+        /**
+         * Helice de tres pas. A velocidade acompanha o nivel da ventilacao e o angulo e ACUMULADO,
+         * nao calculado do tempo absoluto — senao a pa saltaria de posicao a cada mudanca de nivel.
+         */
+        private fun drawFan(canvas: Canvas, cx: Float, cy: Float, radius: Float, dt: Float) {
+            val degreesPerSecond = (110f + fraction * 620f) * direction
+            fanAngle = (fanAngle + degreesPerSecond * dt) % 360f
+            glyphFill.color = accent
+            canvas.save()
+            canvas.rotate(fanAngle, cx, cy)
+            for (i in 0 until 3) {
+                canvas.save()
+                canvas.rotate((i * 120).toFloat(), cx, cy)
+                path.reset()
+                path.moveTo(cx, cy)
+                path.quadTo(cx + radius * 0.62f, cy - radius * 0.30f, cx + radius * 0.95f, cy)
+                path.quadTo(cx + radius * 0.55f, cy + radius * 0.42f, cx, cy)
+                path.close()
+                canvas.drawPath(path, glyphFill)
+                canvas.restore()
+            }
+            canvas.restore()
+            glyphFill.color = 0xFF121620.toInt()
+            canvas.drawCircle(cx, cy, radius * 0.17f, glyphFill)
+        }
+
+        /**
+         * Alto-falante com tres ondas. Subindo, elas acendem de dentro pra fora; descendo, de fora
+         * pra dentro — o sentido do gesto fica legivel sem ler o numero.
+         */
+        private fun drawSpeaker(canvas: Canvas, cx: Float, cy: Float, radius: Float, t: Float) {
+            val left = cx - radius * 0.92f
+            glyphFill.color = accent
+            path.reset()
+            path.moveTo(left, cy - radius * 0.26f)
+            path.lineTo(left + radius * 0.34f, cy - radius * 0.26f)
+            path.lineTo(left + radius * 0.78f, cy - radius * 0.66f)
+            path.lineTo(left + radius * 0.78f, cy + radius * 0.66f)
+            path.lineTo(left + radius * 0.34f, cy + radius * 0.26f)
+            path.lineTo(left, cy + radius * 0.26f)
+            path.close()
+            canvas.drawPath(path, glyphFill)
+
+            glyphStroke.color = accent
+            glyphStroke.strokeWidth = radius * 0.13f
+            val lit = Math.ceil((fraction * 3f).toDouble()).toInt().coerceIn(if (fraction > 0f) 1 else 0, 3)
+            // A onda "viajante" corre pra fora quando sobe e pra dentro quando desce.
+            val travel = if (direction > 0) (t * 2.2f) % 3f else 3f - (t * 2.2f) % 3f
+            for (i in 0 until 3) {
+                val on = i < lit
+                val closeness = 1f - (abs(travel - i) / 1.2f).coerceIn(0f, 1f)
+                val alpha = if (on) (110 + 145 * closeness).toInt() else (30 + 45 * closeness).toInt()
+                glyphStroke.alpha = alpha.coerceIn(0, 255)
+                val rr = radius * (0.42f + i * 0.30f)
+                rect.set(
+                    left + radius * 0.55f - rr,
+                    cy - rr,
+                    left + radius * 0.55f + rr,
+                    cy + rr,
+                )
+                canvas.drawArc(rect, -46f, 92f, false, glyphStroke)
+            }
+            glyphStroke.alpha = 255
+        }
+
+        private fun dp(v: Float) = v * density
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/gestures/GestureSensitivity.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/gestures/GestureSensitivity.kt
@@ -1,0 +1,34 @@
+package br.com.redesurftank.havalshisuku.gestures
+
+/**
+ * Conversao entre o que o dono ajusta e o que o reconhecedor usa.
+ *
+ * O reconhecedor pensa em "distancia por passo, em alturas de tela" — grandeza util pra ele e
+ * incompreensivel numa tela de configuracao. O slider expoe **quanto muda num arraste de meia
+ * tela**, que e a pergunta que a pessoa de fato responde. Este objeto e a ponte entre os dois.
+ *
+ * Puro pra ser testavel: e uma conversao com divisao dos dois lados, exatamente o tipo de conta que
+ * se inverte errado sem ninguem perceber ate o ajuste ficar ao contrario no carro.
+ *
+ * [aspect] entra quando o gesto e HORIZONTAL: pra ele "meia tela" e meia largura, e numa central
+ * esticada (1920x720) ignorar isso faria o numero mostrado mentir por quase 3 vezes.
+ */
+object GestureSensitivity {
+
+    /** Limites do passo, em milesimos de altura de tela. Fora disso nao e ajuste, e engano. */
+    val STEP_RANGE = 8..400
+
+    /** Passo (em milesimos) -> quanto muda num arraste de meia tela. */
+    fun perHalfScreen(stepThousandths: Int, unitPerStep: Float, aspect: Float = 1f): Float {
+        val step = stepThousandths / 1000f
+        if (step <= 0f) return unitPerStep
+        return (0.5f * aspect / step) * unitPerStep
+    }
+
+    /** O caminho de volta: quanto muda em meia tela -> passo (em milesimos), ja limitado. */
+    fun stepThousandths(perHalf: Float, unitPerStep: Float, aspect: Float = 1f): Int {
+        val steps = (perHalf / unitPerStep).coerceAtLeast(0.5f)
+        val step = 0.5f * aspect / steps
+        return Math.round(step * 1000f).coerceIn(STEP_RANGE.first, STEP_RANGE.last)
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/gestures/GestureSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/gestures/GestureSettingsScreen.kt
@@ -1,0 +1,504 @@
+package br.com.redesurftank.havalshisuku.gestures
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.content.edit
+import br.com.redesurftank.App
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Action
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Axis
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Zone
+import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys
+import br.com.redesurftank.havalshisuku.ui.components.AppColors
+import br.com.redesurftank.havalshisuku.ui.components.ImpTokens
+import br.com.redesurftank.havalshisuku.ui.components.StyledCard
+import br.com.redesurftank.havalshisuku.ui.theme.Michroma
+
+/**
+ * Tela de "Gestos na tela", dentro de Recursos.
+ *
+ * Fica aqui, e nao em Configuracoes, porque a configuracao e uma GRADE — dedos x eixo x zona — e
+ * nao um interruptor. A propria central de Recursos declara essa regra: funcao nova entra como card
+ * ali, nao como item solto.
+ *
+ * A tela sempre trabalha em TERCOS. Nao existe escolha separada de "layout" (tela toda / metades /
+ * tercos) porque, podendo repetir a mesma acao, tercos ja e superconjunto de todas: a mesma acao nas
+ * tres zonas E "tela toda". Uma escolha a menos pro dono, um estado a menos pra guardar.
+ */
+@Composable
+fun GestureSettingsScreen(onBackToFeatures: () -> Unit) {
+    val prefs =
+        App.getDeviceProtectedContext()
+            .getSharedPreferences("haval_prefs", Context.MODE_PRIVATE)
+
+    var enabled by remember {
+        mutableStateOf(prefs.getBoolean(SharedPreferencesKeys.ENABLE_SCREEN_GESTURES.key, false))
+    }
+    var bindings by remember { mutableStateOf(ScreenGestureManager.loadBindings()) }
+
+    fun apply(next: GestureBindings) {
+        bindings = next
+        ScreenGestureManager.saveBindings(next)
+    }
+
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
+                .background(AppColors.Background)
+                .verticalScroll(rememberScrollState())
+                .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(18.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Surface(
+                modifier = Modifier.size(46.dp).clickable(onClick = onBackToFeatures),
+                shape = RoundedCornerShape(14.dp),
+                color = ImpTokens.Container,
+            ) {
+                Icon(
+                    Icons.Default.ArrowBack,
+                    contentDescription = "Voltar",
+                    tint = ImpTokens.Accent,
+                    modifier = Modifier.padding(11.dp),
+                )
+            }
+            Spacer(Modifier.width(14.dp))
+            Column {
+                Text(
+                    "Gestos na tela",
+                    color = AppColors.TextPrimary,
+                    fontSize = 32.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    "Arraste com vários dedos, por cima de qualquer app.",
+                    color = AppColors.TextSecondary,
+                    fontSize = 16.sp,
+                )
+            }
+        }
+
+        StyledCard {
+            Column(
+                Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Text(
+                            "Gestos ativos",
+                            color = AppColors.TextPrimary,
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            "O toque não é tirado do app que está na frente — ele continua recebendo o arraste normalmente.",
+                            color = AppColors.TextSecondary,
+                            fontSize = 14.sp,
+                        )
+                    }
+                    Switch(
+                        checked = enabled,
+                        onCheckedChange = {
+                            enabled = it
+                            prefs.edit {
+                                putBoolean(SharedPreferencesKeys.ENABLE_SCREEN_GESTURES.key, it)
+                            }
+                            ScreenGestureManager.setEnabled(it)
+                        },
+                    )
+                }
+                Text(
+                    "Para cima ou para a direita aumenta. A zona é a parte da tela onde o arraste COMEÇA.",
+                    color = ImpTokens.TextMuted,
+                    fontSize = 13.sp,
+                )
+            }
+        }
+
+        SensitivityCard()
+
+        for (fingers in GestureBindings.FINGER_COUNTS) {
+            FingerCountCard(
+                fingers = fingers,
+                bindings = bindings,
+                onChange = { apply(it) },
+            )
+        }
+
+        StyledCard {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(20.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        "Restaurar o padrão",
+                        color = AppColors.TextPrimary,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        "Volta para três dedos: temperatura nas laterais, volume no centro e ventilação na horizontal.",
+                        color = AppColors.TextSecondary,
+                        fontSize = 14.sp,
+                    )
+                }
+                TextChip("Restaurar") { apply(GestureBindings.DEFAULT) }
+            }
+        }
+    }
+}
+
+/**
+ * Sensibilidade de cada ajuste.
+ *
+ * O slider NAO expõe a grandeza interna (distancia por passo, em altura de tela) — expõe o que a
+ * pessoa realmente quer decidir: **quanto muda num arraste de meia tela**. A conversao fica aqui.
+ *
+ * A ventilacao e horizontal, entao "meia tela" pra ela e meia LARGURA; por isso entra a proporcao
+ * da tela na conta, senao o numero mostrado mentiria numa central esticada como esta (1920x720).
+ */
+@Composable
+private fun SensitivityCard() {
+    val configuration = LocalConfiguration.current
+    val aspect =
+        if (configuration.screenHeightDp > 0) {
+            configuration.screenWidthDp.toFloat() / configuration.screenHeightDp
+        } else 1f
+
+    var volumePerHalf by remember {
+        mutableStateOf(
+            perHalfScreen(SharedPreferencesKeys.SCREEN_GESTURE_STEP_VOLUME, 0.030f, 1f)
+        )
+    }
+    var degreesPerHalf by remember {
+        mutableStateOf(
+            perHalfScreen(SharedPreferencesKeys.SCREEN_GESTURE_STEP_TEMPERATURE, 0.075f, 0.5f)
+        )
+    }
+    var fanPerHalf by remember {
+        mutableStateOf(
+            perHalfScreen(SharedPreferencesKeys.SCREEN_GESTURE_STEP_FAN, 0.22f, 1f, aspect)
+        )
+    }
+
+    StyledCard {
+        Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                "Sensibilidade",
+                color = AppColors.TextPrimary,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                "Quanto cada ajuste muda num arraste de meia tela.",
+                color = AppColors.TextSecondary,
+                fontSize = 14.sp,
+            )
+
+            SensitivitySlider(
+                label = "Volume",
+                value = volumePerHalf,
+                range = 3f..40f,
+                readout = "${volumePerHalf.toInt()} pontos",
+                onChange = { volumePerHalf = it },
+                onCommit = {
+                    ScreenGestureManager.saveStepSensitivity(
+                        SharedPreferencesKeys.SCREEN_GESTURE_STEP_VOLUME,
+                        stepThousandths(volumePerHalf, 1f),
+                    )
+                },
+            )
+            SensitivitySlider(
+                label = "Temperatura",
+                value = degreesPerHalf,
+                range = 1f..12f,
+                readout = "${degreesPerHalf.toInt()} °C",
+                onChange = { degreesPerHalf = it },
+                onCommit = {
+                    ScreenGestureManager.saveStepSensitivity(
+                        SharedPreferencesKeys.SCREEN_GESTURE_STEP_TEMPERATURE,
+                        stepThousandths(degreesPerHalf, 0.5f),
+                    )
+                },
+            )
+            SensitivitySlider(
+                label = "Ventilação",
+                value = fanPerHalf,
+                range = 1f..8f,
+                readout = "${fanPerHalf.toInt()} posições",
+                onChange = { fanPerHalf = it },
+                onCommit = {
+                    ScreenGestureManager.saveStepSensitivity(
+                        SharedPreferencesKeys.SCREEN_GESTURE_STEP_FAN,
+                        stepThousandths(fanPerHalf, 1f, aspect),
+                    )
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SensitivitySlider(
+    label: String,
+    value: Float,
+    range: ClosedFloatingPointRange<Float>,
+    readout: String,
+    onChange: (Float) -> Unit,
+    onCommit: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Text(label, color = AppColors.TextPrimary, fontSize = 16.sp, modifier = Modifier.weight(1f))
+            Text("meia tela ≈ $readout", color = ImpTokens.Accent, fontSize = 15.sp)
+        }
+        Slider(
+            value = value,
+            onValueChange = onChange,
+            // Grava so ao SOLTAR: enquanto arrasta, cada quadro do slider reconstruiria o
+            // reconhecedor e gravaria a preferencia sem necessidade.
+            onValueChangeFinished = onCommit,
+            valueRange = range,
+            steps = (range.endInclusive - range.start).toInt() - 1,
+        )
+    }
+}
+
+private fun perHalfScreen(
+    key: SharedPreferencesKeys,
+    fallbackStep: Float,
+    unitPerStep: Float,
+    aspect: Float = 1f,
+): Float =
+    GestureSensitivity.perHalfScreen(
+        ScreenGestureManager.stepSensitivity(key, fallbackStep),
+        unitPerStep,
+        aspect,
+    )
+
+private fun stepThousandths(perHalf: Float, unitPerStep: Float, aspect: Float = 1f): Int =
+    GestureSensitivity.stepThousandths(perHalf, unitPerStep, aspect)
+
+@Composable
+private fun FingerCountCard(
+    fingers: Int,
+    bindings: GestureBindings,
+    onChange: (GestureBindings) -> Unit,
+) {
+    // O aviso existe porque a opcao tem custo REAL, e o dono precisa saber por que ficou estranho
+    // depois — nao porque a gente queira desencorajar.
+    val warning =
+        when (fingers) {
+            4 -> "Com três dedos, o quarto CANCELA o gesto — é o que impede a mão apoiada de virar comando. Usar quatro enfraquece essa proteção."
+            else -> null
+        }
+
+    StyledCard {
+        Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    "$fingers dedos",
+                    color = AppColors.TextPrimary,
+                    fontSize = 20.sp,
+                    fontFamily = Michroma,
+                )
+                Spacer(Modifier.width(12.dp))
+                if (warning != null) {
+                    Badge("atenção", ImpTokens.Attention)
+                } else {
+                    Badge("recomendado", ImpTokens.Accent)
+                }
+            }
+            if (warning != null) {
+                Text(warning, color = ImpTokens.TextMuted, fontSize = 13.sp)
+            }
+
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Spacer(Modifier.width(132.dp))
+                for (label in listOf("esquerda", "centro", "direita")) {
+                    Text(
+                        label,
+                        color = ImpTokens.TextMuted,
+                        fontSize = 12.sp,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                Spacer(Modifier.width(104.dp))
+            }
+
+            AxisRow(fingers, Axis.VERTICAL, "↕  vertical", bindings, onChange)
+            AxisRow(fingers, Axis.HORIZONTAL, "↔  horizontal", bindings, onChange)
+        }
+    }
+}
+
+@Composable
+private fun AxisRow(
+    fingers: Int,
+    axis: Axis,
+    label: String,
+    bindings: GestureBindings,
+    onChange: (GestureBindings) -> Unit,
+) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            label,
+            color = AppColors.TextSecondary,
+            fontSize = 15.sp,
+            modifier = Modifier.width(132.dp),
+        )
+        for (zone in Zone.entries) {
+            Box(modifier = Modifier.weight(1f).padding(end = 8.dp)) {
+                ActionPicker(bindings.actionFor(fingers, axis, zone)) { action ->
+                    onChange(bindings.with(fingers, axis, zone, action))
+                }
+            }
+        }
+        // "Tela toda" nao e um layout separado: e preencher as tres zonas com a mesma acao.
+        Box(modifier = Modifier.width(104.dp)) {
+            ActionPicker(null, placeholder = "tela toda") { action ->
+                onChange(bindings.withWholeRow(fingers, axis, action))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActionPicker(
+    current: Action?,
+    placeholder: String? = null,
+    onPick: (Action?) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Column {
+        Surface(
+            modifier = Modifier.fillMaxWidth().clickable { expanded = true },
+            shape = RoundedCornerShape(10.dp),
+            color = ImpTokens.Ground,
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 11.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    placeholder ?: labelOf(current),
+                    color = if (current == null) ImpTokens.TextMuted else AppColors.TextPrimary,
+                    fontSize = 14.sp,
+                    maxLines = 1,
+                    modifier = Modifier.weight(1f),
+                )
+                Icon(
+                    Icons.Default.ExpandMore,
+                    contentDescription = null,
+                    tint = ImpTokens.TextMuted,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.background(ImpTokens.Container),
+        ) {
+            for (option in listOf(null) + Action.entries) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            labelOf(option),
+                            color =
+                                if (option == current) ImpTokens.Accent else AppColors.TextPrimary,
+                            fontSize = 15.sp,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onPick(option)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Badge(text: String, tint: Color) {
+    Surface(shape = RoundedCornerShape(8.dp), color = tint.copy(alpha = 0.16f)) {
+        Text(
+            text,
+            color = tint,
+            fontSize = 12.sp,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+        )
+    }
+}
+
+@Composable
+private fun TextChip(text: String, onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier.clickable(onClick = onClick),
+        shape = RoundedCornerShape(10.dp),
+        color = ImpTokens.Accent.copy(alpha = 0.16f),
+    ) {
+        Text(
+            text,
+            color = ImpTokens.Accent,
+            fontSize = 15.sp,
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 10.dp),
+        )
+    }
+}
+
+private fun labelOf(action: Action?): String =
+    when (action) {
+        null -> "nenhuma"
+        Action.VOLUME -> "volume"
+        Action.DRIVER_TEMP -> "temp. motorista"
+        Action.PASSENGER_TEMP -> "temp. passageiro"
+        Action.FAN -> "ventilação"
+    }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/gestures/ScreenGestureManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/gestures/ScreenGestureManager.kt
@@ -1,0 +1,504 @@
+package br.com.redesurftank.havalshisuku.gestures
+
+import android.content.Context
+import android.util.Log
+import br.com.redesurftank.App
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Action
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.EvdevTouchParser
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Geometry
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Step
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.SwipeGestureRecognizer
+import br.com.redesurftank.havalshisuku.managers.ServiceManager
+import br.com.redesurftank.havalshisuku.models.CarConstants
+import br.com.redesurftank.havalshisuku.models.CommandListener
+import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys
+import br.com.redesurftank.havalshisuku.utils.ShizukuUtils
+import java.util.Locale
+
+/**
+ * Gestos de tres dedos que valem em QUALQUER tela do carro.
+ *
+ * ## Por que ler `/dev/input` em vez de usar uma janela
+ *
+ * Uma janela overlay so tem dois estados uteis: ou ela e `NOT_TOUCHABLE` e nao ve toque nenhum, ou
+ * ela e tocavel e ENGOLE o toque do app de baixo. Nao existe "ver e deixar passar". Como o gesto
+ * precisa funcionar por cima do Waze, do Spotify e da UI da montadora sem quebrar nenhum deles, a
+ * saida e ler o mesmo dispositivo de entrada que o Android le — passivamente, sem `EVIOCGRAB`.
+ * Quem estiver na frente continua recebendo o toque exatamente como antes.
+ *
+ * O preco disso e que o app de baixo TAMBEM reage ao arraste. Por isso sao tres dedos: praticamente
+ * nenhum app usa esse numero, entao nao ha disputa. Com dois, um arraste na metade esquerda com o
+ * mapa projetado arrastaria o mapa e mexeria na temperatura ao mesmo tempo.
+ *
+ * ## Mapa dos gestos
+ *
+ * | Arraste (3 dedos) | Onde comeca      | Ajusta                     |
+ * |-------------------|------------------|----------------------------|
+ * | vertical          | terco esquerdo   | temperatura do motorista   |
+ * | vertical          | terco central    | volume da midia            |
+ * | vertical          | terco direito    | temperatura do passageiro  |
+ * | horizontal        | tela toda        | ventilacao (fan)           |
+ *
+ * Para cima / para a direita aumenta.
+ */
+object ScreenGestureManager {
+
+    private const val TAG = "ScreenGestures"
+
+    /** Faixa de temperatura aceita pelo HVAC (a mesma do card de A/C do dashboard). */
+    private const val TEMP_MIN = 16.0f
+    private const val TEMP_MAX = 32.0f
+    private const val TEMP_STEP = 0.5f
+    private const val FAN_MAX = 7
+
+    /**
+     * Faixa do volume quando o carro nao publica a dele.
+     *
+     * NAO e o STREAM_MUSIC do Android (esse vai ate 15 e fica cravado no maximo — a montadora
+     * atenua por conta propria, entao `adjustStreamVolume` nao muda nada que se ouca). O volume de
+     * verdade e a chave `sys.settings.audio.media_volume`, a mesma que a funcao de volume inicial
+     * escreve, e vai de 0 a 40.
+     */
+    private const val DEFAULT_VOLUME_MAX = 40
+
+    /** Limites do ajuste de sensibilidade, em milesimos de altura de tela por passo. */
+    val STEP_RANGE = GestureSensitivity.STEP_RANGE
+
+    /** Depois disso, o valor guardado nao vale mais: alguem pode ter mexido pelo painel do carro. */
+    private const val CACHE_TTL_MS = 3_000L
+
+    private const val COLOR_VOLUME = 0xFF4A9EFF.toInt()
+    private const val COLOR_HEATING = 0xFFFF7043.toInt()
+    private const val COLOR_COOLING = 0xFF6FD3FF.toInt()
+    private const val COLOR_FAN = 0xFF4DD0E1.toInt()
+
+    private val parser = EvdevTouchParser()
+    /** Recriado a cada start: a proporcao da tela so e conhecida depois de achar o digitalizador. */
+    @Volatile private var recognizer = SwipeGestureRecognizer()
+
+    @Volatile private var enabled = false
+    @Volatile private var running = false
+    /** Sobe a cada start/stop: o leitor antigo confere e se cala quando fica pra tras. */
+    @Volatile private var generation = 0
+    @Volatile private var geometry: Geometry? = null
+    @Volatile private var readerPid: String? = null
+
+    private val driverTemp = NumericChannel(CarConstants.CAR_HVAC_DRIVER_TEMPERATURE.value)
+    private val passengerTemp = NumericChannel(CarConstants.CAR_HVAC_PASS_TEMPERATURE.value)
+    private val fan = NumericChannel(CarConstants.CAR_HVAC_FAN_SPEED.value)
+    private val mediaVolume = NumericChannel(CarConstants.SYS_SETTINGS_AUDIO_MEDIA_VOLUME.value)
+
+    /** 0 = ainda nao perguntamos ao carro. */
+    @Volatile private var volumeMax = 0
+
+    // ---------------------------------------------------------------------------------------
+    // Ciclo de vida
+    // ---------------------------------------------------------------------------------------
+
+    /** Chamado no boot do servico. Liga so se a preferencia mandar. */
+    fun onServicesReady() {
+        setEnabled(prefEnabled())
+    }
+
+    fun setEnabled(value: Boolean) {
+        enabled = value
+        // Fora da thread de quem chamou: ligar passa por `getevent -pl` via Shizuku, que e uma
+        // chamada BLOQUEANTE. Como isto vem da tela de configuracao, fazer isso na thread da UI
+        // seria um ANR esperando acontecer.
+        runOffMainThread { if (value) startBlocking() else stopBlocking() }
+    }
+
+    private fun runOffMainThread(block: () -> Unit) {
+        Thread {
+                runCatching(block)
+                    .onFailure { Log.e(TAG, "falhou ao (re)configurar os gestos", it) }
+            }
+            .start()
+    }
+
+    private fun prefEnabled(): Boolean =
+        runCatching {
+                App.getDeviceProtectedContext()
+                    .getSharedPreferences("haval_prefs", Context.MODE_PRIVATE)
+                    .getBoolean(SharedPreferencesKeys.ENABLE_SCREEN_GESTURES.key, false)
+            }
+            .getOrDefault(false)
+
+    @Synchronized
+    private fun startBlocking() {
+        if (running) return
+        if (!ShizukuUtils.isShizukuAvailable()) {
+            Log.w(TAG, "Shizuku fora; gestos ficam pra quando ele subir")
+            return
+        }
+        val device = findTouchDevice()
+        if (device == null) {
+            Log.e(TAG, "nenhum dispositivo multitoque encontrado; gestos desligados")
+            return
+        }
+        geometry = buildGeometry(device)
+        running = true
+        val myGeneration = ++generation
+        parser.reset()
+        recognizer = SwipeGestureRecognizer(buildConfig(), loadBindings())
+        killLeftoverReader()
+        Log.w(TAG, "lendo o toque de ${device.path} (${device.maxX}x${device.maxY})")
+        startReader(device.path, myGeneration)
+    }
+
+    @Synchronized
+    private fun stopBlocking() {
+        if (!running) return
+        running = false
+        generation++
+        killLeftoverReader()
+        GestureFeedbackOverlay.hide()
+        Log.w(TAG, "gestos de tela desligados")
+    }
+
+    /**
+     * `echo $$; exec getevent` e o truque que da um cabo pro processo.
+     *
+     * O `runCommandOnBackground` do Shizuku nao devolve handle nenhum — sem isso nao haveria como
+     * parar o leitor depois, e desligar a funcao deixaria um `getevent` rodando pra sempre. Com o
+     * `exec`, o shell VIRA o getevent, entao o pid que ele imprimiu na primeira linha e o pid certo
+     * pra matar.
+     */
+    private fun startReader(devicePath: String, myGeneration: Int) {
+        val command = arrayOf("sh", "-c", "echo $$; exec getevent -l $devicePath")
+        ShizukuUtils.runCommandOnBackground(
+            command,
+            object : CommandListener {
+                private var gotPid = false
+
+                override fun onStdout(line: String) {
+                    if (myGeneration != generation) return
+                    if (!gotPid) {
+                        gotPid = true
+                        val pid = line.trim()
+                        if (pid.toIntOrNull() != null) {
+                            readerPid = pid
+                            rememberReaderPid(pid)
+                            return
+                        }
+                    }
+                    handleLine(line)
+                }
+
+                override fun onStderr(line: String) {
+                    Log.w(TAG, "getevent: $line")
+                }
+
+                override fun onFinished(exitCode: Int) {
+                    if (myGeneration != generation) return
+                    Log.w(TAG, "leitor de toque terminou (code=$exitCode)")
+                    running = false
+                    readerPid = null
+                    // Morte inesperada com a funcao ligada: tenta de novo, sem martelar.
+                    if (enabled) {
+                        Thread {
+                                runCatching { Thread.sleep(5_000) }
+                                if (enabled && myGeneration == generation) startBlocking()
+                            }
+                            .start()
+                    }
+                }
+            },
+        )
+    }
+
+    private fun handleLine(line: String) {
+        val frame = parser.feed(line) ?: return
+        val geo = geometry ?: return
+        val steps = recognizer.onFrame(frame.fingers.map { geo.normalize(it) })
+        if (steps.isEmpty()) return
+        for (step in steps) apply(step)
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Descoberta do dispositivo
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Monta a conversao "coordenada crua -> coordenada da tela".
+     *
+     * A troca de eixos sai das proporcoes (um painel montado de lado reporta retrato onde o display
+     * e paisagem). O espelhamento nao da pra deduzir, entao fica em duas preferencias: se o gesto
+     * responder ao contrario no carro, basta virar a chave por shell — sem build novo.
+     */
+    private fun buildGeometry(device: TouchGestureLogic.TouchDevice): Geometry {
+        val metrics = App.getContext().resources.displayMetrics
+        val swap =
+            TouchGestureLogic.needsAxisSwap(
+                device.maxX,
+                device.maxY,
+                metrics.widthPixels,
+                metrics.heightPixels,
+            )
+        val p = prefs()
+        return Geometry(
+            maxX = device.maxX,
+            maxY = device.maxY,
+            swapXY = swap,
+            invertX = p.getBoolean(SharedPreferencesKeys.SCREEN_GESTURE_INVERT_X.key, false),
+            invertY = p.getBoolean(SharedPreferencesKeys.SCREEN_GESTURE_INVERT_Y.key, false),
+        )
+    }
+
+    private fun findTouchDevice(): TouchGestureLogic.TouchDevice? =
+        runCatching {
+                val out = ShizukuUtils.runCommandAndGetOutput(arrayOf("getevent", "-pl"))
+                TouchGestureLogic.parseTouchDevice(out.orEmpty())
+            }
+            .getOrNull()
+
+    /**
+     * Mata um leitor que tenha sobrado.
+     *
+     * Se o app for morto no meio do caminho, o `getevent` continua vivo do lado do Shizuku — e um
+     * leitor orfao a mais a cada reinicio. Guardar o pid nas preferencias e o que permite limpar
+     * isso mesmo depois de o app inteiro ter reiniciado.
+     */
+    private fun killLeftoverReader() {
+        val pid = readerPid ?: rememberedReaderPid()
+        readerPid = null
+        rememberReaderPid(null)
+        if (pid.isNullOrBlank()) return
+        runCatching { ShizukuUtils.runCommandAndGetOutput(arrayOf("kill", pid)) }
+    }
+
+    private fun prefs() =
+        App.getDeviceProtectedContext().getSharedPreferences("haval_prefs", Context.MODE_PRIVATE)
+
+    private fun rememberReaderPid(pid: String?) {
+        runCatching {
+            prefs().edit().apply {
+                if (pid == null) remove(READER_PID_KEY) else putString(READER_PID_KEY, pid)
+                apply()
+            }
+        }
+    }
+
+    private fun rememberedReaderPid(): String? =
+        runCatching { prefs().getString(READER_PID_KEY, null) }.getOrNull()
+
+    private const val READER_PID_KEY = "screenGestureReaderPid"
+
+    // ---------------------------------------------------------------------------------------
+    // Aplicacao dos passos
+    // ---------------------------------------------------------------------------------------
+
+    private fun apply(step: Step) {
+        runCatching {
+                when (step.action) {
+                    Action.VOLUME -> adjustVolume(step.delta)
+                    Action.DRIVER_TEMP -> adjustTemperature(driverTemp, "Motorista", step.delta)
+                    Action.PASSENGER_TEMP -> adjustTemperature(passengerTemp, "Passageiro", step.delta)
+                    Action.FAN -> adjustFan(step.delta)
+                }
+            }
+            .onFailure { Log.e(TAG, "falhou ao aplicar ${step.action}", it) }
+    }
+
+    /**
+     * Volume pelo canal do CARRO, nao pelo AudioManager.
+     *
+     * A primeira versao usava `adjustStreamVolume(STREAM_MUSIC, ...)` e nao mudava nada: o log de
+     * audio do carro mostrava as chamadas chegando, mas o STREAM_MUSIC tem maximo 15 e a montadora o
+     * mantem cravado nesse maximo, fazendo a atenuacao real por fora. O card mostrava "15" fixo. A
+     * chave que vale e a mesma que a funcao de volume inicial ja escrevia.
+     */
+    private fun adjustVolume(delta: Int) {
+        val sm = ServiceManager.getInstance() ?: return
+        val max = resolveVolumeMax(sm)
+        val current = mediaVolume.read(sm, 0f)
+        val next = (current.toInt() + delta).coerceIn(0, max)
+        if (next.toFloat() == current) return
+        mediaVolume.write(sm, next.toFloat(), next.toString())
+        GestureFeedbackOverlay.show(
+            "Volume",
+            "$next",
+            next.toFloat() / max,
+            COLOR_VOLUME,
+            GestureFeedbackOverlay.Motif.VOLUME,
+            delta,
+        )
+    }
+
+    /** O carro publica a propria faixa; so perguntamos uma vez. */
+    private fun resolveVolumeMax(sm: ServiceManager): Int {
+        val cached = volumeMax
+        if (cached > 0) return cached
+        val raw =
+            runCatching { sm.getData(CarConstants.SYS_SETTINGS_AUDIO_MEDIA_VOLUME_RANGE.value) }
+                .getOrNull()
+        val max = CarVolumeRange.parseMax(raw) ?: DEFAULT_VOLUME_MAX
+        volumeMax = max
+        Log.w(TAG, "faixa do volume do carro: 0..$max (bruto='$raw')")
+        return max
+    }
+
+    /**
+     * Monta os ajustes do reconhecimento, deixando a sensibilidade vir de preferencia quando ela
+     * existir. O padrao do codigo e o ponto de partida; a preferencia so entra pra afinar no carro.
+     */
+    private fun buildConfig(): TouchGestureLogic.Config {
+        val base = TouchGestureLogic.Config(aspect = screenAspect())
+        val p = prefs()
+        fun step(key: SharedPreferencesKeys, fallback: Float): Float {
+            val thousandths = runCatching { p.getInt(key.key, 0) }.getOrDefault(0)
+            // Fora dessa faixa nao e ajuste, e engano: passo minusculo dispara centenas de vezes
+            // num arraste, e gigante nunca dispara.
+            return if (thousandths in STEP_RANGE) thousandths / 1000f else fallback
+        }
+        return base.copy(
+            volumeStep = step(SharedPreferencesKeys.SCREEN_GESTURE_STEP_VOLUME, base.volumeStep),
+            temperatureStep =
+                step(SharedPreferencesKeys.SCREEN_GESTURE_STEP_TEMPERATURE, base.temperatureStep),
+            fanStep = step(SharedPreferencesKeys.SCREEN_GESTURE_STEP_FAN, base.fanStep),
+        )
+    }
+
+    fun loadBindings(): GestureBindings =
+        runCatching {
+                GestureBindings.decode(
+                    prefs().getString(SharedPreferencesKeys.SCREEN_GESTURE_BINDINGS.key, null)
+                )
+            }
+            .getOrDefault(GestureBindings.DEFAULT)
+
+    /** Grava os vinculos e ja passa a valer. */
+    fun saveBindings(bindings: GestureBindings) {
+        runCatching {
+            prefs()
+                .edit()
+                .putString(SharedPreferencesKeys.SCREEN_GESTURE_BINDINGS.key, bindings.encode())
+                .apply()
+        }
+        rebuildRecognizer()
+    }
+
+    /** Sensibilidade de uma acao, em milesimos de altura de tela por passo. */
+    fun saveStepSensitivity(key: SharedPreferencesKeys, thousandths: Int) {
+        runCatching { prefs().edit().putInt(key.key, thousandths).apply() }
+        rebuildRecognizer()
+    }
+
+    fun stepSensitivity(key: SharedPreferencesKeys, fallback: Float): Int {
+        val stored = runCatching { prefs().getInt(key.key, 0) }.getOrDefault(0)
+        return if (stored in STEP_RANGE) stored else Math.round(fallback * 1000f)
+    }
+
+    /**
+     * Troca o reconhecedor em memoria, sem mexer no leitor de toque.
+     *
+     * O reconhecedor guarda os ajustes e as contagens de dedos no construtor, entao mudar a
+     * configuracao exige construir outro. Antes isso reiniciava o leitor inteiro — o que significava
+     * derrubar e resubir um processo (com `getevent -pl` bloqueante no meio) a cada mexida de
+     * slider. Como o campo e `@Volatile` e a thread de leitura so o LE, basta trocar a referencia.
+     */
+    private fun rebuildRecognizer() {
+        if (!running) return
+        runCatching { recognizer = SwipeGestureRecognizer(buildConfig(), loadBindings()) }
+            .onFailure { Log.e(TAG, "falhou ao reconstruir o reconhecedor", it) }
+    }
+
+    /** largura / altura da tela — o reconhecedor precisa disso pra nao deformar os eixos. */
+    private fun screenAspect(): Float =
+        runCatching {
+                val m = App.getContext().resources.displayMetrics
+                if (m.heightPixels > 0) m.widthPixels.toFloat() / m.heightPixels else 1f
+            }
+            .getOrDefault(1f)
+
+    private fun adjustTemperature(channel: NumericChannel, label: String, delta: Int) {
+        // A cor acompanha o sentido, nao o assento: subindo puxa pro laranja, descendo pro azul.
+        val accent = if (delta > 0) COLOR_HEATING else COLOR_COOLING
+        val sm = ServiceManager.getInstance() ?: return
+        val current = channel.read(sm, 22.0f)
+        val next = (current + delta * TEMP_STEP).coerceIn(TEMP_MIN, TEMP_MAX)
+        if (next == current) return
+        val text = String.format(Locale.US, "%.1f", next)
+        channel.write(sm, next, text)
+        GestureFeedbackOverlay.show(
+            label,
+            "$text°",
+            (next - TEMP_MIN) / (TEMP_MAX - TEMP_MIN),
+            accent,
+            // O desenho conta o SENTIDO: floco quando esfria, chama quando esquenta.
+            if (delta > 0) GestureFeedbackOverlay.Motif.HEATING
+            else GestureFeedbackOverlay.Motif.COOLING,
+            delta,
+        )
+    }
+
+    private fun adjustFan(delta: Int) {
+        val sm = ServiceManager.getInstance() ?: return
+        val current = fan.read(sm, 0f)
+        val next = (current.toInt() + delta).coerceIn(0, FAN_MAX)
+        if (next.toFloat() == current) return
+        fan.write(sm, next.toFloat(), next.toString())
+        // Mesmo comportamento do card de A/C do dashboard: cruzar o zero liga/desliga o HVAC, senao
+        // a ventilacao "zero" fica soprando e o "um" nao sopra nada.
+        val power = runCatching { sm.getData(CarConstants.CAR_HVAC_POWER_MODE.value) }.getOrNull()
+        if (next == 0 && power == "1") {
+            sm.updateData(CarConstants.CAR_HVAC_POWER_MODE.value, "0")
+        } else if (next > 0 && power == "0") {
+            sm.updateData(CarConstants.CAR_HVAC_POWER_MODE.value, "1")
+        }
+        GestureFeedbackOverlay.show(
+            "Ventilação",
+            next.toString(),
+            next.toFloat() / FAN_MAX,
+            COLOR_FAN,
+            GestureFeedbackOverlay.Motif.FAN,
+            delta,
+        )
+    }
+
+    /**
+     * Um valor do carro que a gente le, ajusta e escreve de volta.
+     *
+     * A leitura fica guardada por poucos segundos porque um arraste emite varios passos seguidos e
+     * reler o CAN a cada um deixaria o gesto travado. Passado o prazo o valor e relido — se alguem
+     * mexeu pelo painel do carro no meio, a gente parte do numero certo.
+     */
+    private class NumericChannel(val key: String) {
+        @Volatile private var cached = Float.NaN
+        @Volatile private var cachedAt = 0L
+
+        fun read(sm: ServiceManager, fallback: Float): Float {
+            val now = System.currentTimeMillis()
+            if (!cached.isNaN() && now - cachedAt < CACHE_TTL_MS) return cached
+            val raw = runCatching { sm.getData(key) }.getOrNull()
+            val value = raw?.trim()?.toFloatOrNull() ?: fallback
+            cached = value
+            cachedAt = now
+            return value
+        }
+
+        fun write(sm: ServiceManager, value: Float, text: String) {
+            cached = value
+            cachedAt = System.currentTimeMillis()
+            sm.updateData(key, text)
+        }
+    }
+}
+
+/**
+ * Leitura da faixa de volume que o carro publica em `sys.settings.audio.media_volume_range`.
+ *
+ * Objeto separado (e sem nada de Android) so pra ser testavel na JVM: o formato exato do valor nao
+ * esta documentado em lugar nenhum, entao a leitura precisa aguentar as variacoes plausiveis —
+ * "40", "0,40", "(0,40)", "0-40" — em vez de assumir uma.
+ */
+internal object CarVolumeRange {
+    private val NUMBERS = Regex("\\d+")
+
+    /** O MAIOR numero que aparecer; null quando nao da pra confiar no que veio. */
+    fun parseMax(raw: String?): Int? {
+        if (raw.isNullOrBlank()) return null
+        val max = NUMBERS.findAll(raw).mapNotNull { it.value.toIntOrNull() }.maxOrNull() ?: return null
+        return if (max >= 1) max else null
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/gestures/TouchGestureLogic.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/gestures/TouchGestureLogic.kt
@@ -1,0 +1,480 @@
+package br.com.redesurftank.havalshisuku.gestures
+
+import kotlin.math.abs
+
+/**
+ * Logica PURA dos gestos de tela (testavel na JVM, sem Android).
+ *
+ * Divide-se em duas partes independentes:
+ *
+ *  1. [EvdevTouchParser] — le as linhas cruas do `getevent -l` e devolve, a cada SYN_REPORT, onde
+ *     estao os dedos naquele instante. Isso e o que permite enxergar o toque SOBRE qualquer app:
+ *     lemos o mesmo `/dev/input/eventX` que o Android le, sem uma janela nossa no caminho, entao o
+ *     app de baixo continua recebendo o toque normalmente.
+ *
+ *  2. [SwipeGestureRecognizer] — recebe os quadros ja normalizados e decide se virou gesto, com
+ *     quantos dedos, em qual eixo, em qual zona da tela, e quantos "passos" andou. O que cada
+ *     combinacao FAZ vem de [GestureBindings], configurado pelo dono.
+ *
+ * Por que o padrao sao TRES dedos: com dois, um arraste na metade esquerda com o Waze projetado
+ * arrastaria o mapa E mexeria na temperatura ao mesmo tempo — nao roubamos o toque de ninguem, logo
+ * o app de baixo tambem reage. Tres dedos praticamente nenhum app usa, entao nao ha disputa. Quatro
+ * existe como opcao, com o aviso correspondente na tela; dois ficou de fora justamente pela disputa.
+ */
+object TouchGestureLogic {
+
+    /** Ponto normalizado: 0..1 na largura e na altura, origem no canto superior esquerdo. */
+    data class Pt(val x: Float, val y: Float)
+
+    /** Dedo com a coordenada CRUA do driver (antes de normalizar). */
+    data class RawFinger(val x: Int, val y: Int)
+
+    /** Onde estao os dedos no instante de um SYN_REPORT. */
+    data class RawFrame(val fingers: List<RawFinger>)
+
+    enum class Zone { LEFT, CENTER, RIGHT }
+
+    enum class Axis { VERTICAL, HORIZONTAL }
+
+    enum class Action { VOLUME, DRIVER_TEMP, PASSENGER_TEMP, FAN }
+
+    /** Um passo de ajuste: +1 sobe, -1 desce. Um arraste longo emite varios. */
+    data class Step(val action: Action, val delta: Int)
+
+    /**
+     * Ajustes do reconhecimento.
+     *
+     * ## Por que as distancias sao em "alturas de tela", e nao em fracao de cada eixo
+     *
+     * A tela central e 1920x720. Normalizar cada eixo por conta propria deforma o espaco: 100 px na
+     * horizontal viram 0,052 e os mesmos 100 px na vertical viram 0,139. Com isso, um arraste
+     * fisicamente diagonal parece vertical na conta, e um passo horizontal ficaria quase 3x mais
+     * "longo" que o vertical. Entao a comparacao de eixos e a medida dos passos usam a MESMA unidade
+     * — a altura da tela —, multiplicando o deslocamento horizontal pela proporcao [aspect]. So a
+     * ZONA continua em fracao da largura, que e o que ela significa.
+     */
+    data class Config(
+        /** Fronteiras das zonas verticais, em fracao da largura. */
+        val leftEdge: Float = 0.33f,
+        val rightEdge: Float = 0.67f,
+        /** largura / altura da tela. 1 = espaco isotropico (usado nos testes). */
+        val aspect: Float = 1f,
+        /** Quanto o centroide precisa andar (em alturas de tela) pra gente decidir o eixo. */
+        val axisThreshold: Float = 0.022f,
+        /** Quanto o eixo vencedor precisa dominar o outro pra nao ser um arraste diagonal. */
+        val axisDominance: Float = 1.5f,
+        /**
+         * Distancia entre um passo e o proximo, POR ACAO, em alturas de tela.
+         *
+         * Cada ajuste tem uma faixa diferente, e uma distancia unica deixaria uns arrastados e
+         * outros nervosos: o volume vai de 0 a 40, a temperatura de 16 a 32 em degraus de meio grau
+         * e a ventilacao tem so 8 posicoes.
+         *
+         * A primeira calibracao mirava "varrer a faixa inteira num arraste de tela cheia" e ficou
+         * NERVOSA no carro — na temperatura, um arraste natural de uns 300px passava de 7 graus.
+         * Os valores de agora sao mais grossos: nesses mesmos 300px, ~2,8 graus, ~14 de volume e
+         * ~2 posicoes de ventilacao. Ajustaveis por preferencia (em milesimos de altura de tela),
+         * pra afinar no carro sem build novo.
+         */
+        val volumeStep: Float = 0.030f,
+        val temperatureStep: Float = 0.075f,
+        val fanStep: Float = 0.22f,
+        /** Teto de passos por quadro: um arraste MUITO rapido nao pode saltar a faixa inteira. */
+        val maxStepsPerFrame: Int = 6,
+    ) {
+        fun stepFor(action: Action): Float = when (action) {
+            Action.VOLUME -> volumeStep
+            Action.DRIVER_TEMP, Action.PASSENGER_TEMP -> temperatureStep
+            Action.FAN -> fanStep
+        }
+    }
+
+    /**
+     * Como transformar a coordenada crua do driver na coordenada da TELA.
+     *
+     * O eixo do digitalizador nem sempre bate com o do display (ha paineis montados girados ou
+     * espelhados). Os tres ajustes existem pra corrigir isso sem recompilar: da pra conferir no
+     * carro arrastando e vendo se o gesto responde no sentido certo.
+     */
+    data class Geometry(
+        val maxX: Int,
+        val maxY: Int,
+        val swapXY: Boolean = false,
+        val invertX: Boolean = false,
+        val invertY: Boolean = false,
+    ) {
+        fun normalize(f: RawFinger): Pt {
+            val rawX = if (swapXY) f.y else f.x
+            val rawY = if (swapXY) f.x else f.y
+            val spanX = (if (swapXY) maxY else maxX).coerceAtLeast(1)
+            val spanY = (if (swapXY) maxX else maxY).coerceAtLeast(1)
+            var nx = rawX.toFloat() / spanX
+            var ny = rawY.toFloat() / spanY
+            if (invertX) nx = 1f - nx
+            if (invertY) ny = 1f - ny
+            return Pt(nx.coerceIn(0f, 1f), ny.coerceIn(0f, 1f))
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // 1. Leitura do evdev
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * Monta os quadros de toque a partir das linhas do `getevent -l`.
+     *
+     * Suporta os DOIS protocolos multitoque do Linux:
+     *  - Tipo B (o normal hoje): cada dedo mora num "slot"; `ABS_MT_TRACKING_ID` com valor -1
+     *    (0xffffffff) e o dedo saindo. So o que MUDA e reportado, entao o estado dos outros slots
+     *    precisa sobreviver entre um SYN_REPORT e o proximo.
+     *  - Tipo A (paineis antigos): sem slot; os dedos vem em sequencia separados por SYN_MT_REPORT.
+     *
+     * O tipo e detectado pelo que aparece na pratica, nao por configuracao.
+     */
+    class EvdevTouchParser {
+        private val slots = LinkedHashMap<Int, RawFinger>()
+        private var currentSlot = 0
+        private var typeB = false
+
+        // Tipo A: acumula os dedos do quadro corrente.
+        private val typeAFingers = mutableListOf<RawFinger>()
+        private var typeAPendingX: Int? = null
+        private var typeAPendingY: Int? = null
+
+        /** Devolve um quadro quando a linha fecha um SYN_REPORT; caso contrario, null. */
+        fun feed(rawLine: String): RawFrame? {
+            // Caminho quente: um arraste de tres dedos passa perto de 1500 linhas por segundo por
+            // aqui. Descartar de cara o que nao interessa (pressao, area, BTN_TOUCH) evita pagar o
+            // split por regex em cada uma delas.
+            if (!rawLine.contains("ABS_MT_") &&
+                !rawLine.contains("SYN_") &&
+                !rawLine.contains("BTN_TOUCH")
+            ) {
+                return null
+            }
+            // Sem argumento de device o getevent prefixa "/dev/input/eventN:"; com argumento, nao.
+            val line =
+                if (rawLine.startsWith("/dev/input/")) rawLine.substringAfter(": ") else rawLine
+            val parts = line.trim().split(WHITESPACE)
+            if (parts.size < 3) return null
+            val code = parts[1]
+            val value = parts[2]
+
+            when (code) {
+                "ABS_MT_SLOT" -> {
+                    typeB = true
+                    currentSlot = parseHex(value) ?: currentSlot
+                }
+                "ABS_MT_TRACKING_ID" -> {
+                    typeB = true
+                    val id = parseHex(value) ?: return null
+                    // 0xffffffff (-1) = dedo saiu.
+                    if (id == -1) slots.remove(currentSlot)
+                    else slots.getOrPut(currentSlot) { RawFinger(0, 0) }
+                }
+                "ABS_MT_POSITION_X" -> {
+                    val v = parseHex(value) ?: return null
+                    if (typeB) {
+                        val f = slots[currentSlot] ?: RawFinger(0, 0)
+                        slots[currentSlot] = f.copy(x = v)
+                    } else typeAPendingX = v
+                }
+                "ABS_MT_POSITION_Y" -> {
+                    val v = parseHex(value) ?: return null
+                    if (typeB) {
+                        val f = slots[currentSlot] ?: RawFinger(0, 0)
+                        slots[currentSlot] = f.copy(y = v)
+                    } else typeAPendingY = v
+                }
+                "BTN_TOUCH" -> {
+                    // Rede de seguranca contra dedo fantasma. O caminho normal de saida e o
+                    // TRACKING_ID = -1 por slot; se um driver deixar de mandar algum, o slot ficaria
+                    // ocupado PRA SEMPRE e todo gesto seguinte contaria um dedo a mais — ou seja, a
+                    // funcao inteira morreria ate reiniciar o app. BTN_TOUCH UP significa "nao ha
+                    // mais nenhum dedo na tela", entao limpa tudo sem depender de ninguem.
+                    if (value.equals("UP", ignoreCase = true)) slots.clear()
+                }
+                "SYN_MT_REPORT" -> {
+                    val x = typeAPendingX
+                    val y = typeAPendingY
+                    if (x != null && y != null) typeAFingers.add(RawFinger(x, y))
+                    typeAPendingX = null
+                    typeAPendingY = null
+                }
+                "SYN_REPORT" -> {
+                    return if (typeB) {
+                        RawFrame(slots.values.toList())
+                    } else {
+                        val frame = RawFrame(typeAFingers.toList())
+                        typeAFingers.clear()
+                        typeAPendingX = null
+                        typeAPendingY = null
+                        frame
+                    }
+                }
+            }
+            return null
+        }
+
+        /** Esquece o estado — usado quando o processo do getevent cai e volta. */
+        fun reset() {
+            slots.clear()
+            typeAFingers.clear()
+            typeAPendingX = null
+            typeAPendingY = null
+            currentSlot = 0
+        }
+
+        private companion object {
+            val WHITESPACE = Regex("\\s+")
+
+            /** getevent imprime valores em hex de 8 digitos; 0xffffffff e o -1 do tracking id. */
+            fun parseHex(v: String): Int? = v.toLongOrNull(16)?.toInt()
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // 2. Reconhecimento do gesto
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * Detecta arrastes de tres dedos e os converte em passos de ajuste.
+     *
+     * Regras que valem a pena saber:
+     *  - a ZONA e decidida no momento em que o terceiro dedo encosta, pelo centroide inicial. Assim
+     *    o gesto nao "troca de funcao" no meio se a mao derivar pro lado.
+     *  - o EIXO tambem so e decidido uma vez, e so quando um dos dois dominar o outro — arraste
+     *    diagonal nao vira nada, em vez de virar as duas coisas.
+     *  - um quarto dedo CANCELA. Mao apoiada na tela nao pode virar comando.
+     *  - depois de um gesto (ou de um cancelamento) e preciso TIRAR todos os dedos pra comecar
+     *    outro: sem isso, levantar e reencostar um dedo no meio do arraste dispararia de novo.
+     */
+    class SwipeGestureRecognizer(
+        private val config: Config = Config(),
+        private val bindings: GestureBindings = GestureBindings.DEFAULT,
+    ) {
+
+        private enum class State { IDLE, ARMED, CANCELLED }
+
+        private val activeCounts = bindings.activeFingerCounts()
+        private val maxFingers = bindings.maxFingers()
+
+        private var state = State.IDLE
+        private var zone = Zone.CENTER
+        private var axis: Axis? = null
+        private var armedFingers = 0
+        private var emittedAnyStep = false
+        private var start = Pt(0f, 0f)
+        private var lastStep = Pt(0f, 0f)
+
+        /** Eixo escolhido no gesto corrente (null enquanto ainda nao deu pra decidir). */
+        val currentAxis: Axis?
+            get() = axis
+
+        fun onFrame(fingers: List<Pt>): List<Step> {
+            val n = fingers.size
+
+            if (n == 0) {
+                state = State.IDLE
+                axis = null
+                return emptyList()
+            }
+
+            if (activeCounts.isEmpty()) return emptyList()
+
+            if (n > maxFingers) {
+                // Mao apoiada / dedo a mais do que qualquer gesto configurado: cancela e so libera
+                // quando a tela ficar limpa.
+                state = State.CANCELLED
+                axis = null
+                return emptyList()
+            }
+
+            if (state == State.CANCELLED) return emptyList()
+
+            val centroid = centroidOf(fingers)
+
+            if (n !in activeCounts) {
+                // Ou os dedos ainda estao encostando, ou um saiu no meio do gesto.
+                if (state == State.ARMED) state = State.CANCELLED
+                return emptyList()
+            }
+
+            if (state == State.IDLE) {
+                arm(n, centroid)
+                return emptyList()
+            }
+
+            if (n != armedFingers) {
+                // Com mais de uma contagem configurada, encostar tres dedos passa por dois. Enquanto
+                // NENHUM passo saiu, isso e so a mao pousando: re-arma na contagem nova em vez de
+                // disparar a acao errada. Depois do primeiro passo, mudar de contagem cancela.
+                if (emittedAnyStep) {
+                    state = State.CANCELLED
+                    return emptyList()
+                }
+                arm(n, centroid)
+                return emptyList()
+            }
+
+            val dxTotal = centroid.x - start.x
+            val dyTotal = centroid.y - start.y
+
+            if (axis == null) {
+                // Ambos em alturas de tela, senao a tela larga faz todo arraste parecer vertical.
+                val ax = abs(dxTotal) * config.aspect
+                val ay = abs(dyTotal)
+                axis = when {
+                    ay >= config.axisThreshold && ay >= ax * config.axisDominance -> Axis.VERTICAL
+                    ax >= config.axisThreshold && ax >= ay * config.axisDominance -> Axis.HORIZONTAL
+                    else -> null
+                }
+                if (axis == null) return emptyList()
+                // O limiar ja "gastou" o caminho ate aqui: o primeiro passo conta a partir do
+                // ponto onde o eixo ficou claro, senao o gesto nasce ja com um passo de brinde.
+                lastStep = centroid
+                return emptyList()
+            }
+
+            val action = bindings.actionFor(armedFingers, axis!!, zone)
+            if (action == null) {
+                // Combinacao sem acao configurada: o gesto e inerte ate a mao sair da tela.
+                state = State.CANCELLED
+                return emptyList()
+            }
+            val stepDistance = config.stepFor(action)
+            // Deslocamento desde o ultimo passo, sempre em alturas de tela.
+            val travelled = when (axis) {
+                Axis.VERTICAL -> centroid.y - lastStep.y
+                else -> (centroid.x - lastStep.x) * config.aspect
+            }
+            val whole = (abs(travelled) / stepDistance).toInt()
+            if (whole <= 0) return emptyList()
+
+            val count = whole.coerceAtMost(config.maxStepsPerFrame)
+            // Consome a distancia INTEIRA mesmo quando o teto corta os passos: o excedente de um
+            // arraste violento e pra ser descartado, nao pra ficar guardado e sair depois.
+            val consumed = whole * stepDistance * (if (travelled < 0) -1f else 1f)
+            lastStep = when (axis) {
+                Axis.VERTICAL -> lastStep.copy(y = lastStep.y + consumed)
+                else -> lastStep.copy(x = lastStep.x + consumed / config.aspect)
+            }
+
+            // Y cresce pra BAIXO na tela: arrastar pra baixo DIMINUI, pra cima aumenta.
+            // Na horizontal, pra direita aumenta.
+            val forward = travelled > 0
+            val delta = when (axis) {
+                Axis.VERTICAL -> if (forward) -1 else 1
+                else -> if (forward) 1 else -1
+            }
+            emittedAnyStep = true
+            return List(count) { Step(action, delta) }
+        }
+
+        fun reset() {
+            state = State.IDLE
+            axis = null
+            emittedAnyStep = false
+        }
+
+        private fun arm(fingers: Int, centroid: Pt) {
+            state = State.ARMED
+            armedFingers = fingers
+            axis = null
+            emittedAnyStep = false
+            start = centroid
+            lastStep = centroid
+            zone = zoneOf(centroid.x)
+        }
+
+        private fun zoneOf(x: Float): Zone = when {
+            x < config.leftEdge -> Zone.LEFT
+            x > config.rightEdge -> Zone.RIGHT
+            else -> Zone.CENTER
+        }
+
+        private fun centroidOf(fingers: List<Pt>): Pt {
+            var sx = 0f
+            var sy = 0f
+            for (f in fingers) {
+                sx += f.x
+                sy += f.y
+            }
+            return Pt(sx / fingers.size, sy / fingers.size)
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // 3. Descoberta do device da tela
+    // -----------------------------------------------------------------------------------------
+
+    data class TouchDevice(val path: String, val maxX: Int, val maxY: Int)
+
+    /**
+     * Acha a tela na saida do `getevent -pl`.
+     *
+     * Nao da pra cravar `/dev/input/event3` no codigo: a numeracao muda entre firmwares e ate entre
+     * boots. Procuramos o device que reporta `ABS_MT_POSITION_X` e, havendo mais de um (algumas
+     * unidades expoem um digitalizador secundario), fica o de maior resolucao — que e o painel
+     * principal.
+     */
+    fun parseTouchDevice(geteventPl: String): TouchDevice? {
+        var path: String? = null
+        var maxX = 0
+        var maxY = 0
+        var best: TouchDevice? = null
+
+        fun flush() {
+            val p = path ?: return
+            if (maxX > 0 && maxY > 0) {
+                val candidate = TouchDevice(p, maxX, maxY)
+                val current = best
+                if (current == null || candidate.maxX.toLong() * candidate.maxY >
+                    current.maxX.toLong() * current.maxY
+                ) {
+                    best = candidate
+                }
+            }
+        }
+
+        for (raw in geteventPl.lineSequence()) {
+            val line = raw.trim()
+            if (line.startsWith("add device")) {
+                flush()
+                path = line.substringAfter(": ", "").trim().ifEmpty { null }
+                maxX = 0
+                maxY = 0
+                continue
+            }
+            if (line.startsWith("ABS_MT_POSITION_X")) maxX = maxOf(maxX, parseMax(line))
+            if (line.startsWith("ABS_MT_POSITION_Y")) maxY = maxOf(maxY, parseMax(line))
+        }
+        flush()
+        return best
+    }
+
+    /**
+     * O digitalizador esta girado 90 graus em relacao ao display?
+     *
+     * Ha paineis montados de lado, em que `ABS_MT_POSITION_X` corre na ALTURA da tela. Comparar as
+     * proporcoes resolve o caso comum sem precisar de ninguem no carro: se um lado e paisagem e o
+     * outro e retrato, os eixos estao trocados. Espelhamento (crescer pro lado errado) isso NAO
+     * detecta — pra isso existem os ajustes de inversao, que se conferem com um gesto.
+     */
+    fun needsAxisSwap(deviceMaxX: Int, deviceMaxY: Int, displayW: Int, displayH: Int): Boolean {
+        if (deviceMaxX <= 0 || deviceMaxY <= 0 || displayW <= 0 || displayH <= 0) return false
+        val deviceLandscape = deviceMaxX >= deviceMaxY
+        val displayLandscape = displayW >= displayH
+        return deviceLandscape != displayLandscape
+    }
+
+    /** "ABS_MT_POSITION_X : value 0, min 0, max 1919, fuzz 0, flat 0, resolution 0" -> 1919 */
+    private fun parseMax(line: String): Int {
+        val idx = line.indexOf("max ")
+        if (idx < 0) return 0
+        val tail = line.substring(idx + 4).trimStart()
+        val end = tail.indexOfFirst { !it.isDigit() && it != '-' }
+        val number = if (end < 0) tail else tail.substring(0, end)
+        return number.toIntOrNull()?.coerceAtLeast(0) ?: 0
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthModeManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthModeManager.kt
@@ -150,6 +150,8 @@ object StealthModeManager {
             SharedPreferencesKeys.MOBILE_DATA_BLOCK_ON_PROJECTION,
             SharedPreferencesKeys.BLOCK_DATATRACK_TELEMETRY,
             // --- Aviso de voz do cinto: o duck da música é ativação própria ---
+            // --- Gestos na tela: leem o toque e desenham por cima de qualquer app ---
+            SharedPreferencesKeys.ENABLE_SCREEN_GESTURES,
         )
 
     /**
@@ -815,6 +817,9 @@ object StealthModeManager {
             step("unmount_carplay") { CarPlayPatchManager.removeMounts() }
             // onServicesReady() só LIGA; para desligar é o setEnabled(false) (a pref já está false).
             step("stop_hot_router") { HotRouterManager.getInstance().setEnabled(false) }
+            step("stop_screen_gestures") {
+                br.com.redesurftank.havalshisuku.gestures.ScreenGestureManager.setEnabled(false)
+            }
             // Devolve o 4G e a telemetria OEM: no modo o carro tem que se comportar como de fábrica.
             step("release_mobile_data") { MobileDataManager.recomputeAndApply(appContext) }
             step("release_datatrack") { MobileDataManager.applyDatatrackState() }
@@ -901,6 +906,9 @@ object StealthModeManager {
             }
             // onServicesReady() é o ponto do boot: liga só se a pref restaurada mandar.
             step("restart_hot_router") { HotRouterManager.getInstance().onServicesReady() }
+            step("restart_screen_gestures") {
+                br.com.redesurftank.havalshisuku.gestures.ScreenGestureManager.onServicesReady()
+            }
             step("reapply_mobile_data") { MobileDataManager.recomputeAndApply(appContext) }
             step("reapply_datatrack") { MobileDataManager.applyDatatrackState() }
             step("reapply_debloat") { ServiceManager.getInstance().ensureDebloatedSystemApps() }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -451,5 +451,38 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
     DATATRACK_DISABLED_BY_APP("datatrackDisabledByApp", "Controle interno: DataTrack desabilitado por este app"),
     MOBILE_DATA_TRAFFIC_ACCUM_BYTES("mobileDataTrafficAccumBytes", "Acumulado de bytes móveis no ciclo (fallback TrafficStats)"),
     MOBILE_DATA_TRAFFIC_LAST_READING("mobileDataTrafficLastReading", "Última leitura do TrafficStats móvel (controle interno)"),
-    MOBILE_DATA_TRAFFIC_CYCLE_TAG("mobileDataTrafficCycleTag", "Ciclo atual do acumulador de bytes (controle interno)")
+    MOBILE_DATA_TRAFFIC_CYCLE_TAG("mobileDataTrafficCycleTag", "Ciclo atual do acumulador de bytes (controle interno)"),
+    // ===== Gestos de vários dedos na tela =====
+    ENABLE_SCREEN_GESTURES(
+            "enableScreenGestures",
+            "Gestos de vários dedos na tela para volume, temperatura e ventilação"
+    ),
+    SCREEN_GESTURE_BINDINGS(
+            "screenGestureBindings",
+            "Quais gestos fazem o quê (dedos:eixo:zona=ação)"
+    ),
+    // Sensibilidade, em MILÉSIMOS de altura de tela por passo. Maior = mais lento. A tela mostra
+    // isso traduzido para "quanto muda num arraste de meia tela".
+    SCREEN_GESTURE_STEP_VOLUME(
+            "screenGestureStepVolume",
+            "Sensibilidade do volume (milésimos de altura de tela por passo)"
+    ),
+    SCREEN_GESTURE_STEP_TEMPERATURE(
+            "screenGestureStepTemperature",
+            "Sensibilidade da temperatura (milésimos de altura de tela por meio grau)"
+    ),
+    SCREEN_GESTURE_STEP_FAN(
+            "screenGestureStepFan",
+            "Sensibilidade da ventilação (milésimos de altura de tela por posição)"
+    ),
+    // Calibração do digitalizador. Só existem para acertar o sentido do gesto sem recompilar, caso
+    // um painel reporte a coordenada espelhada; a troca de eixos é detectada sozinha.
+    SCREEN_GESTURE_INVERT_X(
+            "screenGestureInvertX",
+            "Calibração: inverter o eixo horizontal do toque"
+    ),
+    SCREEN_GESTURE_INVERT_Y(
+            "screenGestureInvertY",
+            "Calibração: inverter o eixo vertical do toque"
+    )
 }

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
@@ -726,6 +726,12 @@ public class ForegroundService extends Service implements Shizuku.OnBinderDeadLi
         });
 
         try {
+            br.com.redesurftank.havalshisuku.gestures.ScreenGestureManager.INSTANCE.onServicesReady();
+        } catch (Exception e) {
+            Log.e(TAG, "Error starting ScreenGestures: " + e.getMessage(), e);
+        }
+
+        try {
             HotRouterManager.getInstance().onServicesReady();
         } catch (Exception e) {
             Log.e(TAG, "Error starting HotRouter: " + e.getMessage(), e);

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/components/FeaturesHubScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/components/FeaturesHubScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Construction
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.TouchApp
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
@@ -39,6 +40,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import br.com.redesurftank.App
+import br.com.redesurftank.havalshisuku.gestures.GestureSettingsScreen
 import br.com.redesurftank.havalshisuku.ambientlight.AmbientLightSettingsScreen
 import br.com.redesurftank.havalshisuku.models.SharedPreferencesKeys
 import br.com.redesurftank.havalshisuku.ui.theme.Michroma
@@ -50,15 +52,21 @@ fun FeaturesHubScreen() {
     when (selectedFeature) {
         "score" -> TripConsistencyScreen(onBackToFeatures = { selectedFeature = null })
         "ambient_light" -> AmbientLightSettingsScreen(onBackToFeatures = { selectedFeature = null })
+        "gestures" -> GestureSettingsScreen(onBackToFeatures = { selectedFeature = null })
         else -> FeaturesHome(
             onOpenScore = { selectedFeature = "score" },
-            onOpenAmbientLight = { selectedFeature = "ambient_light" }
+            onOpenAmbientLight = { selectedFeature = "ambient_light" },
+            onOpenGestures = { selectedFeature = "gestures" }
         )
     }
 }
 
 @Composable
-private fun FeaturesHome(onOpenScore: () -> Unit, onOpenAmbientLight: () -> Unit) {
+private fun FeaturesHome(
+    onOpenScore: () -> Unit,
+    onOpenAmbientLight: () -> Unit,
+    onOpenGestures: () -> Unit
+) {
     val prefs =
         App.getDeviceProtectedContext()
             .getSharedPreferences("haval_prefs", Context.MODE_PRIVATE)
@@ -115,8 +123,17 @@ private fun FeaturesHome(onOpenScore: () -> Unit, onOpenAmbientLight: () -> Unit
             }
         }
 
-        if (ambientLightEnabled) {
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(18.dp)) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(18.dp)) {
+            FeatureCard(
+                title = "Gestos na tela",
+                description = "Arraste com varios dedos, por cima de qualquer app, para volume, temperatura e ventilacao.",
+                status = "Disponivel",
+                icon = Icons.Default.TouchApp,
+                enabled = true,
+                modifier = Modifier.weight(1f),
+                onClick = onOpenGestures
+            )
+            if (ambientLightEnabled) {
                 FeatureCard(
                     title = "Vallet",
                     description = "Área reservada para controles e regras de uso em modo manobrista.",
@@ -126,6 +143,7 @@ private fun FeaturesHome(onOpenScore: () -> Unit, onOpenAmbientLight: () -> Unit
                     modifier = Modifier.weight(1f),
                     onClick = {}
                 )
+            } else {
                 Spacer(modifier = Modifier.weight(1f))
             }
         }

--- a/app/src/test/java/br/com/redesurftank/havalshisuku/gestures/CarVolumeRangeTest.kt
+++ b/app/src/test/java/br/com/redesurftank/havalshisuku/gestures/CarVolumeRangeTest.kt
@@ -1,0 +1,33 @@
+package br.com.redesurftank.havalshisuku.gestures
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * O formato de `sys.settings.audio.media_volume_range` não está documentado, então a leitura tem que
+ * aguentar as variações plausíveis em vez de assumir uma — e devolver null quando não dá pra
+ * confiar, pra cair na faixa padrão do carro (0..40) em vez de num máximo inventado.
+ */
+class CarVolumeRangeTest {
+
+    @Test
+    fun readsTheMaximumInTheUsualShapes() {
+        assertEquals(40, CarVolumeRange.parseMax("40"))
+        assertEquals(40, CarVolumeRange.parseMax("0,40"))
+        assertEquals(40, CarVolumeRange.parseMax("(0,40)"))
+        assertEquals(40, CarVolumeRange.parseMax("0-40"))
+        assertEquals(40, CarVolumeRange.parseMax("[0, 40]"))
+        assertEquals(40, CarVolumeRange.parseMax(" min 0 max 40 "))
+    }
+
+    @Test
+    fun refusesWhatItCannotTrust() {
+        assertNull(CarVolumeRange.parseMax(null))
+        assertNull(CarVolumeRange.parseMax(""))
+        assertNull(CarVolumeRange.parseMax("   "))
+        assertNull(CarVolumeRange.parseMax("desconhecido"))
+        // Um máximo de zero deixaria o volume travado; melhor cair no padrão.
+        assertNull(CarVolumeRange.parseMax("0"))
+    }
+}

--- a/app/src/test/java/br/com/redesurftank/havalshisuku/gestures/GestureBindingsTest.kt
+++ b/app/src/test/java/br/com/redesurftank/havalshisuku/gestures/GestureBindingsTest.kt
@@ -1,0 +1,162 @@
+package br.com.redesurftank.havalshisuku.gestures
+
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Action
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Axis
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Config
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Pt
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Step
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.SwipeGestureRecognizer
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Zone
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GestureBindingsTest {
+
+    // ---------------------------------------------------------------------------------------
+    // Modelo e persistência
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    fun defaultIsWhatAlwaysWorkedBeforeTheScreenExisted() {
+        val d = GestureBindings.DEFAULT
+        assertEquals(Action.DRIVER_TEMP, d.actionFor(3, Axis.VERTICAL, Zone.LEFT))
+        assertEquals(Action.VOLUME, d.actionFor(3, Axis.VERTICAL, Zone.CENTER))
+        assertEquals(Action.PASSENGER_TEMP, d.actionFor(3, Axis.VERTICAL, Zone.RIGHT))
+        for (zone in Zone.entries) {
+            assertEquals(Action.FAN, d.actionFor(3, Axis.HORIZONTAL, zone))
+        }
+        assertEquals(setOf(3), d.activeFingerCounts())
+        assertNull(d.actionFor(2, Axis.VERTICAL, Zone.LEFT))
+    }
+
+    @Test
+    fun survivesARoundTrip() {
+        val custom =
+            GestureBindings.DEFAULT
+                .with(4, Axis.HORIZONTAL, Zone.RIGHT, Action.VOLUME)
+                .with(4, Axis.VERTICAL, Zone.CENTER, Action.FAN)
+        assertEquals(custom, GestureBindings.decode(custom.encode()))
+    }
+
+    @Test
+    fun turningEverythingOffIsNotTheSameAsNeverConfiguring() {
+        // Sem o marcador, apagar o último vínculo faria os padrões ressuscitarem no próximo boot.
+        var empty = GestureBindings.DEFAULT
+        for (zone in Zone.entries) {
+            empty = empty.with(3, Axis.VERTICAL, zone, null).with(3, Axis.HORIZONTAL, zone, null)
+        }
+        assertTrue(empty.isEmpty())
+        assertEquals(GestureBindings.EMPTY_MARKER, empty.encode())
+        assertTrue(GestureBindings.decode(empty.encode()).isEmpty())
+
+        // Ausente ou em branco continua caindo no padrão.
+        assertEquals(GestureBindings.DEFAULT, GestureBindings.decode(null))
+        assertEquals(GestureBindings.DEFAULT, GestureBindings.decode("   "))
+    }
+
+    @Test
+    fun aBrokenEntryIsSkippedInsteadOfLosingEverything() {
+        // Configuração meio lida é melhor que gesto nenhum: o dono conserta a que sumiu.
+        // "2:H:R" entra na lista do lixo de proposito: dois dedos saiu das opcoes, entao uma
+        // configuracao antiga que o tenha precisa ser descartada em vez de reviver.
+        val raw = "3:V:C=volume;lixo;9:V:L=fan;3:X:L=volume;3:V:Z=fan;3:V:L=inexistente;2:H:R=fan;4:H:R=fan"
+        val b = GestureBindings.decode(raw)
+        assertEquals(Action.VOLUME, b.actionFor(3, Axis.VERTICAL, Zone.CENTER))
+        assertEquals(Action.FAN, b.actionFor(4, Axis.HORIZONTAL, Zone.RIGHT))
+        assertNull(b.actionFor(2, Axis.HORIZONTAL, Zone.RIGHT))
+        assertEquals(setOf(3, 4), b.activeFingerCounts())
+        assertNull(b.actionFor(3, Axis.VERTICAL, Zone.LEFT))
+    }
+
+    @Test
+    fun wholeRowIsJustTheSameActionInEveryZone() {
+        val b = GestureBindings.DEFAULT.withWholeRow(4, Axis.VERTICAL, Action.VOLUME)
+        for (zone in Zone.entries) {
+            assertEquals(Action.VOLUME, b.actionFor(4, Axis.VERTICAL, zone))
+        }
+        assertEquals(setOf(3, 4), b.activeFingerCounts())
+        assertEquals(4, b.maxFingers())
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Reconhecimento com mais de uma contagem configurada
+    // ---------------------------------------------------------------------------------------
+
+    private fun fingersAt(center: Pt, n: Int): List<Pt> =
+        (0 until n).map { Pt(center.x + (it - (n - 1) / 2f) * 0.01f, center.y) }
+
+    /** Encosta os dedos UM A UM (como acontece de verdade) e depois arrasta. */
+    private fun landAndSwipe(
+        r: SwipeGestureRecognizer,
+        n: Int,
+        from: Pt,
+        to: Pt,
+    ): List<Step> {
+        val out = mutableListOf<Step>()
+        for (k in 1..n) out += r.onFrame(fingersAt(from, k))
+        for (i in 1..40) {
+            val t = i.toFloat() / 40
+            out += r.onFrame(fingersAt(Pt(from.x, from.y + (to.y - from.y) * t), n))
+        }
+        return out
+    }
+
+    @Test
+    fun landingFourFingersDoesNotFireTheThreeFingerAction() {
+        // Ao encostar quatro dedos passa-se por três. Enquanto nenhum passo saiu, isso é só a mão
+        // pousando — tem que re-armar na contagem nova, não disparar a ação de três dedos.
+        val bindings = GestureBindings.DEFAULT.withWholeRow(4, Axis.VERTICAL, Action.FAN)
+        val steps = landAndSwipe(SwipeGestureRecognizer(Config(), bindings), 4, Pt(0.5f, 0.15f), Pt(0.5f, 0.85f))
+        assertTrue(steps.isNotEmpty())
+        assertTrue("saiu $steps", steps.all { it.action == Action.FAN })
+    }
+
+    @Test
+    fun fourFingersWorkWhenTheOwnerBindsThem() {
+        val bindings = GestureBindings.DEFAULT.withWholeRow(4, Axis.VERTICAL, Action.FAN)
+        val steps = landAndSwipe(SwipeGestureRecognizer(Config(), bindings), 4, Pt(0.5f, 0.15f), Pt(0.5f, 0.85f))
+        assertTrue(steps.isNotEmpty())
+        assertTrue(steps.all { it.action == Action.FAN && it.delta == -1 })
+    }
+
+    @Test
+    fun anUnboundCombinationIsInert() {
+        // Três dedos na horizontal sem vínculo: não vira nada, e não vira outra coisa por engano.
+        var bindings = GestureBindings.DEFAULT
+        for (zone in Zone.entries) bindings = bindings.with(3, Axis.HORIZONTAL, zone, null)
+        val r = SwipeGestureRecognizer(Config(), bindings)
+        val out = mutableListOf<Step>()
+        for (k in 1..3) out += r.onFrame(fingersAt(Pt(0.15f, 0.5f), k))
+        for (i in 1..40) {
+            out += r.onFrame(fingersAt(Pt(0.15f + 0.7f * i / 40f, 0.5f), 3))
+        }
+        assertTrue("saiu $out", out.isEmpty())
+    }
+
+    @Test
+    fun aCountAboveEverythingConfiguredCancels() {
+        // Só três dedos configurados: quatro é mão apoiada, não gesto.
+        val steps =
+            landAndSwipe(
+                SwipeGestureRecognizer(Config(), GestureBindings.DEFAULT),
+                4,
+                Pt(0.5f, 0.15f),
+                Pt(0.5f, 0.85f),
+            )
+        assertTrue(steps.isEmpty())
+    }
+
+    @Test
+    fun withNothingConfiguredNoGestureEverFires() {
+        val steps =
+            landAndSwipe(
+                SwipeGestureRecognizer(Config(), GestureBindings.decode(GestureBindings.EMPTY_MARKER)),
+                3,
+                Pt(0.5f, 0.15f),
+                Pt(0.5f, 0.85f),
+            )
+        assertTrue(steps.isEmpty())
+    }
+}

--- a/app/src/test/java/br/com/redesurftank/havalshisuku/gestures/GestureSensitivityTest.kt
+++ b/app/src/test/java/br/com/redesurftank/havalshisuku/gestures/GestureSensitivityTest.kt
@@ -1,0 +1,51 @@
+package br.com.redesurftank.havalshisuku.gestures
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A conversão tem divisão dos dois lados — é o tipo de conta que se inverte errado sem ninguém
+ * perceber até o ajuste ficar ao contrário no carro.
+ */
+class GestureSensitivityTest {
+
+    @Test
+    fun theSliderValueSurvivesTheRoundTrip() {
+        // Temperatura: meio grau por passo.
+        for (degrees in listOf(2f, 3f, 6f, 10f)) {
+            val step = GestureSensitivity.stepThousandths(degrees, 0.5f)
+            assertEquals(degrees, GestureSensitivity.perHalfScreen(step, 0.5f), 0.25f)
+        }
+        // Volume: um ponto por passo.
+        for (points in listOf(5f, 17f, 30f)) {
+            val step = GestureSensitivity.stepThousandths(points, 1f)
+            assertEquals(points, GestureSensitivity.perHalfScreen(step, 1f), 1f)
+        }
+    }
+
+    @Test
+    fun horizontalUsesHalfTheWIDTH() {
+        // Numa central 1920x720, ignorar a proporção faria o número mostrado mentir por quase 3x.
+        val aspect = 1920f / 720f
+        val step = GestureSensitivity.stepThousandths(6f, 1f, aspect)
+        assertEquals(6f, GestureSensitivity.perHalfScreen(step, 1f, aspect), 0.5f)
+        // O mesmo passo lido SEM a proporção daria um número bem menor — é a prova de que ela pesa.
+        assertTrue(GestureSensitivity.perHalfScreen(step, 1f) < 3f)
+    }
+
+    @Test
+    fun theCurrentDefaultsLandOnSaneNumbers() {
+        // Os padrões do código, traduzidos para o que a tela mostra.
+        assertEquals(17f, GestureSensitivity.perHalfScreen(30, 1f), 1f)
+        assertEquals(3.3f, GestureSensitivity.perHalfScreen(75, 0.5f), 0.3f)
+        assertEquals(6f, GestureSensitivity.perHalfScreen(220, 1f, 1920f / 720f), 0.5f)
+    }
+
+    @Test
+    fun absurdValuesAreClampedInsteadOfAccepted() {
+        // Passo minúsculo dispararia centenas de vezes num arraste; gigante nunca dispararia.
+        assertEquals(GestureSensitivity.STEP_RANGE.last, GestureSensitivity.stepThousandths(0.01f, 1f))
+        assertEquals(GestureSensitivity.STEP_RANGE.first, GestureSensitivity.stepThousandths(9999f, 1f))
+    }
+}

--- a/app/src/test/java/br/com/redesurftank/havalshisuku/gestures/TouchGestureLogicTest.kt
+++ b/app/src/test/java/br/com/redesurftank/havalshisuku/gestures/TouchGestureLogicTest.kt
@@ -1,0 +1,361 @@
+package br.com.redesurftank.havalshisuku.gestures
+
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Action
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Config
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.EvdevTouchParser
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Geometry
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Pt
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.RawFinger
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.Step
+import br.com.redesurftank.havalshisuku.gestures.TouchGestureLogic.SwipeGestureRecognizer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TouchGestureLogicTest {
+
+    // ---------------------------------------------------------------------------------------
+    // Leitura do evdev
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    fun typeBParserBuildsFrameFromSlots() {
+        val p = EvdevTouchParser()
+        val lines = listOf(
+            "EV_ABS       ABS_MT_SLOT          00000000",
+            "EV_ABS       ABS_MT_TRACKING_ID   0000001a",
+            "EV_ABS       ABS_MT_POSITION_X    00000064", // 100
+            "EV_ABS       ABS_MT_POSITION_Y    000000c8", // 200
+            "EV_ABS       ABS_MT_SLOT          00000001",
+            "EV_ABS       ABS_MT_TRACKING_ID   0000001b",
+            "EV_ABS       ABS_MT_POSITION_X    000000c8", // 200
+            "EV_ABS       ABS_MT_POSITION_Y    000000c8",
+            "EV_SYN       SYN_REPORT           00000000",
+        )
+        var frame: TouchGestureLogic.RawFrame? = null
+        lines.forEach { l -> p.feed(l)?.let { frame = it } }
+        assertEquals(listOf(RawFinger(100, 200), RawFinger(200, 200)), frame!!.fingers)
+    }
+
+    @Test
+    fun typeBParserKeepsUnchangedSlotsBetweenReports() {
+        // O driver so reporta o que MUDA: no segundo quadro so o slot 1 se move, e o slot 0 tem
+        // que continuar existindo com a posicao antiga.
+        val p = EvdevTouchParser()
+        listOf(
+            "EV_ABS       ABS_MT_SLOT          00000000",
+            "EV_ABS       ABS_MT_TRACKING_ID   00000001",
+            "EV_ABS       ABS_MT_POSITION_X    0000000a",
+            "EV_ABS       ABS_MT_POSITION_Y    0000000a",
+            "EV_ABS       ABS_MT_SLOT          00000001",
+            "EV_ABS       ABS_MT_TRACKING_ID   00000002",
+            "EV_ABS       ABS_MT_POSITION_X    00000014",
+            "EV_ABS       ABS_MT_POSITION_Y    00000014",
+            "EV_SYN       SYN_REPORT           00000000",
+        ).forEach { p.feed(it) }
+
+        var frame: TouchGestureLogic.RawFrame? = null
+        listOf(
+            "EV_ABS       ABS_MT_POSITION_Y    0000001e",
+            "EV_SYN       SYN_REPORT           00000000",
+        ).forEach { l -> p.feed(l)?.let { frame = it } }
+
+        assertEquals(listOf(RawFinger(10, 10), RawFinger(20, 30)), frame!!.fingers)
+    }
+
+    @Test
+    fun trackingIdMinusOneRemovesFinger() {
+        val p = EvdevTouchParser()
+        listOf(
+            "EV_ABS       ABS_MT_SLOT          00000000",
+            "EV_ABS       ABS_MT_TRACKING_ID   00000001",
+            "EV_ABS       ABS_MT_POSITION_X    0000000a",
+            "EV_ABS       ABS_MT_POSITION_Y    0000000a",
+            "EV_SYN       SYN_REPORT           00000000",
+        ).forEach { p.feed(it) }
+
+        var frame: TouchGestureLogic.RawFrame? = null
+        listOf(
+            "EV_ABS       ABS_MT_TRACKING_ID   ffffffff",
+            "EV_SYN       SYN_REPORT           00000000",
+        ).forEach { l -> p.feed(l)?.let { frame = it } }
+
+        assertTrue(frame!!.fingers.isEmpty())
+    }
+
+    @Test
+    fun btnTouchUpClearsEveryFinger() {
+        // Rede de seguranca: se a saida por slot falhasse, um dedo fantasma travaria todo gesto
+        // seguinte. O painel deste carro manda os dois sinais (confirmado no proprio hardware).
+        val p = EvdevTouchParser()
+        listOf(
+            "EV_KEY       BTN_TOUCH            DOWN",
+            "EV_ABS       ABS_MT_TRACKING_ID   00000006",
+            "EV_ABS       ABS_MT_POSITION_X    0000000a",
+            "EV_ABS       ABS_MT_POSITION_Y    0000000a",
+            "EV_SYN       SYN_REPORT           00000000",
+        ).forEach { p.feed(it) }
+
+        var frame: TouchGestureLogic.RawFrame? = null
+        listOf(
+            "EV_KEY       BTN_TOUCH            UP",
+            "EV_SYN       SYN_REPORT           00000000",
+        ).forEach { l -> p.feed(l)?.let { frame = it } }
+
+        assertTrue(frame!!.fingers.isEmpty())
+    }
+
+    @Test
+    fun firstFingerWithoutAnExplicitSlotLandsOnSlotZero() {
+        // O driver deste carro OMITE o ABS_MT_SLOT do primeiro dedo (slot 0 e o corrente).
+        // Capturado no carro: BTN_TOUCH DOWN vem direto seguido do TRACKING_ID.
+        val p = EvdevTouchParser()
+        var frame: TouchGestureLogic.RawFrame? = null
+        listOf(
+            "EV_KEY       BTN_TOUCH            DOWN",
+            "EV_ABS       ABS_MT_TRACKING_ID   00000003",
+            "EV_ABS       ABS_MT_POSITION_X    00000341",
+            "EV_ABS       ABS_MT_POSITION_Y    000000bc",
+            "EV_SYN       SYN_REPORT           00000000",
+        ).forEach { l -> p.feed(l)?.let { frame = it } }
+        assertEquals(listOf(RawFinger(0x341, 0xbc)), frame!!.fingers)
+    }
+
+    @Test
+    fun parserAcceptsLinesWithDevicePrefix() {
+        val p = EvdevTouchParser()
+        var frame: TouchGestureLogic.RawFrame? = null
+        listOf(
+            "/dev/input/event2: EV_ABS       ABS_MT_SLOT          00000000",
+            "/dev/input/event2: EV_ABS       ABS_MT_TRACKING_ID   00000005",
+            "/dev/input/event2: EV_ABS       ABS_MT_POSITION_X    00000032",
+            "/dev/input/event2: EV_ABS       ABS_MT_POSITION_Y    00000032",
+            "/dev/input/event2: EV_SYN       SYN_REPORT           00000000",
+        ).forEach { l -> p.feed(l)?.let { frame = it } }
+        assertEquals(listOf(RawFinger(50, 50)), frame!!.fingers)
+    }
+
+    @Test
+    fun typeAParserSplitsFingersBySynMtReport() {
+        val p = EvdevTouchParser()
+        var frame: TouchGestureLogic.RawFrame? = null
+        listOf(
+            "EV_ABS       ABS_MT_POSITION_X    0000000a",
+            "EV_ABS       ABS_MT_POSITION_Y    00000014",
+            "EV_SYN       SYN_MT_REPORT        00000000",
+            "EV_ABS       ABS_MT_POSITION_X    0000001e",
+            "EV_ABS       ABS_MT_POSITION_Y    00000028",
+            "EV_SYN       SYN_MT_REPORT        00000000",
+            "EV_SYN       SYN_REPORT           00000000",
+        ).forEach { l -> p.feed(l)?.let { frame = it } }
+        assertEquals(listOf(RawFinger(10, 20), RawFinger(30, 40)), frame!!.fingers)
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Descoberta do device
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    fun picksTheLargestMultitouchDevice() {
+        val out = """
+            add device 1: /dev/input/event0
+              name:     "gpio-keys"
+                KEY (0001): 0072  0073
+            add device 2: /dev/input/event3
+              name:     "secondary-digitizer"
+                ABS_MT_POSITION_X    : value 0, min 0, max 479, fuzz 0, flat 0, resolution 0
+                ABS_MT_POSITION_Y    : value 0, min 0, max 319, fuzz 0, flat 0, resolution 0
+            add device 3: /dev/input/event2
+              name:     "main-touch"
+                ABS_MT_POSITION_X    : value 0, min 0, max 1919, fuzz 0, flat 0, resolution 0
+                ABS_MT_POSITION_Y    : value 0, min 0, max 1079, fuzz 0, flat 0, resolution 0
+        """.trimIndent()
+        val dev = TouchGestureLogic.parseTouchDevice(out)!!
+        assertEquals("/dev/input/event2", dev.path)
+        assertEquals(1919, dev.maxX)
+        assertEquals(1079, dev.maxY)
+    }
+
+    @Test
+    fun deviceWithoutMultitouchIsIgnored() {
+        val out = """
+            add device 1: /dev/input/event0
+              name:     "gpio-keys"
+                KEY (0001): 0072
+        """.trimIndent()
+        assertNull(TouchGestureLogic.parseTouchDevice(out))
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Geometria
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    fun geometryNormalizesAndCanCorrectARotatedPanel() {
+        val g = Geometry(maxX = 1000, maxY = 500)
+        assertEquals(0.5f, g.normalize(RawFinger(500, 250)).x, 0.001f)
+        assertEquals(0.5f, g.normalize(RawFinger(500, 250)).y, 0.001f)
+
+        val swapped = Geometry(maxX = 1000, maxY = 500, swapXY = true, invertY = true)
+        val p = swapped.normalize(RawFinger(x = 250, y = 100))
+        assertEquals(100f / 500f, p.x, 0.001f)
+        assertEquals(1f - 250f / 1000f, p.y, 0.001f)
+    }
+
+    @Test
+    fun axisSwapIsDetectedWhenTheDigitizerIsMountedSideways() {
+        // Painel paisagem + digitalizador paisagem: nada a trocar.
+        assertTrue(!TouchGestureLogic.needsAxisSwap(1919, 1079, 1920, 1080))
+        // Digitalizador reportando retrato num display paisagem: eixos girados.
+        assertTrue(TouchGestureLogic.needsAxisSwap(1079, 1919, 1920, 1080))
+        // Sem dados confiaveis, nao inventa.
+        assertTrue(!TouchGestureLogic.needsAxisSwap(0, 0, 1920, 1080))
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Reconhecimento do gesto
+    // ---------------------------------------------------------------------------------------
+
+    /** Arrasta [n] dedos de [from] ate [to] em passos pequenos, devolvendo tudo que saiu. */
+    private fun swipe(
+        r: SwipeGestureRecognizer,
+        n: Int,
+        from: Pt,
+        to: Pt,
+        frames: Int = 40,
+    ): List<Step> {
+        val out = mutableListOf<Step>()
+        out += r.onFrame(fingersAt(from, n))
+        for (i in 1..frames) {
+            val t = i.toFloat() / frames
+            val p = Pt(from.x + (to.x - from.x) * t, from.y + (to.y - from.y) * t)
+            out += r.onFrame(fingersAt(p, n))
+        }
+        return out
+    }
+
+    /** Espalha [n] dedos em volta do centro, sem sair da zona. */
+    private fun fingersAt(center: Pt, n: Int): List<Pt> =
+        (0 until n).map { Pt(center.x + (it - (n - 1) / 2f) * 0.01f, center.y) }
+
+    @Test
+    fun threeFingersDownInTheCenterLowersVolume() {
+        val r = SwipeGestureRecognizer()
+        val steps = swipe(r, 3, Pt(0.5f, 0.2f), Pt(0.5f, 0.8f))
+        assertTrue(steps.isNotEmpty())
+        assertTrue(steps.all { it.action == Action.VOLUME })
+        assertTrue(steps.all { it.delta == -1 })
+    }
+
+    @Test
+    fun threeFingersUpInTheCenterRaisesVolume() {
+        val r = SwipeGestureRecognizer()
+        val steps = swipe(r, 3, Pt(0.5f, 0.8f), Pt(0.5f, 0.2f))
+        assertTrue(steps.isNotEmpty())
+        assertTrue(steps.all { it.action == Action.VOLUME && it.delta == 1 })
+    }
+
+    @Test
+    fun leftThirdControlsDriverTemperatureAndRightThirdThePassenger() {
+        val left = swipe(SwipeGestureRecognizer(), 3, Pt(0.15f, 0.8f), Pt(0.15f, 0.2f))
+        assertTrue(left.isNotEmpty())
+        assertTrue(left.all { it.action == Action.DRIVER_TEMP && it.delta == 1 })
+
+        val right = swipe(SwipeGestureRecognizer(), 3, Pt(0.85f, 0.2f), Pt(0.85f, 0.8f))
+        assertTrue(right.isNotEmpty())
+        assertTrue(right.all { it.action == Action.PASSENGER_TEMP && it.delta == -1 })
+    }
+
+    @Test
+    fun horizontalIsFanAnywhereOnTheScreen() {
+        val toTheRight = swipe(SwipeGestureRecognizer(), 3, Pt(0.2f, 0.3f), Pt(0.9f, 0.3f))
+        assertTrue(toTheRight.isNotEmpty())
+        assertTrue(toTheRight.all { it.action == Action.FAN && it.delta == 1 })
+
+        val toTheLeft = swipe(SwipeGestureRecognizer(), 3, Pt(0.9f, 0.9f), Pt(0.2f, 0.9f))
+        assertTrue(toTheLeft.isNotEmpty())
+        assertTrue(toTheLeft.all { it.action == Action.FAN && it.delta == -1 })
+    }
+
+    @Test
+    fun twoFingersDoNothing() {
+        val steps = swipe(SwipeGestureRecognizer(), 2, Pt(0.5f, 0.2f), Pt(0.5f, 0.9f))
+        assertTrue(steps.isEmpty())
+    }
+
+    @Test
+    fun aFourthFingerCancelsTheGesture() {
+        // Mao apoiada na tela nao pode virar comando.
+        val steps = swipe(SwipeGestureRecognizer(), 4, Pt(0.5f, 0.2f), Pt(0.5f, 0.9f))
+        assertTrue(steps.isEmpty())
+    }
+
+    @Test
+    fun diagonalDragIsIgnored() {
+        // Nem vira volume nem vira ventilacao: o eixo so e aceito quando domina o outro.
+        val steps = swipe(SwipeGestureRecognizer(), 3, Pt(0.4f, 0.2f), Pt(0.9f, 0.7f))
+        assertTrue(steps.isEmpty())
+    }
+
+    @Test
+    fun zoneIsLockedWhenTheGestureStartsSoDriftDoesNotSwitchTheAction() {
+        // Comeca no terco esquerdo (motorista) e deriva ate o centro; segue motorista.
+        val steps = swipe(SwipeGestureRecognizer(), 3, Pt(0.10f, 0.85f), Pt(0.45f, 0.15f))
+        assertTrue(steps.isNotEmpty())
+        assertTrue(steps.all { it.action == Action.DRIVER_TEMP })
+    }
+
+    @Test
+    fun longerDragProducesMoreSteps() {
+        val short = swipe(SwipeGestureRecognizer(), 3, Pt(0.5f, 0.5f), Pt(0.5f, 0.7f))
+        val long = swipe(SwipeGestureRecognizer(), 3, Pt(0.5f, 0.1f), Pt(0.5f, 0.95f))
+        assertTrue(long.size > short.size)
+    }
+
+    @Test
+    fun liftingAFingerEndsTheGestureUntilTheScreenIsClear() {
+        val r = SwipeGestureRecognizer()
+        swipe(r, 3, Pt(0.5f, 0.2f), Pt(0.5f, 0.5f))
+        // Um dedo sai: acabou. Voltar pra tres NAO recomeca — precisa limpar a tela antes, senao
+        // um dedo que perde contato no meio do arraste dispararia um gesto novo.
+        r.onFrame(fingersAt(Pt(0.5f, 0.5f), 2))
+        val after = swipe(r, 3, Pt(0.5f, 0.5f), Pt(0.5f, 0.9f))
+        assertTrue(after.isEmpty())
+
+        r.onFrame(emptyList())
+        val fresh = swipe(r, 3, Pt(0.5f, 0.2f), Pt(0.5f, 0.8f))
+        assertTrue(fresh.isNotEmpty())
+    }
+
+    @Test
+    fun onAWideScreenTheAxisIsJudgedInRealDistanceNotInEachAxisOwnFraction() {
+        // 1920x720: sem corrigir a proporcao, andar a MESMA distancia fisica nos dois eixos daria
+        // 0,3 na largura contra 0,8 na altura, e todo arraste pareceria vertical.
+        val wide = Config(aspect = 1920f / 720f)
+        val steps =
+            swipe(SwipeGestureRecognizer(wide), 3, Pt(0.2f, 0.30f), Pt(0.5f, 0.60f))
+        assertTrue(steps.isNotEmpty())
+        assertTrue(steps.all { it.action == Action.FAN })
+    }
+
+    @Test
+    fun eachAdjustmentHasItsOwnStepSoTheRangesFeelAlike() {
+        // A ventilacao tem 8 posicoes e o volume 41: com um passo unico, um dos dois sairia
+        // inutilizavel. O mesmo arraste tem que render MENOS passos de ventilacao que de volume.
+        val volume = swipe(SwipeGestureRecognizer(), 3, Pt(0.5f, 0.15f), Pt(0.5f, 0.85f))
+        val fan = swipe(SwipeGestureRecognizer(), 3, Pt(0.15f, 0.5f), Pt(0.85f, 0.5f))
+        assertTrue(volume.all { it.action == Action.VOLUME })
+        assertTrue(fan.all { it.action == Action.FAN })
+        assertTrue("volume=${volume.size} fan=${fan.size}", volume.size > fan.size)
+    }
+
+    @Test
+    fun aVeryFastDragIsCappedPerFrame() {
+        val r = SwipeGestureRecognizer(Config(maxStepsPerFrame = 2))
+        r.onFrame(fingersAt(Pt(0.5f, 0.05f), 3))
+        r.onFrame(fingersAt(Pt(0.5f, 0.15f), 3)) // decide o eixo
+        val jump = r.onFrame(fingersAt(Pt(0.5f, 0.95f), 3))
+        assertEquals(2, jump.size)
+    }
+}


### PR DESCRIPTION
Arraste com **três dedos**, em qualquer tela e por cima de qualquer app, para ajustar volume, temperatura e ventilação. Opt-in, default desligado, em **Recursos → Gestos na tela** — onde também se escolhe o que cada combinação faz.

| Arraste (3 dedos) | Onde começa    | Ajusta                    |
|-------------------|----------------|---------------------------|
| vertical          | terço esquerdo | temperatura do motorista  |
| vertical          | terço central  | volume da mídia           |
| vertical          | terço direito  | temperatura do passageiro |
| horizontal        | tela toda      | ventilação                |

Para cima / para a direita aumenta. Um cartão aparece no centro da tela com o valor novo e um desenho animado do que está acontecendo — floco esfriando, chama esquentando, hélice girando, ondas saindo do alto-falante.

## Por que ler `/dev/input`, e não usar uma janela

Essa é a decisão que sustenta o resto, e as alternativas óbvias não funcionam.

**Janela overlay não serve.** Ela só tem dois estados úteis: ou é `FLAG_NOT_TOUCHABLE` e não vê toque nenhum, ou é tocável e **engole** o toque do app de baixo. Não existe "ver e deixar passar" — uma janela em tela cheia quebraria todo app que estivesse na frente.

**AccessibilityService também não.** O `onGesture()` exige modo de exploração por toque, que muda o modelo de interação inteiro do sistema, e as APIs de região de passagem de gesto são de API 30+ (a unidade é Android 9).

O que resta e funciona é ler passivamente o mesmo dispositivo de entrada que o Android lê, via `getevent` pelo Shizuku. O kernel entrega o mesmo evento a todos os leitores, então quem está na frente continua recebendo o toque como antes.

> ⚠️ **Nunca dar `EVIOCGRAB` aqui.** Grab exclusivo no nó não mata só este recurso — mata o toque do **Android inteiro** na unidade, nenhum app recebe `MotionEvent`. O `getevent` não faz grab (nem tem opção), mas é a primeira coisa a conferir em qualquer alteração nesta pasta.

O preço é que o app de baixo **também** reage ao arraste. Daí três dedos: quase nenhum app usa esse número. Com dois, um arraste na metade esquerda com o mapa projetado moveria o mapa *e* mexeria na temperatura — por isso dois dedos não é oferecido. Quatro é oferecido com aviso, porque hoje é o quarto dedo que **cancela** o gesto e impede a mão apoiada de virar comando.

## O que o hardware mostrou

Conferi o parser contra a captura do toque cru, não contra a suposição. Nada disso está documentado em lugar nenhum:

- **O driver omite o `ABS_MT_SLOT` do primeiro dedo** — slot 0 é o corrente, então depois do `BTN_TOUCH DOWN` vem o `ABS_MT_TRACKING_ID` direto. Um parser que exigisse o slot explícito perderia o primeiro dedo de *todo* toque.
- **Cada `SYN_REPORT` carrega um dedo só**, não todos: o quadro é montado com os slots vivos, o que triplica o número de quadros.
- **A saída é o Type B padrão** (`TRACKING_ID ffffffff` por slot) **e** um `BTN_TOUCH UP` por toque. Os dois são tratados — um slot que ficasse ocupado somaria um dedo a mais em todo gesto seguinte e mataria o recurso até reiniciar o app.
- **O nó da tela é descoberto sozinho** (maior área entre os que reportam `ABS_MT_POSITION_X`), porque a numeração do `eventN` muda entre firmwares.

## Dois achados que valem para além deste recurso

**`adjustStreamVolume` é um no-op nesta central.** A chamada chega a ser executada — dá para ver no `dumpsys audio` — e não muda nada que se ouça: o `STREAM_MUSIC` tem máximo 15 e é mantido cravado nesse máximo, com a atenuação real feita por fora. O volume de verdade é `sys.settings.audio.media_volume`, escrito pelo mesmo caminho que a função de volume inicial já usava.

**Normalizar cada eixo por si deforma o espaço numa tela 1920×720.** 100 px na horizontal viram 0,052 e os mesmos 100 px na vertical viram 0,139. Isso enviesava a detecção de direção (arraste diagonal parecia vertical) e fazia o passo horizontal ser quase 3× mais longo que o vertical. A comparação de eixos e a medida dos passos passaram a usar a mesma unidade, a altura da tela.

## Escopo

14 arquivos, +2814/−5. Seis novos em `gestures/`, mais quatro pontos de ligação: as chaves em `SharedPreferencesKeys`, o start em `ForegroundService.onServicesReady()`, o card na central de Recursos, e a lista que o Modo Concessionária desliga (com passos próprios de parar e religar).

Compila em Kotlin e Java sobre a `preview` atual. **40 testes de unidade** cobrem o parser (os dois protocolos multitoque, os dois caminhos de saída do dedo, a sequência exata capturada do hardware), a descoberta do device, a correção de proporção, a leitura de configuração mal formada, a conversão da sensibilidade e o reconhecimento — com os casos negativos: dedo a mais, arraste diagonal, deriva de zona, combinação sem ação configurada.

## O que ainda não foi validado

- **Uso prolongado dirigindo.** O recurso foi testado no carro parado, em várias rodadas, mas nada aqui foi exercitado numa viagem.
- **Custo de CPU.** Passam ~1500 linhas/s pelo parser durante um arraste. O caminho quente descarta cedo o que não interessa, mas isso precisa ser medido com `top` — o R8 remove os `Log.*` no release, então logcat não serve.
- **Comportamento com projeção ativa.** Três dedos não deve conflitar com Android Auto / CarPlay, mas isso é raciocínio, não teste. Se aparecer conflito, o mais simples é suspender os gestos enquanto houver projeção.
- **Outras variantes de central.** A descoberta do device e a detecção de eixo girado foram escritas para não depender deste hardware, mas só uma unidade foi verificada. Espelhamento não dá para deduzir das proporções, então ficaram duas preferências de calibração ajustáveis sem build novo.
- **Um tap de três dedos ainda clica no que estiver embaixo.** Consequência direta de não roubar o toque; o arraste raramente ativa botão porque o movimento cancela o clique.

<details>
<summary>Descritivo para a nota de versão</summary>

**Gestos na tela**

Agora dá para mexer no volume, na temperatura e na ventilação arrastando três dedos em qualquer tela, mesmo com outro aplicativo na frente. Na vertical: o lado esquerdo é a temperatura do motorista, o meio é o volume e o lado direito é a do passageiro. Na horizontal, em qualquer ponto da tela, é a ventilação. Para cima ou para a direita aumenta.

Um cartão aparece no meio da tela mostrando o que mudou. O recurso vem desligado; para ligar e escolher o que cada gesto faz, vá em Recursos → Gestos na tela.

</details>
