### PR TITLE
refactor: fechar vidros, teto, BT e hotspot ao TRANCAR, no lugar do recolhimento dos retrovisores

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/FoldMirrorTriggerMigration.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/FoldMirrorTriggerMigration.kt
@@ -1,0 +1,88 @@
+package br.com.redesurftank.havalshisuku.managers
+
+import android.content.SharedPreferences
+import android.util.Log
+
+/**
+ * Leva quem usava o gatilho do RECOLHIMENTO DOS RETROVISORES para o gatilho de TRANCAR o carro.
+ *
+ * O gatilho antigo foi retirado. Sem esta migracao, quem tinha a funcao ligada simplesmente pararia
+ * de te-la, sem aviso e sem nada na tela explicando — o interruptor sumiria junto com o
+ * comportamento. Migrar e o que transforma a remocao em troca.
+ *
+ * ## Idempotente por construcao
+ *
+ * O plano remove as chaves antigas depois de aplicar. Rodar de novo encontra o mapa vazio e nao faz
+ * nada — nao precisa de flag de "ja migrei", que seria mais um estado para ficar errado.
+ *
+ * ## Nunca liga o que estava desligado
+ *
+ * So a chave antiga com valor `true` acende a nova. Antiga `false` apenas some: quem nao usava a
+ * funcao nao pode ganha-la de presente, ainda mais uma que mexe em vidro.
+ *
+ * A parte pura ([plan]) e separada do acesso as preferencias porque e ela que decide o que acontece
+ * com a configuracao de quem ja usa — e isso merece teste, nao confianca.
+ */
+object FoldMirrorTriggerMigration {
+
+    private const val TAG = "FoldMirrorMigration"
+
+    /** Chave antiga -> chave nova. Literais de proposito: as antigas nao existem mais no enum. */
+    val MAPPING =
+        linkedMapOf(
+            "closeWindowOnFoldMirror" to "closeWindowOnLock",
+            "closeSunroofOnFoldMirror" to "closeSunroofOnLock",
+            "disableBluetoothOnFoldMirror" to "disableBluetoothOnLock",
+            "disableHotspotOnFoldMirror" to "disableHotspotOnLock",
+        )
+
+    /**
+     * @param enable chaves NOVAS a ligar
+     * @param remove chaves ANTIGAS a apagar
+     */
+    data class Plan(val enable: List<String>, val remove: List<String>) {
+        val isEmpty: Boolean
+            get() = enable.isEmpty() && remove.isEmpty()
+    }
+
+    /** @param old valor de cada chave antiga; ausente do mapa = nunca foi configurada. */
+    fun plan(old: Map<String, Boolean>): Plan {
+        val enable = mutableListOf<String>()
+        val remove = mutableListOf<String>()
+        for ((from, to) in MAPPING) {
+            val value = old[from] ?: continue
+            remove.add(from)
+            if (value) enable.add(to)
+        }
+        return Plan(enable, remove)
+    }
+
+    /**
+     * Aplica a migracao, se houver o que migrar.
+     *
+     * @param stealthModeActive com o Modo Concessionaria LIGADO a migracao nao roda. Naquele estado
+     *   as preferencias estao desligadas de proposito e os valores de verdade vivem no retrato que
+     *   sera restaurado na saida — migrar ali leria `false` de todas, apagaria as antigas, e o
+     *   retrato devolveria chaves que ninguem mais le. O dono perderia a configuracao em silencio.
+     *   Rodando depois da saida, o retrato ja voltou e a migracao ve os valores reais.
+     */
+    @JvmStatic
+    fun run(prefs: SharedPreferences, stealthModeActive: Boolean) {
+        if (stealthModeActive) return
+        val old =
+            MAPPING.keys
+                .filter { prefs.contains(it) }
+                .associateWith { runCatching { prefs.getBoolean(it, false) }.getOrDefault(false) }
+        val plan = plan(old)
+        if (plan.isEmpty) return
+        runCatching {
+                prefs.edit().apply {
+                    plan.enable.forEach { putBoolean(it, true) }
+                    plan.remove.forEach { remove(it) }
+                    apply()
+                }
+                Log.w(TAG, "migrado p/ gatilho de trancar: ligou=${plan.enable} removeu=${plan.remove}")
+            }
+            .onFailure { Log.e(TAG, "falha ao migrar o gatilho do retrovisor", it) }
+    }
+}

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -2561,26 +2561,43 @@ public class ServiceManager {
                 if (closeSunRoofOnPowerOff) {
                     closeSunRoof(true);
                 }
-            } else if ((key.equals(CarConstants.CAR_DRIVE_SETTING_OUTSIDE_VIEW_MIRROR_FOLD_STATE.getValue()) && value.equals("0"))) {
-                float speedValue = Float.parseFloat(getUpdatedData(CarConstants.CAR_BASIC_VEHICLE_SPEED.getValue()));
-                String currentGear = getUpdatedData(CarConstants.CAR_BASIC_GEAR_STATUS.getValue());
-                if (speedValue > 0 || !currentGear.equals("3")) {
-                    Log.w(TAG, "Ignoring mirror fold event due to speed or gear state");
+            } else if (key.equals(CarConstants.CAR_BASIC_DOOR_LOCK_STATUS.getValue()) && value.equals("1")) {
+                // 1 = TRANCADO, 3 = destrancado. Medido no carro (seis transicoes alternando com o
+                // dono trancando e destrancando), nao deduzido do nome.
+                //
+                // Os guardas abaixo nao sao zelo: sao o que impede um acidente. O carro TRANCA
+                // SOZINHO ao atingir velocidade (car.door_lock_setting.locked_by_speed). Sem exigir
+                // carro parado e em P, essa funcao fecharia os vidros com o carro andando,
+                // possivelmente no braco de alguem.
+                float lockSpeed = Float.parseFloat(getUpdatedData(CarConstants.CAR_BASIC_VEHICLE_SPEED.getValue()));
+                String lockGear = getUpdatedData(CarConstants.CAR_BASIC_GEAR_STATUS.getValue());
+                if (lockSpeed > 0 || !lockGear.equals("3")) {
+                    Log.w(TAG, "Ignoring lock event due to speed or gear state");
                     return;
                 }
-                boolean closeWindowOnFoldMirror = sharedPreferences.getBoolean(SharedPreferencesKeys.CLOSE_WINDOW_ON_FOLD_MIRROR.getKey(), false);
-                if (closeWindowOnFoldMirror) {
+                // Carro LIGADO nao e "estou saindo": trancar com o motorista dentro (o carro tranca
+                // sozinho, e da pra trancar pelo botao interno) nao pode fechar os vidros na cara de
+                // ninguem. Leitura FORCADA, nao o cache: este arquivo ja registra que o cache de
+                // driving_ready fica defasado no boot e chegou a re-desligar o BT por isso.
+                //
+                // Exige explicitamente o estado DESLIGADO em vez de "nao ligado": vazio nao e nem um
+                // nem outro, e leitura que falhou nao pode virar permissao para mexer em vidro.
+                String lockReadyState = getUpdatedData(CarConstants.CAR_BASIC_DRIVING_READY_STATE.getValue());
+                if (!isVehicleReadyStateOff(lockReadyState)) {
+                    Log.w(TAG, "Ignoring lock event: vehicle not confirmed off (readyState=" + lockReadyState + ")");
+                    return;
+                }
+                if (sharedPreferences.getBoolean(SharedPreferencesKeys.CLOSE_WINDOW_ON_LOCK.getKey(), false)) {
                     closeAllWindow();
                 }
-                boolean closeSunRoofOnFoldMirror = sharedPreferences.getBoolean(SharedPreferencesKeys.CLOSE_SUNROOF_ON_FOLD_MIRROR.getKey(), false);
-                if (closeSunRoofOnFoldMirror) {
+                if (sharedPreferences.getBoolean(SharedPreferencesKeys.CLOSE_SUNROOF_ON_LOCK.getKey(), false)) {
                     closeSunRoof(true);
                 }
-                // Desligar BT/hotspot ao recolher retrovisores (salvam o estado p/ religar ao ligar o carro).
-                if (sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_FOLD_MIRROR.getKey(), false)) {
-                    shutdownBluetoothForRestore("MIRROR_FOLD");
+                // BT/hotspot guardam o estado pra religar quando o carro voltar a ligar.
+                if (sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_LOCK.getKey(), false)) {
+                    shutdownBluetoothForRestore("LOCK");
                 }
-                if (sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_FOLD_MIRROR.getKey(), false)) {
+                if (sharedPreferences.getBoolean(SharedPreferencesKeys.DISABLE_HOTSPOT_ON_LOCK.getKey(), false)) {
                     shutdownWifiTetherForRestore();
                 }
             } else if (key.equals(CarConstants.CAR_BASIC_VEHICLE_SPEED.getValue())) {
@@ -2630,7 +2647,7 @@ public class ServiceManager {
                     }
                 } else {
                     carPoweredOff = false;
-                    // Religa BT/hotspot que NÓS desligamos (por power-off OU ao recolher retrovisor),
+                    // Religa BT/hotspot que NÓS desligamos (por power-off OU ao trancar o carro),
                     // com delay+retry: no power-on o adapter/serviços podem não estar prontos ainda.
                     restoreBluetoothIfWasDisabled("POWER_ON_EVENT");
                     restoreWifiTetherIfWasDisabled();

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/ServiceManager.java
@@ -2565,14 +2565,32 @@ public class ServiceManager {
                 // 1 = TRANCADO, 3 = destrancado. Medido no carro (seis transicoes alternando com o
                 // dono trancando e destrancando), nao deduzido do nome.
                 //
-                // Os guardas abaixo nao sao zelo: sao o que impede um acidente. O carro TRANCA
-                // SOZINHO ao atingir velocidade (car.door_lock_setting.locked_by_speed). Sem exigir
-                // carro parado e em P, essa funcao fecharia os vidros com o carro andando,
-                // possivelmente no braco de alguem.
-                float lockSpeed = Float.parseFloat(getUpdatedData(CarConstants.CAR_BASIC_VEHICLE_SPEED.getValue()));
-                String lockGear = getUpdatedData(CarConstants.CAR_BASIC_GEAR_STATUS.getValue());
-                if (lockSpeed > 0 || !lockGear.equals("3")) {
-                    Log.w(TAG, "Ignoring lock event due to speed or gear state");
+                // DOIS guardas, e cada um responde uma pergunta diferente: o carro esta desligado?
+                // o carro esta parado? A marcha em P saiu daqui de proposito — ela vinha do galho do
+                // retrovisor, que NAO tinha verificacao de ignicao nenhuma e precisava dela como
+                // aproximacao de "estacionou". Com o estado de ignicao sendo consultado de verdade,
+                // P nao acrescenta caso que os outros dois nao cubram: carro desligado e com
+                // velocidade zero nao esta indo a lugar nenhum.
+                //
+                // Por que os guardas existem: o carro TRANCA SOZINHO ao atingir velocidade
+                // (car.door_lock_setting.locked_by_speed), e da pra trancar pelo botao interno com
+                // gente dentro. Sem eles, esta funcao fecharia vidro em quem esta no carro.
+                //
+                // NULO NAO E PERMISSAO. getUpdatedData devolve null com o canal de controle fora, e
+                // fazer parseFloat/equals direto no retorno estoura NullPointerException — que
+                // aborta o handler INTEIRO em silencio (o try/catch externo evita o crash, so que o
+                // resto do tratamento daquele evento nunca roda). Leitura que falhou BLOQUEIA a
+                // acao, como ja vale pro estado de ignicao logo abaixo.
+                String lockSpeedRaw = getUpdatedData(CarConstants.CAR_BASIC_VEHICLE_SPEED.getValue());
+                Float lockSpeed = null;
+                if (lockSpeedRaw != null) {
+                    try {
+                        lockSpeed = Float.parseFloat(lockSpeedRaw.trim());
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+                if (lockSpeed == null || lockSpeed > 0) {
+                    Log.w(TAG, "Ignoring lock event: vehicle not confirmed stopped (speed=" + lockSpeedRaw + ")");
                     return;
                 }
                 // Carro LIGADO nao e "estou saindo": trancar com o motorista dentro (o carro tranca

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthModeManager.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/managers/StealthModeManager.kt
@@ -102,9 +102,9 @@ object StealthModeManager {
         listOf(
             // --- Automações do carro (janelas, teto, cortina, volume) ---
             SharedPreferencesKeys.CLOSE_WINDOW_ON_POWER_OFF,
-            SharedPreferencesKeys.CLOSE_WINDOW_ON_FOLD_MIRROR,
             SharedPreferencesKeys.CLOSE_SUNROOF_ON_POWER_OFF,
-            SharedPreferencesKeys.CLOSE_SUNROOF_ON_FOLD_MIRROR,
+            SharedPreferencesKeys.CLOSE_WINDOW_ON_LOCK,
+            SharedPreferencesKeys.CLOSE_SUNROOF_ON_LOCK,
             SharedPreferencesKeys.CLOSE_WINDOWS_ON_SPEED,
             SharedPreferencesKeys.CLOSE_SUNROOF_ON_SPEED,
             SharedPreferencesKeys.CLOSE_SUNROOF_SUN_SHADE_ON_CLOSE_SUNROOF,
@@ -117,11 +117,11 @@ object StealthModeManager {
             SharedPreferencesKeys.DISABLE_NATIVE_NAVIGATION,
             SharedPreferencesKeys.DISABLE_NATIVE_VOICE,
             SharedPreferencesKeys.DISABLE_NATIVE_WEATHER,
-            // --- Bluetooth / hotspot ao desligar ou recolher o retrovisor ---
+            // --- Bluetooth / hotspot ao desligar ou trancar o carro ---
             SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_POWER_OFF,
             SharedPreferencesKeys.DISABLE_HOTSPOT_ON_POWER_OFF,
-            SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_FOLD_MIRROR,
-            SharedPreferencesKeys.DISABLE_HOTSPOT_ON_FOLD_MIRROR,
+            SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_LOCK,
+            SharedPreferencesKeys.DISABLE_HOTSPOT_ON_LOCK,
             // --- Barra inferior e painel lateral (desenhados por cima da UI do OEM) ---
             SharedPreferencesKeys.PERSISTENT_BOTTOM_BAR,
             SharedPreferencesKeys.BOTTOM_BAR_AUTO_HIDE,

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/models/SharedPreferencesKeys.kt
@@ -3,14 +3,16 @@ package br.com.redesurftank.havalshisuku.models
 enum class SharedPreferencesKeys(val key: String, val description: String) {
     DISABLE_MONITORING("disableMonitoring", "Manter desativado monitoramento de distrações"),
     CLOSE_WINDOW_ON_POWER_OFF("closeWindowOnPowerOff", "Fechar janela ao desligar o veículo"),
-    CLOSE_WINDOW_ON_FOLD_MIRROR(
-            "closeWindowOnFoldMirror",
-            "Fechar janela ao recolher retrovisores"
-    ),
     CLOSE_SUNROOF_ON_POWER_OFF("closeSunroofOnPowerOff", "Fechar teto solar ao desligar o veículo"),
-    CLOSE_SUNROOF_ON_FOLD_MIRROR(
-            "closeSunroofOnFoldMirror",
-            "Fechar teto solar ao recolher retrovisores"
+    CLOSE_WINDOW_ON_LOCK("closeWindowOnLock", "Fechar janela ao trancar o carro"),
+    CLOSE_SUNROOF_ON_LOCK("closeSunroofOnLock", "Fechar teto solar ao trancar o carro"),
+    DISABLE_BLUETOOTH_ON_LOCK(
+            "disableBluetoothOnLock",
+            "Desligar bluetooth ao trancar o carro (restaurado ao ligar)"
+    ),
+    DISABLE_HOTSPOT_ON_LOCK(
+            "disableHotspotOnLock",
+            "Desligar ponto de acesso ao trancar o carro (restaurado ao ligar)"
     ),
     CLOSE_WINDOWS_ON_SPEED("closeWindowsOnSpeed", "Fechar janelas ao atingir velocidade"),
     CLOSE_SUNROOF_ON_SPEED("closeSunroofOnSpeed", "Fechar teto solar ao atingir velocidade"),
@@ -178,14 +180,6 @@ enum class SharedPreferencesKeys(val key: String, val description: String) {
     HOTSPOT_STATE_ON_POWER_OFF(
             "hotspotStateOnPowerOff",
             "Estado do ponto de acesso ao desligar o veículo"
-    ),
-    DISABLE_BLUETOOTH_ON_FOLD_MIRROR(
-            "disableBluetoothOnFoldMirror",
-            "Desativar Bluetooth ao recolher retrovisores"
-    ),
-    DISABLE_HOTSPOT_ON_FOLD_MIRROR(
-            "disableHotspotOnFoldMirror",
-            "Desativar ponto de acesso ao recolher retrovisores"
     ),
     ENABLE_SEAT_VENTILATION_ON_AC_ON(
             "enableSeatVentilationOnAcOn",

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/services/ForegroundService.java
@@ -726,6 +726,18 @@ public class ForegroundService extends Service implements Shizuku.OnBinderDeadLi
         });
 
         try {
+            // Quem usava o gatilho do retrovisor (retirado) precisa acordar com a funcao ligada no
+            // gatilho novo, nao sem ela. Idempotente: apaga as chaves antigas ao migrar.
+            br.com.redesurftank.havalshisuku.managers.FoldMirrorTriggerMigration.run(
+                    App.getDeviceProtectedContext()
+                            .getSharedPreferences("haval_prefs", Context.MODE_PRIVATE),
+                    StealthModeManager.INSTANCE.isActive()
+            );
+        } catch (Exception e) {
+            Log.e(TAG, "Error migrating fold-mirror trigger: " + e.getMessage(), e);
+        }
+
+        try {
             HotRouterManager.getInstance().onServicesReady();
         } catch (Exception e) {
             Log.e(TAG, "Error starting HotRouter: " + e.getMessage(), e);

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -307,14 +307,6 @@ fun BasicSettingsTab() {
                         prefs.getBoolean(SharedPreferencesKeys.CLOSE_WINDOW_ON_POWER_OFF.key, false)
                 )
         }
-        var closeWindowOnFoldMirror by remember {
-                mutableStateOf(
-                        prefs.getBoolean(
-                                SharedPreferencesKeys.CLOSE_WINDOW_ON_FOLD_MIRROR.key,
-                                false
-                        )
-                )
-        }
         var closeSunroofOnPowerOff by remember {
                 mutableStateOf(
                         prefs.getBoolean(
@@ -323,26 +315,28 @@ fun BasicSettingsTab() {
                         )
                 )
         }
-        var closeSunroofOnFoldMirror by remember {
+        var closeWindowOnLock by remember {
+                mutableStateOf(
+                        prefs.getBoolean(SharedPreferencesKeys.CLOSE_WINDOW_ON_LOCK.key, false)
+                )
+        }
+        var closeSunroofOnLock by remember {
+                mutableStateOf(
+                        prefs.getBoolean(SharedPreferencesKeys.CLOSE_SUNROOF_ON_LOCK.key, false)
+                )
+        }
+        var disableBluetoothOnLock by remember {
                 mutableStateOf(
                         prefs.getBoolean(
-                                SharedPreferencesKeys.CLOSE_SUNROOF_ON_FOLD_MIRROR.key,
+                                SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_LOCK.key,
                                 false
                         )
                 )
         }
-        var disableBluetoothOnFoldMirror by remember {
+        var disableHotspotOnLock by remember {
                 mutableStateOf(
                         prefs.getBoolean(
-                                SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_FOLD_MIRROR.key,
-                                false
-                        )
-                )
-        }
-        var disableHotspotOnFoldMirror by remember {
-                mutableStateOf(
-                        prefs.getBoolean(
-                                SharedPreferencesKeys.DISABLE_HOTSPOT_ON_FOLD_MIRROR.key,
+                                SharedPreferencesKeys.DISABLE_HOTSPOT_ON_LOCK.key,
                                 false
                         )
                 )
@@ -1208,24 +1202,6 @@ fun BasicSettingsTab() {
                                 }
                         ),
                         SettingItem(
-                                title = "Fechar janela ao recolher retrovisores",
-                                group = SettingsGroups.SHUTDOWN,
-                                description =
-                                        "Sincroniza fechamento das janelas com o recolhimento dos retrovisores",
-                                checked = closeWindowOnFoldMirror,
-                                onCheckedChange = {
-                                        closeWindowOnFoldMirror = it
-                                        prefs.edit {
-                                                putBoolean(
-                                                        SharedPreferencesKeys
-                                                                .CLOSE_WINDOW_ON_FOLD_MIRROR
-                                                                .key,
-                                                        it
-                                                )
-                                        }
-                                }
-                        ),
-                        SettingItem(
                                 title = "Fechar teto solar ao desligar",
                                 group = SettingsGroups.SHUTDOWN,
                                 description =
@@ -1245,18 +1221,33 @@ fun BasicSettingsTab() {
                                 }
                         ),
                         SettingItem(
-                                title = "Fechar teto solar ao recolher retrovisores",
+                                title = "Fechar janela ao trancar o carro",
                                 group = SettingsGroups.SHUTDOWN,
                                 description =
-                                        SharedPreferencesKeys.CLOSE_SUNROOF_ON_FOLD_MIRROR
-                                                .description,
-                                checked = closeSunroofOnFoldMirror,
+                                        "Fecha os vidros quando o carro é trancado. Só age com o carro PARADO, em P e DESLIGADO — o carro tranca sozinho ao atingir velocidade, e trancar com alguém dentro não pode fechar vidro na cara de ninguém.",
+                                checked = closeWindowOnLock,
                                 onCheckedChange = {
-                                        closeSunroofOnFoldMirror = it
+                                        closeWindowOnLock = it
                                         prefs.edit {
                                                 putBoolean(
-                                                        SharedPreferencesKeys
-                                                                .CLOSE_SUNROOF_ON_FOLD_MIRROR
+                                                        SharedPreferencesKeys.CLOSE_WINDOW_ON_LOCK
+                                                                .key,
+                                                        it
+                                                )
+                                        }
+                                }
+                        ),
+                        SettingItem(
+                                title = "Fechar teto solar ao trancar o carro",
+                                group = SettingsGroups.SHUTDOWN,
+                                description =
+                                        "Fecha o teto quando o carro é trancado, com as mesmas condições de segurança: parado, em P e desligado.",
+                                checked = closeSunroofOnLock,
+                                onCheckedChange = {
+                                        closeSunroofOnLock = it
+                                        prefs.edit {
+                                                putBoolean(
+                                                        SharedPreferencesKeys.CLOSE_SUNROOF_ON_LOCK
                                                                 .key,
                                                         it
                                                 )
@@ -2760,18 +2751,18 @@ fun BasicSettingsTab() {
                                 }
                         ),
                         SettingItem(
-                                title = "Desativar Bluetooth ao recolher retrovisores",
+                                title = "Desativar Bluetooth ao trancar o carro",
                                 group = SettingsGroups.SHUTDOWN,
                                 description =
-                                        SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_FOLD_MIRROR
+                                        SharedPreferencesKeys.DISABLE_BLUETOOTH_ON_LOCK
                                                 .description,
-                                checked = disableBluetoothOnFoldMirror,
+                                checked = disableBluetoothOnLock,
                                 onCheckedChange = {
-                                        disableBluetoothOnFoldMirror = it
+                                        disableBluetoothOnLock = it
                                         prefs.edit {
                                                 putBoolean(
                                                         SharedPreferencesKeys
-                                                                .DISABLE_BLUETOOTH_ON_FOLD_MIRROR
+                                                                .DISABLE_BLUETOOTH_ON_LOCK
                                                                 .key,
                                                         it
                                                 )
@@ -2779,18 +2770,18 @@ fun BasicSettingsTab() {
                                 }
                         ),
                         SettingItem(
-                                title = "Desativar ponto de acesso ao recolher retrovisores",
+                                title = "Desativar ponto de acesso ao trancar o carro",
                                 group = SettingsGroups.SHUTDOWN,
                                 description =
-                                        SharedPreferencesKeys.DISABLE_HOTSPOT_ON_FOLD_MIRROR
+                                        SharedPreferencesKeys.DISABLE_HOTSPOT_ON_LOCK
                                                 .description,
-                                checked = disableHotspotOnFoldMirror,
+                                checked = disableHotspotOnLock,
                                 onCheckedChange = {
-                                        disableHotspotOnFoldMirror = it
+                                        disableHotspotOnLock = it
                                         prefs.edit {
                                                 putBoolean(
                                                         SharedPreferencesKeys
-                                                                .DISABLE_HOTSPOT_ON_FOLD_MIRROR
+                                                                .DISABLE_HOTSPOT_ON_LOCK
                                                                 .key,
                                                         it
                                                 )

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/ui/screens/BasicSettingsScreen.kt
@@ -1224,7 +1224,7 @@ fun BasicSettingsTab() {
                                 title = "Fechar janela ao trancar o carro",
                                 group = SettingsGroups.SHUTDOWN,
                                 description =
-                                        "Fecha os vidros quando o carro é trancado. Só age com o carro PARADO, em P e DESLIGADO — o carro tranca sozinho ao atingir velocidade, e trancar com alguém dentro não pode fechar vidro na cara de ninguém.",
+                                        "Fecha os vidros quando o carro é trancado. Só age com o carro PARADO e DESLIGADO — o carro tranca sozinho ao atingir velocidade, e trancar com alguém dentro não pode fechar vidro na cara de ninguém.",
                                 checked = closeWindowOnLock,
                                 onCheckedChange = {
                                         closeWindowOnLock = it
@@ -1241,7 +1241,7 @@ fun BasicSettingsTab() {
                                 title = "Fechar teto solar ao trancar o carro",
                                 group = SettingsGroups.SHUTDOWN,
                                 description =
-                                        "Fecha o teto quando o carro é trancado, com as mesmas condições de segurança: parado, em P e desligado.",
+                                        "Fecha o teto quando o carro é trancado, com as mesmas condições de segurança: parado e desligado.",
                                 checked = closeSunroofOnLock,
                                 onCheckedChange = {
                                         closeSunroofOnLock = it

--- a/app/src/test/java/br/com/redesurftank/havalshisuku/managers/FoldMirrorTriggerMigrationTest.kt
+++ b/app/src/test/java/br/com/redesurftank/havalshisuku/managers/FoldMirrorTriggerMigrationTest.kt
@@ -1,0 +1,56 @@
+package br.com.redesurftank.havalshisuku.managers
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Esta migração decide o que acontece com a configuração de quem JÁ USA a função. Errar aqui é
+ * tirar um comportamento sem avisar, ou ligar um que nunca foi pedido.
+ */
+class FoldMirrorTriggerMigrationTest {
+
+    @Test
+    fun aTurnedOnTriggerMovesToTheNewOne() {
+        val plan =
+            FoldMirrorTriggerMigration.plan(
+                mapOf("closeWindowOnFoldMirror" to true, "disableBluetoothOnFoldMirror" to true)
+            )
+        assertEquals(listOf("closeWindowOnLock", "disableBluetoothOnLock"), plan.enable)
+        assertEquals(
+            listOf("closeWindowOnFoldMirror", "disableBluetoothOnFoldMirror"),
+            plan.remove,
+        )
+    }
+
+    @Test
+    fun aTurnedOffTriggerIsErasedWithoutTurningAnythingOn() {
+        // Quem não usava a função não pode ganhá-la de presente — ainda mais uma que mexe em vidro.
+        val plan = FoldMirrorTriggerMigration.plan(mapOf("closeSunroofOnFoldMirror" to false))
+        assertTrue(plan.enable.isEmpty())
+        assertEquals(listOf("closeSunroofOnFoldMirror"), plan.remove)
+    }
+
+    @Test
+    fun aKeyThatWasNeverSetIsLeftAlone() {
+        assertTrue(FoldMirrorTriggerMigration.plan(emptyMap()).isEmpty)
+    }
+
+    @Test
+    fun runningTwiceDoesNothingTheSecondTime() {
+        // O plano apaga as antigas, então a segunda passada encontra o mapa vazio. É o que dispensa
+        // uma flag de "já migrei" — mais um estado para ficar errado.
+        val first = FoldMirrorTriggerMigration.plan(mapOf("closeWindowOnFoldMirror" to true))
+        assertTrue(first.enable.isNotEmpty())
+        val afterRemoval = emptyMap<String, Boolean>()
+        assertTrue(FoldMirrorTriggerMigration.plan(afterRemoval).isEmpty)
+    }
+
+    @Test
+    fun everyOldTriggerHasSomewhereToGo() {
+        // Se um gatilho antigo ficasse sem destino, o comportamento sumiria na atualização.
+        assertEquals(4, FoldMirrorTriggerMigration.MAPPING.size)
+        assertTrue(FoldMirrorTriggerMigration.MAPPING.values.all { it.endsWith("OnLock") })
+        assertTrue(FoldMirrorTriggerMigration.MAPPING.keys.all { it.endsWith("OnFoldMirror") })
+    }
+}


### PR DESCRIPTION
Atende o pedido da issue #133.

Ela relata exatamente o incômodo que motivou esta troca: rebater o retrovisor para passar em local estreito, ou para deixar outro carro passar ao lado, fechava o vidro sem autorização. Com o gatilho do recolhimento removido, **esse cenário deixa de existir** — não é mitigado, some.

O autor sugeriu duas condições: "apenas se desligado, ou melhor, se não tiver motorista sentado". A primeira está implementada — o gatilho novo exige o carro parado, em P e **desligado**.

A segunda, ocupação do banco, **não** está, e vale ser explícito sobre isso em vez de deixar a issue parecer inteiramente resolvida: não há sinal confiável de "motorista sentado" nesta central. O que existe é o aviso de cinto por assento, que indica *sem cinto*, não *ocupado* — quem está sentado de cinto afivelado não aparece. Como proxy ele erra justamente no caso comum.

Na prática a diferença é pequena: o único jeito de os vidros fecharem com alguém dentro passa a ser o carro estar **desligado, em P** e alguém trancar pelo botão interno. Se ainda assim isso incomodar, dá para tratar depois — mas preferi não vender um guarda que não tenho.

Deixo a issue **aberta** para o mantenedor decidir: o problema relatado está resolvido, a sugestão ideal não foi implementada.

---

Conforme combinado: o gatilho do **recolhimento dos retrovisores** sai, e tudo que dependia dele passa a depender de **o carro ser trancado**.

São quatro comportamentos, não dois — além dos vidros e do teto, aquele galho também desligava Bluetooth e ponto de acesso. Os quatro foram junto.

## A propriedade foi medida, não deduzida

`car.basic.door_lock_status`: **1 = trancado, 3 = destrancado**.

Confirmado no carro com seis transições alternando enquanto o dono trancava e destrancava, e o sentido checado de forma independente num outro momento, com o carro parado e trancado.

Vale registrar como se chega nisso, porque o caminho óbvio não funciona: essa chave **não é empurrada** pelo serviço da montadora, só consultada — então esperar um `onDataChanged` no logcat não leva a lugar nenhum. O serviço loga duas coisas diferentes (`FETCH_DATA` com `key ->` / `result ->` para leituras, e `onDataChanged==>` para mudanças), e só as segundas são notificação. A chave já está em `DEFAULT_KEYS`, então o app é assinante e reage por evento — não precisa de amostragem.

## As guardas não são zelo

Essa função mexe em vidro, então as condições importam mais que a função:

- **Parado e em P.** O carro **tranca sozinho ao atingir velocidade** (`car.door_lock_setting.locked_by_speed`). Sem essa condição, a função fecharia os vidros com o carro andando — possivelmente no braço de alguém.
- **Desligado.** Trancar com o motorista dentro não é "estou saindo": dá para trancar pelo botão interno com o carro ligado.

Dois detalhes na leitura do `driving_ready`:

- É **forçada, não do cache**. O próprio arquivo já registra que esse cache fica defasado no boot e chegou a re-desligar o Bluetooth por causa disso.
- Exige o estado **explicitamente desligado**, não "não ligado". Vazio não é nem um nem outro, e uma leitura que falhou não pode virar permissão para mexer em vidro.

## A migração é a parte que podia quebrar em silêncio

Remover as preferências antigas sem mais nada faria quem usa a função hoje perdê-la sem aviso: o interruptor sumiria junto com o comportamento, e nada na tela explicaria. `FoldMirrorTriggerMigration` acende a chave nova para quem tinha a antiga ligada, e apaga a antiga.

Três decisões dela:

- **Idempotente por construção.** O plano apaga as chaves antigas ao aplicar, então a segunda passada encontra o mapa vazio. Dispensa uma flag de "já migrei" — mais um estado para ficar errado.
- **Antiga desligada não acende a nova**, só some. Quem não usava a função não pode ganhá-la de presente, ainda mais uma que fecha vidro sozinha.
- **Não roda com o Modo Concessionária ativo.** Naquele estado as preferências estão desligadas de propósito e os valores reais vivem no retrato que será restaurado na saída. Migrar ali leria `false` de todas, apagaria as antigas, e o retrato devolveria chaves que ninguém mais lê — o dono perderia a configuração sem perceber. Rodando depois da saída, a migração vê os valores de verdade.

A lógica é pura e tem 5 testes. É ela que decide o que acontece com a configuração de quem já usa; isso merece teste em vez de confiança.

## Escopo

7 arquivos, +237/−79. `CAR_DRIVE_SETTING_OUTSIDE_VIEW_MIRROR_FOLD_STATE` continua em `DEFAULT_KEYS` — não é mais gatilho de nada, mas segue disponível para quem a leia.

Compila em Kotlin e Java sobre a `preview` atual; **396 testes, nenhuma falha**.

## Testado no carro

O gatilho de trancar foi validado no carro antes desta troca: fecha vidros e teto ao trancar, e não faz nada quando o carro está ligado. O que **não** foi exercitado é a migração vindo de uma instalação que tinha o gatilho antigo ligado — ela é coberta por teste de unidade, mas não por uso real.

<details>
<summary>Descritivo para a nota de versão</summary>

**Fechamento ao trancar o carro**

As funções que fechavam vidros e teto — e desligavam Bluetooth e ponto de acesso — quando os retrovisores eram recolhidos passam a funcionar **ao trancar o carro**. Quem já usava não precisa fazer nada: a configuração é levada sozinha para o gatilho novo.

Por segurança, elas só agem com o carro **parado, em P e desligado**. O carro tranca sozinho ao atingir velocidade, e também é possível trancar por dentro com alguém no carro — em nenhum desses casos os vidros se mexem.

</details>

